### PR TITLE
Add timestamps, fix empty learn output, add e2e tests

### DIFF
--- a/e2e/dream_test.go
+++ b/e2e/dream_test.go
@@ -1,0 +1,343 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ellistarn/shade/internal/bedrock"
+	"github.com/ellistarn/shade/internal/dream"
+	"github.com/ellistarn/shade/internal/source"
+	"github.com/ellistarn/shade/internal/storage"
+)
+
+// mockStore implements dream.Store with in-memory state.
+type mockStore struct {
+	sessions []storage.SessionEntry
+	data     map[string]*source.Session
+	json     map[string][]byte
+	skills   map[string]string
+	deleted  []string
+}
+
+func newMockStore() *mockStore {
+	return &mockStore{
+		data:   map[string]*source.Session{},
+		json:   map[string][]byte{},
+		skills: map[string]string{},
+	}
+}
+
+func (m *mockStore) addSession(src, id string, modified time.Time, messages []source.Message) {
+	key := fmt.Sprintf("memories/%s/%s.json", src, id)
+	m.sessions = append(m.sessions, storage.SessionEntry{
+		Source:       src,
+		SessionID:    id,
+		Key:          key,
+		LastModified: modified,
+	})
+	m.data[src+"/"+id] = &source.Session{
+		Source:    src,
+		SessionID: id,
+		Messages:  messages,
+	}
+}
+
+func (m *mockStore) ListSessions(_ context.Context) ([]storage.SessionEntry, error) {
+	return m.sessions, nil
+}
+
+func (m *mockStore) GetSession(_ context.Context, src, sessionID string) (*source.Session, error) {
+	s, ok := m.data[src+"/"+sessionID]
+	if !ok {
+		return nil, fmt.Errorf("session not found: %s/%s", src, sessionID)
+	}
+	return s, nil
+}
+
+func (m *mockStore) GetJSON(_ context.Context, key string, v any) error {
+	return fmt.Errorf("not found: %s", key) // always fresh start
+}
+
+func (m *mockStore) PutJSON(_ context.Context, key string, v any) error {
+	return nil
+}
+
+func (m *mockStore) DeletePrefix(_ context.Context, prefix string) error {
+	m.deleted = append(m.deleted, prefix)
+	return nil
+}
+
+func (m *mockStore) PutSkill(_ context.Context, name, content string) error {
+	m.skills[name] = content
+	return nil
+}
+
+// mockLLM implements dream.LLM with canned responses.
+type mockLLM struct {
+	reflectResponse string
+	learnResponse   string
+	calls           []llmCall
+}
+
+type llmCall struct {
+	system string
+	user   string
+}
+
+func (m *mockLLM) Converse(_ context.Context, system, user string) (string, bedrock.Usage, error) {
+	m.calls = append(m.calls, llmCall{system: system, user: user})
+	usage := bedrock.Usage{InputTokens: 100, OutputTokens: 50}
+	if strings.Contains(system, "compressing observations") {
+		return m.learnResponse, usage, nil
+	}
+	return m.reflectResponse, usage, nil
+}
+
+func TestDreamPipeline(t *testing.T) {
+	store := newMockStore()
+	store.addSession("claude-code", "sess-1", time.Now(), []source.Message{
+		{Role: "user", Content: "use kebab-case for file names"},
+		{Role: "assistant", Content: "OK, I'll rename them."},
+	})
+	store.addSession("claude-code", "sess-2", time.Now(), []source.Message{
+		{Role: "user", Content: "never use emojis in commit messages"},
+		{Role: "assistant", Content: "Understood."},
+	})
+
+	llm := &mockLLM{
+		reflectResponse: "- Prefers kebab-case file names\n- No emojis in commits",
+		learnResponse: `=== SKILL: naming-conventions ===
+---
+name: Naming Conventions
+description: File and commit naming preferences.
+---
+
+Use kebab-case for file names. Never use emojis in commit messages.
+
+=== SKILL: commit-style ===
+---
+name: Commit Style
+description: How to write commits.
+---
+
+Keep commit messages plain text, no emojis.`,
+	}
+
+	result, err := dream.Run(context.Background(), store, llm, dream.Options{})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	if result.Processed != 2 {
+		t.Errorf("Processed = %d, want 2", result.Processed)
+	}
+	if result.Skills != 2 {
+		t.Errorf("Skills = %d, want 2", result.Skills)
+	}
+	if result.Pruned != 0 {
+		t.Errorf("Pruned = %d, want 0", result.Pruned)
+	}
+	if len(result.Warnings) != 0 {
+		t.Errorf("Warnings = %v, want none", result.Warnings)
+	}
+
+	// Verify skills were written
+	if _, ok := store.skills["naming-conventions"]; !ok {
+		t.Error("skill 'naming-conventions' not written to store")
+	}
+	if _, ok := store.skills["commit-style"]; !ok {
+		t.Error("skill 'commit-style' not written to store")
+	}
+
+	// Verify old skills were cleared first
+	if len(store.deleted) == 0 || store.deleted[0] != "skills/" {
+		t.Errorf("expected DeletePrefix(\"skills/\"), got %v", store.deleted)
+	}
+
+	// Verify LLM was called: 2 reflect + 1 learn = 3 calls
+	if len(llm.calls) != 3 {
+		t.Errorf("LLM calls = %d, want 3", len(llm.calls))
+	}
+}
+
+func TestDreamPipelineNoMemories(t *testing.T) {
+	store := newMockStore()
+	llm := &mockLLM{}
+
+	result, err := dream.Run(context.Background(), store, llm, dream.Options{})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if result.Processed != 0 {
+		t.Errorf("Processed = %d, want 0", result.Processed)
+	}
+	if result.Skills != 0 {
+		t.Errorf("Skills = %d, want 0", result.Skills)
+	}
+	if len(llm.calls) != 0 {
+		t.Errorf("LLM calls = %d, want 0", len(llm.calls))
+	}
+}
+
+func TestDreamPipelineLimit(t *testing.T) {
+	store := newMockStore()
+	for i := 0; i < 5; i++ {
+		store.addSession("test", fmt.Sprintf("sess-%d", i), time.Now(), []source.Message{
+			{Role: "user", Content: fmt.Sprintf("message %d", i)},
+			{Role: "assistant", Content: "ok"},
+		})
+	}
+
+	llm := &mockLLM{
+		reflectResponse: "- observation",
+		learnResponse: `=== SKILL: test-skill ===
+---
+name: Test
+description: Test skill.
+---
+
+Content here.`,
+	}
+
+	result, err := dream.Run(context.Background(), store, llm, dream.Options{Limit: 2})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	// 2 reflect calls + 1 learn call
+	if result.Processed != 2 {
+		t.Errorf("Processed = %d, want 2", result.Processed)
+	}
+	if len(llm.calls) != 3 {
+		t.Errorf("LLM calls = %d, want 3 (2 reflect + 1 learn)", len(llm.calls))
+	}
+}
+
+func TestDreamPipelineEmptyConversation(t *testing.T) {
+	store := newMockStore()
+	// Session with only empty messages produces no observations
+	store.addSession("test", "empty", time.Now(), []source.Message{
+		{Role: "user", Content: ""},
+		{Role: "assistant", Content: ""},
+	})
+
+	llm := &mockLLM{}
+
+	result, err := dream.Run(context.Background(), store, llm, dream.Options{})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	// Empty conversation produces no reflect call, but still shows up in pending
+	if result.Processed != 0 {
+		t.Errorf("Processed = %d, want 0", result.Processed)
+	}
+}
+
+func TestDreamPipelineReprocess(t *testing.T) {
+	store := newMockStore()
+	store.addSession("test", "sess-1", time.Now(), []source.Message{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi"},
+	})
+
+	llm := &mockLLM{
+		reflectResponse: "- observation",
+		learnResponse: `=== SKILL: test ===
+---
+name: Test
+description: A test skill.
+---
+
+Content.`,
+	}
+
+	// First run
+	_, err := dream.Run(context.Background(), store, llm, dream.Options{})
+	if err != nil {
+		t.Fatalf("first Run() error: %v", err)
+	}
+
+	// With Reprocess, it should process again even though state would normally prune it
+	llm.calls = nil
+	result, err := dream.Run(context.Background(), store, llm, dream.Options{Reprocess: true})
+	if err != nil {
+		t.Fatalf("reprocess Run() error: %v", err)
+	}
+	if result.Processed != 1 {
+		t.Errorf("Processed = %d, want 1", result.Processed)
+	}
+}
+
+func TestParseSkillsResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "basic",
+			input: `=== SKILL: code-style ===
+---
+name: Code Style
+description: Coding preferences.
+---
+
+Use tabs not spaces.`,
+			want: map[string]string{
+				"code-style": "---\nname: Code Style\ndescription: Coding preferences.\n---\n\nUse tabs not spaces.",
+			},
+		},
+		{
+			name:  "wrapped in code fences",
+			input: "```\n=== SKILL: test ===\n---\nname: Test\ndescription: Test.\n---\n\nContent.\n```",
+			want: map[string]string{
+				"test": "---\nname: Test\ndescription: Test.\n---\n\nContent.",
+			},
+		},
+		{
+			name: "multiple skills",
+			input: `=== SKILL: a ===
+Content A.
+
+=== SKILL: b ===
+Content B.`,
+			want: map[string]string{
+				"a": "Content A.",
+				"b": "Content B.",
+			},
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "no skills delimiter",
+			input:   "just some random text without any skills",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := dream.ParseSkillsResponse(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseSkillsResponse() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d skills, want %d", len(got), len(tt.want))
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("skill %q:\n  got:  %q\n  want: %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}

--- a/internal/bedrock/client.go
+++ b/internal/bedrock/client.go
@@ -16,6 +16,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+
+	"github.com/ellistarn/shade/internal/log"
 )
 
 const defaultModel = "us.anthropic.claude-opus-4-6-v1"
@@ -145,7 +147,7 @@ func (c *Client) Converse(ctx context.Context, system, user string) (string, Usa
 		}
 		lastErr = err
 		backoff := backoffDuration(attempt)
-		fmt.Printf("  throttled (attempt %d/%d), backing off %s\n", attempt+1, maxRetries, backoff.Round(time.Millisecond))
+		log.Printf("  throttled (attempt %d/%d), backing off %s\n", attempt+1, maxRetries, backoff.Round(time.Millisecond))
 		select {
 		case <-ctx.Done():
 			return "", Usage{}, ctx.Err()
@@ -170,7 +172,7 @@ func (c *Client) converse(ctx context.Context, system, user string) (string, Usa
 			},
 		},
 		InferenceConfig: &types.InferenceConfiguration{
-			MaxTokens: aws.Int32(16000),
+			MaxTokens: aws.Int32(64000),
 		},
 		// Adaptive thinking for Opus 4.6: lets Claude decide when and how much to think.
 		// https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-adaptive-thinking.html
@@ -195,7 +197,11 @@ func (c *Client) converse(ctx context.Context, system, user string) (string, Usa
 	}
 	usage.inputPricePerToken = c.pricing.inputPerToken
 	usage.outputPricePerToken = c.pricing.outputPerToken
-	return extractText(out), usage, nil
+	text := extractText(out)
+	if out.StopReason == types.StopReasonMaxTokens {
+		return text, usage, fmt.Errorf("response truncated: hit max token limit (%d output tokens)", usage.OutputTokens)
+	}
+	return text, usage, nil
 }
 
 // isThrottling checks whether the error is a Bedrock throttling (429) response.

--- a/internal/dream/dream.go
+++ b/internal/dream/dream.go
@@ -9,9 +9,25 @@ import (
 	"time"
 
 	"github.com/ellistarn/shade/internal/bedrock"
+	"github.com/ellistarn/shade/internal/log"
 	"github.com/ellistarn/shade/internal/source"
 	"github.com/ellistarn/shade/internal/storage"
 )
+
+// Store is the subset of storage.Client used by the dream pipeline.
+type Store interface {
+	GetJSON(ctx context.Context, key string, v any) error
+	PutJSON(ctx context.Context, key string, v any) error
+	ListSessions(ctx context.Context) ([]storage.SessionEntry, error)
+	GetSession(ctx context.Context, src, sessionID string) (*source.Session, error)
+	DeletePrefix(ctx context.Context, prefix string) error
+	PutSkill(ctx context.Context, name, content string) error
+}
+
+// LLM is the subset of bedrock.Client used by the dream pipeline.
+type LLM interface {
+	Converse(ctx context.Context, system, user string) (string, bedrock.Usage, error)
+}
 
 // State tracks which memories have been processed so we can prune on subsequent runs.
 type State struct {
@@ -47,22 +63,22 @@ func estimateTokens(s string) int {
 
 // Run executes the dream pipeline: load state, map new memories to observations,
 // reduce observations into skills, and persist the results.
-func Run(ctx context.Context, store *storage.Client, llm *bedrock.Client, opts Options) (*Result, error) {
+func Run(ctx context.Context, store Store, llm LLM, opts Options) (*Result, error) {
 	// Load prior dream state (missing state means first run)
 	var state State
 	if opts.Reprocess {
-		fmt.Println("Reprocessing all memories (ignoring saved state)")
+		log.Println("Reprocessing all memories (ignoring saved state)")
 		state = State{Memories: map[string]time.Time{}}
 	} else {
-		fmt.Println("Loading dream state...")
+		log.Println("Loading dream state...")
 		if err := store.GetJSON(ctx, stateKey, &state); err != nil {
-			fmt.Println("No prior dream state found, starting fresh")
+			log.Println("No prior dream state found, starting fresh")
 			state = State{Memories: map[string]time.Time{}}
 		}
 	}
 
 	// List all memories and filter to ones we haven't processed since their last modification
-	fmt.Println("Listing memories...")
+	log.Println("Listing memories...")
 	entries, err := store.ListSessions(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list memories: %w", err)
@@ -77,16 +93,16 @@ func Run(ctx context.Context, store *storage.Client, llm *bedrock.Client, opts O
 		pending = append(pending, e)
 	}
 	if opts.Limit > 0 && len(pending) > opts.Limit {
-		fmt.Printf("Found %d new memories, limiting to %d\n", len(pending), opts.Limit)
+		log.Printf("Found %d new memories, limiting to %d\n", len(pending), opts.Limit)
 		pending = pending[:opts.Limit]
 	}
-	fmt.Printf("Found %d memories (%d new, %d already processed)\n", len(entries), len(pending), pruned)
+	log.Printf("Found %d memories (%d new, %d already processed)\n", len(entries), len(pending), pruned)
 	if len(pending) == 0 {
 		return &Result{Pruned: pruned, Skills: 0}, nil
 	}
 
 	// Estimate tokens: load each session and estimate the input size
-	fmt.Println("Estimating token usage...")
+	log.Println("Estimating token usage...")
 	var totalEstimate int
 	for _, entry := range pending {
 		session, err := store.GetSession(ctx, entry.Source, entry.SessionID)
@@ -96,10 +112,10 @@ func Run(ctx context.Context, store *storage.Client, llm *bedrock.Client, opts O
 		conversation := formatSession(session)
 		totalEstimate += estimateTokens(reflectPrompt) + estimateTokens(conversation)
 	}
-	fmt.Printf("Estimated ~%dk input tokens for reflect phase\n", totalEstimate/1000)
+	log.Printf("Estimated ~%dk input tokens for reflect phase\n", totalEstimate/1000)
 
 	// Reflect: extract observations from each new/updated memory in parallel
-	fmt.Printf("Reflecting on %d memories...\n", len(pending))
+	log.Printf("Reflecting on %d memories...\n", len(pending))
 	type mapResult struct {
 		key          string
 		observations string
@@ -121,7 +137,7 @@ func Run(ctx context.Context, store *storage.Client, llm *bedrock.Client, opts O
 			if err != nil {
 				results[i] = mapResult{key: entry.Key, err: err}
 				n := completed.Add(1)
-				fmt.Printf("  [%d/%d] %s (error)\n", n, len(pending), entry.Key)
+				log.Printf("  [%d/%d] %s (error)\n", n, len(pending), entry.Key)
 				return
 			}
 			msgs := len(session.Messages)
@@ -129,9 +145,9 @@ func Run(ctx context.Context, store *storage.Client, llm *bedrock.Client, opts O
 			results[i] = mapResult{key: entry.Key, observations: obs, usage: usage, err: err}
 			n := completed.Add(1)
 			if err != nil {
-				fmt.Printf("  [%d/%d] %s (%d msgs) error: %v\n", n, len(pending), entry.Key, msgs, err)
+				log.Printf("  [%d/%d] %s (%d msgs) error: %v\n", n, len(pending), entry.Key, msgs, err)
 			} else {
-				fmt.Printf("  [%d/%d] %s (%d msgs, %d in / %d out tokens, $%.4f)\n",
+				log.Printf("  [%d/%d] %s (%d msgs, %d in / %d out tokens, $%.4f)\n",
 					n, len(pending), entry.Key, msgs, usage.InputTokens, usage.OutputTokens, usage.Cost())
 			}
 		}(i, entry)
@@ -154,18 +170,18 @@ func Run(ctx context.Context, store *storage.Client, llm *bedrock.Client, opts O
 		}
 		processedKeys[r.key] = time.Now()
 	}
-	fmt.Printf("Reflected on %d memories ($%.4f)\n", len(allObservations), reflectUsage.Cost())
+	log.Printf("Reflected on %d memories ($%.4f)\n", len(allObservations), reflectUsage.Cost())
 
 	// Learn: compress observations into skills
-	fmt.Printf("Learning skills from %d reflections...\n", len(allObservations))
+	log.Printf("Learning skills from %d reflections...\n", len(allObservations))
 	skills, learnUsage, err := learn(ctx, llm, allObservations)
 	if err != nil {
 		return nil, fmt.Errorf("learn failed: %w", err)
 	}
-	fmt.Printf("Produced %d skills ($%.4f)\n", len(skills), learnUsage.Cost())
+	log.Printf("Produced %d skills ($%.4f)\n", len(skills), learnUsage.Cost())
 
 	// Write skills to S3 (clear old skills first, dream produces a complete set)
-	fmt.Println("Writing skills to storage...")
+	log.Println("Writing skills to storage...")
 	if err := store.DeletePrefix(ctx, "skills/"); err != nil {
 		return nil, fmt.Errorf("failed to clear old skills: %w", err)
 	}
@@ -176,7 +192,7 @@ func Run(ctx context.Context, store *storage.Client, llm *bedrock.Client, opts O
 	}
 
 	// Update state with newly processed memories
-	fmt.Println("Saving dream state...")
+	log.Println("Saving dream state...")
 	for k, v := range processedKeys {
 		state.Memories[k] = v
 	}
@@ -194,7 +210,7 @@ func Run(ctx context.Context, store *storage.Client, llm *bedrock.Client, opts O
 	}, nil
 }
 
-func reflect(ctx context.Context, llm *bedrock.Client, session *source.Session) (string, bedrock.Usage, error) {
+func reflect(ctx context.Context, llm LLM, session *source.Session) (string, bedrock.Usage, error) {
 	conversation := formatSession(session)
 	if conversation == "" {
 		return "", bedrock.Usage{}, nil
@@ -202,7 +218,7 @@ func reflect(ctx context.Context, llm *bedrock.Client, session *source.Session) 
 	return llm.Converse(ctx, reflectPrompt, conversation)
 }
 
-func learn(ctx context.Context, llm *bedrock.Client, observations []string) (map[string]string, bedrock.Usage, error) {
+func learn(ctx context.Context, llm LLM, observations []string) (map[string]string, bedrock.Usage, error) {
 	if len(observations) == 0 {
 		return nil, bedrock.Usage{}, nil
 	}
@@ -211,7 +227,7 @@ func learn(ctx context.Context, llm *bedrock.Client, observations []string) (map
 	if err != nil {
 		return nil, usage, err
 	}
-	skills, err := parseSkillsResponse(raw)
+	skills, err := ParseSkillsResponse(raw)
 	return skills, usage, err
 }
 
@@ -226,10 +242,10 @@ func formatSession(session *source.Session) string {
 	return b.String()
 }
 
-// parseSkillsResponse splits the LLM's reduce output into individual skill files.
+// ParseSkillsResponse splits the LLM's reduce output into individual skill files.
 // Expected format: multiple blocks delimited by "=== SKILL: skill-name ===" headers,
 // where each block contains the complete SKILL.md content (frontmatter + body).
-func parseSkillsResponse(raw string) (map[string]string, error) {
+func ParseSkillsResponse(raw string) (map[string]string, error) {
 	// Strip markdown code fences the LLM sometimes wraps output in
 	cleaned := strings.TrimSpace(raw)
 	if strings.HasPrefix(cleaned, "```") {

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,15 @@
+package log
+
+import (
+	"fmt"
+	"time"
+)
+
+func Printf(format string, args ...any) {
+	fmt.Printf(time.Now().Format("15:04:05")+" "+format, args...)
+}
+
+func Println(args ...any) {
+	fmt.Print(time.Now().Format("15:04:05") + " ")
+	fmt.Println(args...)
+}

--- a/internal/shade/shade.go
+++ b/internal/shade/shade.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/ellistarn/shade/internal/bedrock"
+	"github.com/ellistarn/shade/internal/log"
 	"github.com/ellistarn/shade/internal/skill"
 	"github.com/ellistarn/shade/internal/source"
 	"github.com/ellistarn/shade/internal/storage"
@@ -93,34 +94,34 @@ func formatSkills(skills []skill.Skill) string {
 
 // Upload scans local sources, diffs against S3, and uploads changed sessions.
 func (s *Shade) Upload(ctx context.Context) (*UploadResult, error) {
-	fmt.Println("Listing remote sessions...")
+	log.Println("Listing remote sessions...")
 	existing, err := s.storage.ListSessions(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list remote sessions: %w", err)
 	}
-	fmt.Printf("Found %d remote sessions\n", len(existing))
+	log.Printf("Found %d remote sessions\n", len(existing))
 	remote := map[string]storage.SessionEntry{}
 	for _, e := range existing {
 		remote[e.Key] = e
 	}
 
-	fmt.Println("Scanning local sessions...")
+	log.Println("Scanning local sessions...")
 	var local []source.Session
 	var warnings []string
 	if sessions, err := source.OpenCodeSessions(); err != nil {
 		warnings = append(warnings, fmt.Sprintf("failed to read OpenCode sessions: %v", err))
 	} else {
-		fmt.Printf("Found %d OpenCode sessions\n", len(sessions))
+		log.Printf("Found %d OpenCode sessions\n", len(sessions))
 		local = append(local, sessions...)
 	}
 	if sessions, err := source.ClaudeCodeSessions(); err != nil {
 		warnings = append(warnings, fmt.Sprintf("failed to read Claude Code sessions: %v", err))
 	} else {
-		fmt.Printf("Found %d Claude Code sessions\n", len(sessions))
+		log.Printf("Found %d Claude Code sessions\n", len(sessions))
 		local = append(local, sessions...)
 	}
 
-	fmt.Printf("Diffing %d local sessions against remote...\n", len(local))
+	log.Printf("Diffing %d local sessions against remote...\n", len(local))
 	var uploaded, skipped int
 	var totalBytes int
 	for i := range local {
@@ -134,7 +135,7 @@ func (s *Shade) Upload(ctx context.Context) (*UploadResult, error) {
 		size := len(data)
 		if entry, exists := remote[key]; exists {
 			if !sess.UpdatedAt.After(entry.LastModified) {
-				fmt.Printf("  skip %s (%s, unchanged)\n", key, FormatBytes(size))
+				log.Printf("  skip %s (%s, unchanged)\n", key, FormatBytes(size))
 				skipped++
 				continue
 			}
@@ -143,7 +144,7 @@ func (s *Shade) Upload(ctx context.Context) (*UploadResult, error) {
 			warnings = append(warnings, fmt.Sprintf("failed to upload %s: %v", sess.SessionID, err))
 			continue
 		}
-		fmt.Printf("  upload %s (%s)\n", key, FormatBytes(size))
+		log.Printf("  upload %s (%s)\n", key, FormatBytes(size))
 		uploaded++
 		totalBytes += size
 	}


### PR DESCRIPTION
## Summary

Stacked on #1.

- Adds timestamped output via `internal/log` package, replacing raw `fmt.Print*` calls in dream, shade, and bedrock packages
- Fixes empty learn output caused by adaptive thinking consuming the entire 16k `MaxTokens` budget, leaving no room for text. Bumped to 64k and added an explicit error when `StopReason == max_tokens`
- Introduces `Store` and `LLM` interfaces in the dream package so the pipeline can be tested with mocks
- Adds e2e tests in `e2e/` covering the full dream pipeline, limit/reprocess flags, empty conversations, and skills response parsing