### PR TITLE
Rename ask to advise in root command registration

### DIFF
--- a/cmd/shade/root.go
+++ b/cmd/shade/root.go
@@ -21,7 +21,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(newDreamCmd())
 	cmd.AddCommand(newInspectCmd())
 	cmd.AddCommand(newListenCmd())
-	cmd.AddCommand(newAskCmd())
+	cmd.AddCommand(newAdviseCmd())
 	return cmd
 }
 


### PR DESCRIPTION
## Summary
- Updates `root.go` to register `newAdviseCmd()` instead of `newAskCmd()`, completing the ask-to-advise rename