### PR TITLE
Fix README tagline: shade advises, not serves skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Shade
 
 A shade is a projection of how you think. It absorbs your memories from agent interactions, distills
-them into skills, and serves those skills to any agent that asks.
+them into skills, and uses those skills to advise any agent that asks.
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- The shade doesn't serve skills directly — it distills advice from them. Updated the tagline to reflect that.