### PR TITLE
Add inspect command and dream history snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ compresses the reflections into skills that capture your expertise. Skills are g
 information: they teach models how you want things done without leaking underlying data. Dreaming is
 lossy by design, keeping what matters and forgetting what doesn't.
 
-Reflections are persisted so you can re-synthesize skills later with better models or prompts
-(`dream --learn`) without re-processing all your memories.
+Each dream snapshots your previous skills before overwriting them, so you have a full history of how
+your shade has evolved. Reflections are persisted so you can re-synthesize skills later with better
+models or prompts (`dream --learn`) without re-processing all your memories.
+
+**Inspect** prints your current skills so you can see what your shade has learned. Use
+`inspect --diff` to get an LLM-generated summary of what changed since the last dream.
 
 **Listen** starts an MCP server that exposes a single tool: **ask**. An agent sends a question and
 gets back guidance shaped by your skills. Each call is stateless, a one-shot interaction with no
@@ -41,6 +45,8 @@ export SHADE_MODEL=claude-sonnet-4-20250514
 shade push              # push memories to storage
 shade dream             # distill skills from memories
 shade dream --learn     # re-synthesize skills from existing reflections
+shade inspect           # print all skills
+shade inspect --diff    # summarize what changed since the last dream
 shade listen            # start the MCP server
 ```
 
@@ -74,7 +80,8 @@ running anywhere.
 S3-compatible storage with the following layout:
 
 ```
-skills/{name}/SKILL.md               # distilled skills (https://agentskills.io)
-memories/{source}/{id}.json          # human session history
-dream/reflections/{source}/{id}.md   # per-memory reflections
+skills/{name}/SKILL.md                          # distilled skills (https://agentskills.io)
+memories/{source}/{id}.json                     # human session history
+dreams/reflections/{source}/{id}.md             # per-memory reflections
+dreams/history/{timestamp}/skills/{name}/SKILL.md  # skill snapshots from previous dreams
 ```

--- a/cmd/shade/inspect.go
+++ b/cmd/shade/inspect.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ellistarn/shade/internal/bedrock"
+	"github.com/ellistarn/shade/internal/log"
+	"github.com/ellistarn/shade/internal/skill"
+	"github.com/ellistarn/shade/internal/storage"
+)
+
+func newInspectCmd() *cobra.Command {
+	var diff bool
+	cmd := &cobra.Command{
+		Use:   "inspect",
+		Short: "Inspect distilled skills",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireBucket(); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			store, err := storage.NewClient(ctx, bucket)
+			if err != nil {
+				return err
+			}
+			s3Client := store.S3()
+
+			if diff {
+				return runDiff(cmd, store, s3Client)
+			}
+
+			log.Println("Loading skills...")
+			skills, err := skill.LoadAll(ctx, s3Client, bucket)
+			if err != nil {
+				return fmt.Errorf("failed to load skills: %w", err)
+			}
+			if len(skills) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No skills found. Run 'shade dream' to generate skills from memories.")
+				return nil
+			}
+			log.Printf("Found %d skills\n", len(skills))
+			sort.Slice(skills, func(i, j int) bool { return skills[i].Slug < skills[j].Slug })
+			for i, sk := range skills {
+				if i > 0 {
+					fmt.Fprintln(cmd.OutOrStdout())
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "=== %s ===\n", sk.Name)
+				fmt.Fprintf(cmd.OutOrStdout(), "%s\n", sk.Description)
+				fmt.Fprintln(cmd.OutOrStdout())
+				fmt.Fprintln(cmd.OutOrStdout(), sk.Content)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&diff, "diff", false, "summarize what changed since the last dream")
+	return cmd
+}
+
+func runDiff(cmd *cobra.Command, store *storage.Client, s3Client skill.S3API) error {
+	ctx := cmd.Context()
+
+	log.Println("Loading dream history...")
+	dreams, err := store.ListDreams(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list dream history: %w", err)
+	}
+	if len(dreams) == 0 {
+		return fmt.Errorf("no dream history found; run 'shade dream' to create a snapshot")
+	}
+	latest := dreams[len(dreams)-1]
+	log.Printf("Comparing snapshot %s with current skills\n", latest)
+
+	prev, err := store.GetDreamSkills(ctx, latest)
+	if err != nil {
+		return fmt.Errorf("failed to load dream snapshot %s: %w", latest, err)
+	}
+	current, err := skill.LoadAll(ctx, s3Client, bucket)
+	if err != nil {
+		return fmt.Errorf("failed to load current skills: %w", err)
+	}
+	log.Printf("Previous: %d skills, Current: %d skills\n", len(prev), len(current))
+
+	if len(prev) == 0 && len(current) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No skills in either snapshot.")
+		return nil
+	}
+
+	prevText := formatSkillSet("Previous skills", prev)
+	currText := formatSkillSet("Current skills", current)
+
+	log.Println("Generating diff summary...")
+	llm, err := bedrock.NewClient(ctx, bedrock.ModelSonnet)
+	if err != nil {
+		return err
+	}
+
+	prompt := `Compare the previous and current skill sets. Summarize what changed in a few concise bullet points: which skills were added, removed, or meaningfully revised. Focus on substance, not formatting.`
+
+	summary, usage, err := llm.Converse(ctx, prompt, prevText+"\n\n---\n\n"+currText)
+	if err != nil {
+		return fmt.Errorf("failed to generate diff summary: %w", err)
+	}
+	log.Printf("Diff complete ($%.4f)\n", usage.Cost())
+	fmt.Fprintf(cmd.OutOrStdout(), "Changes since %s:\n\n%s\n", latest, strings.TrimSpace(summary))
+	return nil
+}
+
+func formatSkillSet(label string, skills []skill.Skill) string {
+	if len(skills) == 0 {
+		return fmt.Sprintf("%s: (none)", label)
+	}
+	sort.Slice(skills, func(i, j int) bool { return skills[i].Slug < skills[j].Slug })
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s:\n\n", label)
+	for _, sk := range skills {
+		fmt.Fprintf(&b, "## %s\n%s\n\n%s\n\n", sk.Name, sk.Description, sk.Content)
+	}
+	return b.String()
+}

--- a/cmd/shade/root.go
+++ b/cmd/shade/root.go
@@ -19,6 +19,7 @@ func newRootCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&bucket, "bucket", os.Getenv("SHADE_BUCKET"), "S3 bucket name (or set SHADE_BUCKET)")
 	cmd.AddCommand(newPushCmd())
 	cmd.AddCommand(newDreamCmd())
+	cmd.AddCommand(newInspectCmd())
 	cmd.AddCommand(newListenCmd())
 	cmd.AddCommand(newAskCmd())
 	return cmd

--- a/e2e/dream_test.go
+++ b/e2e/dream_test.go
@@ -80,7 +80,7 @@ func (m *mockStore) PutReflection(_ context.Context, key, content string) error 
 
 func (m *mockStore) DeletePrefix(_ context.Context, prefix string) error {
 	m.deleted = append(m.deleted, prefix)
-	if prefix == "dream/reflections/" {
+	if prefix == "dreams/reflections/" {
 		m.reflections = map[string]string{}
 	}
 	return nil
@@ -88,6 +88,10 @@ func (m *mockStore) DeletePrefix(_ context.Context, prefix string) error {
 
 func (m *mockStore) PutSkill(_ context.Context, name, content string) error {
 	m.skills[name] = content
+	return nil
+}
+
+func (m *mockStore) SnapshotSkills(_ context.Context, _ string) error {
 	return nil
 }
 

--- a/internal/dream/dream.go
+++ b/internal/dream/dream.go
@@ -24,6 +24,7 @@ type Store interface {
 	PutReflection(ctx context.Context, key, content string) error
 	DeletePrefix(ctx context.Context, prefix string) error
 	PutSkill(ctx context.Context, name, content string) error
+	SnapshotSkills(ctx context.Context, timestamp string) error
 }
 
 // LLM is the subset of an LLM client used by the dream pipeline.
@@ -72,7 +73,7 @@ func Run(ctx context.Context, store Store, client LLM, opts Options) (*Result, e
 	// If reprocessing, clear all existing reflections
 	if opts.Reflect {
 		log.Println("Re-reflecting all memories (clearing existing reflections)")
-		if err := store.DeletePrefix(ctx, "dream/reflections/"); err != nil {
+		if err := store.DeletePrefix(ctx, "dreams/reflections/"); err != nil {
 			return nil, fmt.Errorf("failed to clear reflections: %w", err)
 		}
 		reflections = map[string]time.Time{}
@@ -187,16 +188,12 @@ func Run(ctx context.Context, store Store, client LLM, opts Options) (*Result, e
 	}
 	log.Printf("Produced %d skills ($%.4f)\n", len(skills), learnUsage.Cost())
 
-	// Write skills (clear old skills first, dream produces a complete set)
-	log.Println("Writing skills to storage...")
-	if err := store.DeletePrefix(ctx, "skills/"); err != nil {
-		return nil, fmt.Errorf("failed to clear old skills: %w", err)
+	// Write skills (snapshot old skills first, then clear and replace)
+	writeWarnings, err := writeSkills(ctx, store, skills)
+	if err != nil {
+		return nil, err
 	}
-	for name, content := range skills {
-		if err := store.PutSkill(ctx, name, content); err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to write skill %s: %v", name, err))
-		}
-	}
+	warnings = append(warnings, writeWarnings...)
 
 	processed := len(pending) - len(warnings)
 	if processed < 0 {
@@ -230,7 +227,28 @@ func LearnOnly(ctx context.Context, store Store, client LLM) (*Result, error) {
 	log.Printf("Produced %d skills ($%.4f)\n", len(skills), usage.Cost())
 
 	log.Println("Writing skills to storage...")
-	var warnings []string
+	writeWarnings, err := writeSkills(ctx, store, skills)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		Skills:   len(skills),
+		Usage:    usage,
+		Warnings: writeWarnings,
+	}, nil
+}
+
+// writeSkills snapshots existing skills, clears them, and writes the new set.
+func writeSkills(ctx context.Context, store Store, skills map[string]string) (warnings []string, err error) {
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+	log.Printf("Snapshotting previous skills to dreams/history/%s/...\n", timestamp)
+	if err := store.SnapshotSkills(ctx, timestamp); err != nil {
+		log.Printf("Snapshot skipped (expected on first dream): %v\n", err)
+	} else {
+		log.Printf("Snapshot saved\n")
+	}
+	log.Printf("Writing %d skills to storage...\n", len(skills))
 	if err := store.DeletePrefix(ctx, "skills/"); err != nil {
 		return nil, fmt.Errorf("failed to clear old skills: %w", err)
 	}
@@ -239,12 +257,7 @@ func LearnOnly(ctx context.Context, store Store, client LLM) (*Result, error) {
 			warnings = append(warnings, fmt.Sprintf("failed to write skill %s: %v", name, err))
 		}
 	}
-
-	return &Result{
-		Skills:   len(skills),
-		Usage:    usage,
-		Warnings: warnings,
-	}, nil
+	return warnings, nil
 }
 
 // loadAllReflections fetches every persisted reflection from storage.

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -130,7 +130,7 @@ func loadSkill(ctx context.Context, client S3API, bucket, key string) (*Skill, e
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", key, err)
 	}
-	return parse(string(data))
+	return Parse(string(data))
 }
 
 // parseMeta extracts only the YAML frontmatter from a SKILL.md, ignoring the body.
@@ -146,8 +146,8 @@ func parseMeta(raw string) (*Skill, error) {
 	return &sk, nil
 }
 
-// parse splits a SKILL.md into YAML frontmatter and markdown body.
-func parse(raw string) (*Skill, error) {
+// Parse splits a SKILL.md into YAML frontmatter and markdown body.
+func Parse(raw string) (*Skill, error) {
 	frontmatter, body, err := splitFrontmatter(raw)
 	if err != nil {
 		return nil, err

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/ellistarn/shade/internal/awsconfig"
+	"github.com/ellistarn/shade/internal/skill"
 	"github.com/ellistarn/shade/internal/source"
 )
 
@@ -20,6 +22,12 @@ type Client struct {
 	s3     *s3.Client
 	bucket string
 }
+
+// S3 returns the underlying S3 client for direct use by skill loading.
+func (c *Client) S3() *s3.Client { return c.s3 }
+
+// Bucket returns the configured bucket name.
+func (c *Client) Bucket() string { return c.bucket }
 
 func NewClient(ctx context.Context, bucket string) (*Client, error) {
 	cfg, err := awsconfig.Load(ctx)
@@ -163,10 +171,10 @@ func (c *Client) PutSkill(ctx context.Context, name, content string) error {
 	return nil
 }
 
-// PutReflection writes a reflection to S3 under dream/reflections/{key}.md.
+// PutReflection writes a reflection to S3 under dreams/reflections/{key}.md.
 func (c *Client) PutReflection(ctx context.Context, key, content string) error {
 	// Replace the memories/ prefix so reflections mirror the memory layout
-	path := fmt.Sprintf("dream/reflections/%s.md", strings.TrimPrefix(strings.TrimSuffix(key, ".json"), "memories/"))
+	path := fmt.Sprintf("dreams/reflections/%s.md", strings.TrimPrefix(strings.TrimSuffix(key, ".json"), "memories/"))
 	contentType := "text/markdown"
 	_, err := c.s3.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      &c.bucket,
@@ -180,12 +188,12 @@ func (c *Client) PutReflection(ctx context.Context, key, content string) error {
 	return nil
 }
 
-// ListReflections returns the keys of all persisted reflections under dream/reflections/.
+// ListReflections returns the keys of all persisted reflections under dreams/reflections/.
 func (c *Client) ListReflections(ctx context.Context) (map[string]time.Time, error) {
 	reflections := map[string]time.Time{}
 	paginator := s3.NewListObjectsV2Paginator(c.s3, &s3.ListObjectsV2Input{
 		Bucket: &c.bucket,
-		Prefix: aws.String("dream/reflections/"),
+		Prefix: aws.String("dreams/reflections/"),
 	})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
@@ -193,9 +201,9 @@ func (c *Client) ListReflections(ctx context.Context) (map[string]time.Time, err
 			return nil, fmt.Errorf("failed to list reflections: %w", err)
 		}
 		for _, obj := range page.Contents {
-			// Convert dream/reflections/opencode/ses_abc.md back to memories/opencode/ses_abc.json
+			// Convert dreams/reflections/opencode/ses_abc.md back to memories/opencode/ses_abc.json
 			key := aws.ToString(obj.Key)
-			memoryKey := strings.TrimPrefix(key, "dream/reflections/")
+			memoryKey := strings.TrimPrefix(key, "dreams/reflections/")
 			memoryKey = "memories/" + strings.TrimSuffix(memoryKey, ".md") + ".json"
 			reflections[memoryKey] = aws.ToTime(obj.LastModified)
 		}
@@ -205,7 +213,7 @@ func (c *Client) ListReflections(ctx context.Context) (map[string]time.Time, err
 
 // GetReflection downloads a reflection's content from S3.
 func (c *Client) GetReflection(ctx context.Context, memoryKey string) (string, error) {
-	path := fmt.Sprintf("dream/reflections/%s.md", strings.TrimPrefix(strings.TrimSuffix(memoryKey, ".json"), "memories/"))
+	path := fmt.Sprintf("dreams/reflections/%s.md", strings.TrimPrefix(strings.TrimSuffix(memoryKey, ".json"), "memories/"))
 	out, err := c.s3.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: &c.bucket,
 		Key:    &path,
@@ -243,6 +251,103 @@ func (c *Client) DeletePrefix(ctx context.Context, prefix string) error {
 		}
 	}
 	return nil
+}
+
+// SnapshotSkills copies all current skills to dreams/{timestamp}/skills/.
+// This preserves the skill set before a dream overwrites it.
+func (c *Client) SnapshotSkills(ctx context.Context, timestamp string) error {
+	prefix := "skills/"
+	paginator := s3.NewListObjectsV2Paginator(c.s3, &s3.ListObjectsV2Input{
+		Bucket: &c.bucket,
+		Prefix: aws.String(prefix),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list skills for snapshot: %w", err)
+		}
+		for _, obj := range page.Contents {
+			srcKey := aws.ToString(obj.Key)
+			dstKey := fmt.Sprintf("dreams/history/%s/%s", timestamp, srcKey)
+			copySource := fmt.Sprintf("%s/%s", c.bucket, srcKey)
+			if _, err := c.s3.CopyObject(ctx, &s3.CopyObjectInput{
+				Bucket:     &c.bucket,
+				CopySource: &copySource,
+				Key:        &dstKey,
+			}); err != nil {
+				return fmt.Errorf("failed to copy %s to %s: %w", srcKey, dstKey, err)
+			}
+		}
+	}
+	return nil
+}
+
+// ListDreams returns timestamps of all dream snapshots, sorted ascending.
+func (c *Client) ListDreams(ctx context.Context) ([]string, error) {
+	prefix := "dreams/history/"
+	out, err := c.s3.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket:    &c.bucket,
+		Prefix:    aws.String(prefix),
+		Delimiter: aws.String("/"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list dreams: %w", err)
+	}
+	var timestamps []string
+	for _, cp := range out.CommonPrefixes {
+		p := aws.ToString(cp.Prefix)
+		// "dreams/history/2026-03-11T16:30:00Z/" -> "2026-03-11T16:30:00Z"
+		p = strings.TrimPrefix(p, prefix)
+		p = strings.TrimSuffix(p, "/")
+		if p != "" {
+			timestamps = append(timestamps, p)
+		}
+	}
+	sort.Strings(timestamps)
+	return timestamps, nil
+}
+
+// GetDreamSkills loads all skills from a specific dream snapshot.
+func (c *Client) GetDreamSkills(ctx context.Context, timestamp string) ([]skill.Skill, error) {
+	prefix := fmt.Sprintf("dreams/history/%s/skills/", timestamp)
+	var skills []skill.Skill
+	paginator := s3.NewListObjectsV2Paginator(c.s3, &s3.ListObjectsV2Input{
+		Bucket: &c.bucket,
+		Prefix: aws.String(prefix),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list dream skills: %w", err)
+		}
+		for _, obj := range page.Contents {
+			key := aws.ToString(obj.Key)
+			if !strings.HasSuffix(key, "/SKILL.md") {
+				continue
+			}
+			out, err := c.s3.GetObject(ctx, &s3.GetObjectInput{
+				Bucket: &c.bucket,
+				Key:    &key,
+			})
+			if err != nil {
+				continue
+			}
+			data, err := io.ReadAll(out.Body)
+			out.Body.Close()
+			if err != nil {
+				continue
+			}
+			sk, err := skill.Parse(string(data))
+			if err != nil {
+				continue
+			}
+			// Extract slug from key like "dreams/ts/skills/foo/SKILL.md"
+			rel := strings.TrimPrefix(key, prefix)
+			sk.Slug = strings.TrimSuffix(rel, "/SKILL.md")
+			skills = append(skills, *sk)
+		}
+	}
+	return skills, nil
 }
 
 func sessionKey(src, sessionID string) string {


### PR DESCRIPTION
## Summary

- **`shade inspect`** prints all distilled skills to stdout
- **`shade inspect --diff`** loads the most recent dream snapshot vs current skills and asks the LLM to summarize what changed
- **Dream history**: each dream snapshots the previous skill set to `dreams/history/{timestamp}/` before overwriting, preserving how the shade evolves over time
- **Path reorganization**: reflections moved from `dream/reflections/` to `dreams/reflections/` so all dream state lives under one prefix

## Storage layout

```
skills/{name}/SKILL.md                             # current skills
memories/{source}/{id}.json                        # session history
dreams/reflections/{source}/{id}.md                # per-memory reflections
dreams/history/{timestamp}/skills/{name}/SKILL.md  # snapshots from previous dreams
```

## Notes

- Existing reflections under `dream/reflections/` will need a `--reflect` run to repopulate under the new path
- `skill.Parse` exported for reuse by storage layer