### PR TITLE
Cache skill catalog on boot, rename ask to advise

### DIFF
--- a/cmd/shade/advise.go
+++ b/cmd/shade/advise.go
@@ -9,10 +9,10 @@ import (
 	"github.com/ellistarn/shade/internal/shade"
 )
 
-func newAskCmd() *cobra.Command {
+func newAdviseCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "ask [question]",
-		Short: "Ask the shade a question",
+		Use:   "advise [question]",
+		Short: "Ask the shade for advice",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := requireBucket(); err != nil {
@@ -24,7 +24,7 @@ func newAskCmd() *cobra.Command {
 				return err
 			}
 			question := strings.Join(args, " ")
-			answer, err := s.Ask(ctx, question)
+			answer, err := s.Advise(ctx, question)
 			if err != nil {
 				return err
 			}

--- a/e2e/ask_test.go
+++ b/e2e/ask_test.go
@@ -151,7 +151,7 @@ description: %s
 
 %s`
 
-func TestAskWithSkillLookup(t *testing.T) {
+func TestAdviseWithSkillLookup(t *testing.T) {
 	s3Client := &mockS3{skills: map[string]string{
 		"skills/naming-conventions/SKILL.md": fmt.Sprintf(skillFileTemplate,
 			"Naming Conventions", "File and commit naming preferences.", "Use kebab-case for file names."),
@@ -169,9 +169,9 @@ func TestAskWithSkillLookup(t *testing.T) {
 	bedrockClient := bedrock.NewClientWithRuntime(ctx, runtime)
 	s := shade.NewForTest(s3Client, bedrockClient, "test-bucket")
 
-	answer, err := s.Ask(ctx, "how should I name files?")
+	answer, err := s.Advise(ctx, "how should I name files?")
 	if err != nil {
-		t.Fatalf("Ask() error: %v", err)
+		t.Fatalf("Advise() error: %v", err)
 	}
 	if answer != "Use kebab-case for your file names." {
 		t.Errorf("answer = %q, want %q", answer, "Use kebab-case for your file names.")
@@ -201,7 +201,7 @@ func TestAskWithSkillLookup(t *testing.T) {
 	}
 }
 
-func TestAskNoSkillsNeeded(t *testing.T) {
+func TestAdviseNoSkillsNeeded(t *testing.T) {
 	s3Client := &mockS3{skills: map[string]string{
 		"skills/naming-conventions/SKILL.md": fmt.Sprintf(skillFileTemplate,
 			"Naming Conventions", "File and commit naming preferences.", "Use kebab-case."),
@@ -217,9 +217,9 @@ func TestAskNoSkillsNeeded(t *testing.T) {
 	bedrockClient := bedrock.NewClientWithRuntime(ctx, runtime)
 	s := shade.NewForTest(s3Client, bedrockClient, "test-bucket")
 
-	answer, err := s.Ask(ctx, "hello")
+	answer, err := s.Advise(ctx, "hello")
 	if err != nil {
-		t.Fatalf("Ask() error: %v", err)
+		t.Fatalf("Advise() error: %v", err)
 	}
 	if answer != "Hello! How can I help?" {
 		t.Errorf("answer = %q, want %q", answer, "Hello! How can I help?")
@@ -235,7 +235,7 @@ func TestAskNoSkillsNeeded(t *testing.T) {
 	}
 }
 
-func TestAskEmptyCatalog(t *testing.T) {
+func TestAdviseEmptyCatalog(t *testing.T) {
 	s3Client := &mockS3{skills: map[string]string{}}
 
 	runtime := &mockRuntime{responses: []bedrockruntime.ConverseOutput{
@@ -247,9 +247,9 @@ func TestAskEmptyCatalog(t *testing.T) {
 	bedrockClient := bedrock.NewClientWithRuntime(ctx, runtime)
 	s := shade.NewForTest(s3Client, bedrockClient, "test-bucket")
 
-	answer, err := s.Ask(ctx, "how do you handle errors?")
+	answer, err := s.Advise(ctx, "how do you handle errors?")
 	if err != nil {
-		t.Fatalf("Ask() error: %v", err)
+		t.Fatalf("Advise() error: %v", err)
 	}
 	if answer != "I don't have any relevant skills for that." {
 		t.Errorf("answer = %q", answer)
@@ -263,7 +263,7 @@ func TestAskEmptyCatalog(t *testing.T) {
 	}
 }
 
-func TestAskMultipleSkills(t *testing.T) {
+func TestAdviseMultipleSkills(t *testing.T) {
 	s3Client := &mockS3{skills: map[string]string{
 		"skills/naming-conventions/SKILL.md": fmt.Sprintf(skillFileTemplate,
 			"Naming Conventions", "File naming preferences.", "Use kebab-case."),
@@ -284,9 +284,9 @@ func TestAskMultipleSkills(t *testing.T) {
 	bedrockClient := bedrock.NewClientWithRuntime(ctx, runtime)
 	s := shade.NewForTest(s3Client, bedrockClient, "test-bucket")
 
-	answer, err := s.Ask(ctx, "what are your coding conventions?")
+	answer, err := s.Advise(ctx, "what are your coding conventions?")
 	if err != nil {
-		t.Fatalf("Ask() error: %v", err)
+		t.Fatalf("Advise() error: %v", err)
 	}
 	if answer != "Use kebab-case and wrap errors with context." {
 		t.Errorf("answer = %q", answer)
@@ -301,7 +301,7 @@ func TestAskMultipleSkills(t *testing.T) {
 	}
 }
 
-func TestAskMultiRoundToolUse(t *testing.T) {
+func TestAdviseMultiRoundToolUse(t *testing.T) {
 	s3Client := &mockS3{skills: map[string]string{
 		"skills/error-handling/SKILL.md": fmt.Sprintf(skillFileTemplate,
 			"Error Handling", "Error return patterns.", "Wrap errors with context. See also: logging."),
@@ -323,9 +323,9 @@ func TestAskMultiRoundToolUse(t *testing.T) {
 	bedrockClient := bedrock.NewClientWithRuntime(ctx, runtime)
 	s := shade.NewForTest(s3Client, bedrockClient, "test-bucket")
 
-	answer, err := s.Ask(ctx, "how should I handle errors?")
+	answer, err := s.Advise(ctx, "how should I handle errors?")
 	if err != nil {
-		t.Fatalf("Ask() error: %v", err)
+		t.Fatalf("Advise() error: %v", err)
 	}
 	if answer != "Wrap errors with context and use structured logging." {
 		t.Errorf("answer = %q", answer)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -11,11 +11,11 @@ import (
 	"github.com/ellistarn/shade/prompts"
 )
 
-// NewServer creates an MCP server with a single "ask" tool.
+// NewServer creates an MCP server with an ask tool.
 func NewServer(s *shade.Shade) *server.MCPServer {
 	srv := server.NewMCPServer("shade", "0.1.0", server.WithToolCapabilities(false))
 	srv.AddTool(
-		mcp.NewTool("ask",
+		mcp.NewTool("advise",
 			mcp.WithDescription(prompts.Tool),
 			mcp.WithString("question", mcp.Required(), mcp.Description("The question to ask")),
 		),
@@ -30,7 +30,7 @@ func askHandler(s *shade.Shade) server.ToolHandlerFunc {
 		if err != nil {
 			return nil, err
 		}
-		answer, err := s.Ask(ctx, question)
+		answer, err := s.Advise(ctx, question)
 		if err != nil {
 			return nil, fmt.Errorf("failed to ask: %w", err)
 		}

--- a/internal/shade/shade.go
+++ b/internal/shade/shade.go
@@ -34,6 +34,7 @@ type Shade struct {
 	s3      skill.S3API
 	bedrock *bedrock.Client
 	bucket  string
+	catalog []skill.Skill
 }
 
 func New(ctx context.Context, bucket string) (*Shade, error) {
@@ -49,11 +50,18 @@ func New(ctx context.Context, bucket string) (*Shade, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create bedrock client: %w", err)
 	}
+	s3Client := s3.NewFromConfig(cfg)
+	catalog, err := skill.LoadCatalog(ctx, s3Client, bucket)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load skill catalog: %w", err)
+	}
+	log.Printf("Loaded %d skills\n", len(catalog))
 	return &Shade{
 		storage: storageClient,
-		s3:      s3.NewFromConfig(cfg),
+		s3:      s3Client,
 		bedrock: bedrockClient,
 		bucket:  bucket,
+		catalog: catalog,
 	}, nil
 }
 
@@ -94,16 +102,12 @@ func readSkillToolSpec() *types.ToolConfiguration {
 	}
 }
 
-// Ask answers a question using the shade's distilled skills.
+// Advise answers a question using the shade's distilled skills.
 // The LLM sees a catalog of skill names and descriptions, then uses tool
 // calling to fetch the full content of any skills it deems relevant.
 // This is a stateless one-shot: no session history, no persistence.
-func (s *Shade) Ask(ctx context.Context, question string) (string, error) {
-	catalog, err := skill.LoadCatalog(ctx, s.s3, s.bucket)
-	if err != nil {
-		return "", fmt.Errorf("failed to load skill catalog: %w", err)
-	}
-	system := fmt.Sprintf(systemPrompt, formatCatalog(catalog))
+func (s *Shade) Advise(ctx context.Context, question string) (string, error) {
+	system := fmt.Sprintf(systemPrompt, formatCatalog(s.catalog))
 	toolConfig := readSkillToolSpec()
 
 	handler := func(name string, input map[string]any) (string, error) {


### PR DESCRIPTION
## Summary

- Load the skill catalog from S3 once during `New()` instead of on every call
- Rename `ask` to `advise` across CLI command, MCP tool, Go method, and tests to reflect the shade's advisory role