### PR TITLE
Fix shadowed context variable and data race in tests

### DIFF
--- a/internal/bedrock/client.go
+++ b/internal/bedrock/client.go
@@ -104,7 +104,7 @@ func NewClient(ctx context.Context) (*Client, error) {
 	if model == "" {
 		model = defaultModel
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	refillCtx, cancel := context.WithCancel(context.Background())
 	c := &Client{
 		runtime:  bedrockruntime.NewFromConfig(cfg),
 		model:    model,
@@ -112,7 +112,7 @@ func NewClient(ctx context.Context) (*Client, error) {
 		throttle: make(chan struct{}, requestsPerSec),
 		cancel:   cancel,
 	}
-	go c.refillTokens(ctx)
+	go c.refillTokens(refillCtx)
 	return c, nil
 }
 

--- a/internal/dream/dream_test.go
+++ b/internal/dream/dream_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -89,6 +90,7 @@ func (m *mockStore) PutSkill(_ context.Context, name, content string) error {
 // call count rather than prompt content: the last call in a batch is the learn
 // call, all others are reflect calls.
 type mockLLM struct {
+	mu              sync.Mutex
 	reflectResponse string
 	learnResponse   string
 	calls           []llmCall
@@ -102,7 +104,9 @@ type llmCall struct {
 }
 
 func (m *mockLLM) Converse(_ context.Context, system, user string) (string, bedrock.Usage, error) {
+	m.mu.Lock()
 	m.calls = append(m.calls, llmCall{system: system, user: user})
+	m.mu.Unlock()
 	usage := bedrock.Usage{InputTokens: 100, OutputTokens: 50}
 	n := int(m.callCount.Add(1))
 	// The learn call is the last one (after all reflect calls)


### PR DESCRIPTION
## Summary

Addresses review feedback from #3:

- Rename shadowed `ctx` to `refillCtx` in `bedrock.NewClient` to clarify that the refill goroutine's context is intentionally detached from the caller
- Guard `mockLLM.calls` with a mutex to prevent a data race when concurrent reflect goroutines append to the slice

Tests pass clean with `-race`.