### PR TITLE
Fix variable shadowing in dream command that causes nil pointer dereference

### DIFF
--- a/cmd/muse/dream.go
+++ b/cmd/muse/dream.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 
@@ -27,45 +29,57 @@ func newDreamCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			var result *dream.Result
 			if learn {
-				learnLLM, err := bedrock.NewClient(ctx, bedrock.ModelOpus)
-				if err != nil {
-					return err
+				client, cerr := bedrock.NewClient(ctx, bedrock.ModelOpus)
+				if cerr != nil {
+					return cerr
 				}
-				log.Printf("Learning with %s\n", learnLLM.Model())
-				result, err = dream.LearnOnly(ctx, store, learnLLM)
-			} else {
-				reflectLLM, err := bedrock.NewClient(ctx, bedrock.ModelSonnet)
-				if err != nil {
-					return err
-				}
-				learnLLM, err := bedrock.NewClient(ctx, bedrock.ModelOpus)
-				if err != nil {
-					return err
-				}
-				log.Printf("Reflecting with %s, learning with %s\n", reflectLLM.Model(), learnLLM.Model())
-				result, err = dream.Run(ctx, store, reflectLLM, learnLLM, dream.Options{Reflect: reflect, Limit: limit})
+				log.Printf("Learning with %s\n", client.Model())
+				return runDream(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), store, nil, client, true, false, 0)
 			}
+			reflectClient, err := bedrock.NewClient(ctx, bedrock.ModelSonnet)
 			if err != nil {
 				return err
 			}
-			for _, w := range result.Warnings {
-				fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", w)
+			learnClient, err := bedrock.NewClient(ctx, bedrock.ModelOpus)
+			if err != nil {
+				return err
 			}
-			if !learn {
-				fmt.Fprintf(cmd.OutOrStdout(), "Processed %d memories (%d pruned)\n", result.Processed, result.Pruned)
-				if result.Remaining > 0 {
-					fmt.Fprintf(cmd.OutOrStdout(), "%d memories still pending reflection (run dream again)\n", result.Remaining)
-				}
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Produced %d skills (%dk input, %dk output tokens, $%.2f)\n",
-				result.Skills, result.Usage.InputTokens/1000, result.Usage.OutputTokens/1000, result.Usage.Cost())
-			return nil
+			log.Printf("Reflecting with %s, learning with %s\n", reflectClient.Model(), learnClient.Model())
+			return runDream(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), store, reflectClient, learnClient, false, reflect, limit)
 		},
 	}
 	cmd.Flags().BoolVar(&reflect, "reflect", false, "re-reflect on all memories from scratch")
 	cmd.Flags().BoolVar(&learn, "learn", false, "skip reflect, re-synthesize skills from existing reflections")
 	cmd.Flags().IntVar(&limit, "limit", 100, "max memories to process (0 = no limit)")
 	return cmd
+}
+
+// runDream executes the dream pipeline and prints results. Extracted from the
+// command handler so it can be tested with mock dependencies.
+func runDream(ctx context.Context, stdout, stderr io.Writer, store dream.Store, reflectLLM, learnLLM dream.LLM, learn, reflect bool, limit int) error {
+	var (
+		result *dream.Result
+		err    error
+	)
+	if learn {
+		result, err = dream.LearnOnly(ctx, store, learnLLM)
+	} else {
+		result, err = dream.Run(ctx, store, reflectLLM, learnLLM, dream.Options{Reflect: reflect, Limit: limit})
+	}
+	if err != nil {
+		return err
+	}
+	for _, w := range result.Warnings {
+		fmt.Fprintf(stderr, "warning: %s\n", w)
+	}
+	if !learn {
+		fmt.Fprintf(stdout, "Processed %d memories (%d pruned)\n", result.Processed, result.Pruned)
+		if result.Remaining > 0 {
+			fmt.Fprintf(stdout, "%d memories still pending reflection (run dream again)\n", result.Remaining)
+		}
+	}
+	fmt.Fprintf(stdout, "Produced %d skills (%dk input, %dk output tokens, $%.2f)\n",
+		result.Skills, result.Usage.InputTokens/1000, result.Usage.OutputTokens/1000, result.Usage.Cost())
+	return nil
 }

--- a/cmd/muse/dream_test.go
+++ b/cmd/muse/dream_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ellistarn/muse/internal/llm"
+	"github.com/ellistarn/muse/internal/source"
+	"github.com/ellistarn/muse/internal/storage"
+)
+
+func TestDreamCmd_RequiresBucket(t *testing.T) {
+	t.Setenv("MUSE_BUCKET", "")
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"dream"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when bucket is not set")
+	}
+	if got := err.Error(); got != "bucket is required: use --bucket or set MUSE_BUCKET" {
+		t.Errorf("unexpected error: %s", got)
+	}
+}
+
+func TestDreamCmd_LearnRequiresBucket(t *testing.T) {
+	t.Setenv("MUSE_BUCKET", "")
+
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"dream", "--learn"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when bucket is not set with --learn flag")
+	}
+}
+
+func TestRunDream_PropagatesRunError(t *testing.T) {
+	store := &failingStore{err: fmt.Errorf("storage unavailable")}
+	ctx := context.Background()
+	var stdout, stderr bytes.Buffer
+
+	err := runDream(ctx, &stdout, &stderr, store, &testLLM{}, &testLLM{}, false, false, 100)
+	if err == nil {
+		t.Fatal("expected error from failing store, got nil")
+	}
+	if !strings.Contains(err.Error(), "storage unavailable") {
+		t.Errorf("expected error to contain 'storage unavailable', got: %s", err.Error())
+	}
+}
+
+func TestRunDream_PropagatesLearnError(t *testing.T) {
+	store := newTestStore()
+	store.reflections["memories/test/sess-1.json"] = "- observation"
+	ctx := context.Background()
+	var stdout, stderr bytes.Buffer
+
+	err := runDream(ctx, &stdout, &stderr, store, nil, &testLLM{err: fmt.Errorf("learn failed")}, true, false, 0)
+	if err == nil {
+		t.Fatal("expected error from failing LLM, got nil")
+	}
+	if !strings.Contains(err.Error(), "learn failed") {
+		t.Errorf("expected error to contain 'learn failed', got: %s", err.Error())
+	}
+}
+
+func TestRunDream_SuccessfulRun(t *testing.T) {
+	store := newTestStore()
+	store.addSession("test", "sess-1", []source.Message{
+		{Role: "user", Content: "use tabs"},
+		{Role: "assistant", Content: "ok"},
+		{Role: "user", Content: "also no emojis"},
+		{Role: "assistant", Content: "sure"},
+	})
+	mockLLM := &testLLM{
+		reflectResponse: "- Uses tabs\n- No emojis",
+		learnResponse: `=== SKILL: style ===
+---
+name: Style
+description: Code style preferences.
+---
+
+Use tabs. No emojis.`,
+	}
+
+	ctx := context.Background()
+	var stdout, stderr bytes.Buffer
+
+	err := runDream(ctx, &stdout, &stderr, store, mockLLM, mockLLM, false, false, 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Processed 1 memories") {
+		t.Errorf("expected 'Processed 1 memories', got: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Produced 1 skills") {
+		t.Errorf("expected 'Produced 1 skills', got: %s", stdout.String())
+	}
+}
+
+func TestRunDream_SuccessfulLearn(t *testing.T) {
+	store := newTestStore()
+	store.reflections["memories/test/sess-1.json"] = "- observation"
+	mockLLM := &testLLM{
+		learnResponse: `=== SKILL: test ===
+---
+name: Test
+description: Test skill.
+---
+
+Content.`,
+	}
+
+	ctx := context.Background()
+	var stdout, stderr bytes.Buffer
+
+	err := runDream(ctx, &stdout, &stderr, store, nil, mockLLM, true, false, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Produced 1 skills") {
+		t.Errorf("expected 'Produced 1 skills', got: %s", stdout.String())
+	}
+}
+
+// testStore implements dream.Store with in-memory state.
+type testStore struct {
+	sessions    []storage.SessionEntry
+	data        map[string]*source.Session
+	skills      map[string]string
+	reflections map[string]string
+}
+
+func newTestStore() *testStore {
+	return &testStore{
+		data:        map[string]*source.Session{},
+		skills:      map[string]string{},
+		reflections: map[string]string{},
+	}
+}
+
+func (s *testStore) addSession(src, id string, messages []source.Message) {
+	key := fmt.Sprintf("memories/%s/%s.json", src, id)
+	s.sessions = append(s.sessions, storage.SessionEntry{
+		Source:       src,
+		SessionID:    id,
+		Key:          key,
+		LastModified: time.Now(),
+	})
+	s.data[src+"/"+id] = &source.Session{
+		Source:    src,
+		SessionID: id,
+		Messages:  messages,
+	}
+}
+
+func (s *testStore) ListSessions(_ context.Context) ([]storage.SessionEntry, error) {
+	return s.sessions, nil
+}
+func (s *testStore) GetSession(_ context.Context, src, id string) (*source.Session, error) {
+	sess, ok := s.data[src+"/"+id]
+	if !ok {
+		return nil, fmt.Errorf("session not found: %s/%s", src, id)
+	}
+	return sess, nil
+}
+func (s *testStore) ListReflections(_ context.Context) (map[string]time.Time, error) {
+	result := map[string]time.Time{}
+	for key := range s.reflections {
+		result[key] = time.Now()
+	}
+	return result, nil
+}
+func (s *testStore) GetReflection(_ context.Context, key string) (string, error) {
+	content, ok := s.reflections[key]
+	if !ok {
+		return "", fmt.Errorf("reflection not found: %s", key)
+	}
+	return content, nil
+}
+func (s *testStore) PutReflection(_ context.Context, key, content string) error {
+	s.reflections[key] = content
+	return nil
+}
+func (s *testStore) DeletePrefix(_ context.Context, prefix string) error {
+	if prefix == "dreams/reflections/" {
+		s.reflections = map[string]string{}
+	}
+	return nil
+}
+func (s *testStore) PutSkill(_ context.Context, name, content string) error {
+	s.skills[name] = content
+	return nil
+}
+func (s *testStore) SnapshotSkills(_ context.Context, _ string) error { return nil }
+
+// failingStore implements dream.Store where all operations return an error.
+type failingStore struct{ err error }
+
+func (s *failingStore) ListSessions(_ context.Context) ([]storage.SessionEntry, error) {
+	return nil, s.err
+}
+func (s *failingStore) GetSession(_ context.Context, _, _ string) (*source.Session, error) {
+	return nil, s.err
+}
+func (s *failingStore) ListReflections(_ context.Context) (map[string]time.Time, error) {
+	return nil, s.err
+}
+func (s *failingStore) GetReflection(_ context.Context, _ string) (string, error) {
+	return "", s.err
+}
+func (s *failingStore) PutReflection(_ context.Context, _, _ string) error { return s.err }
+func (s *failingStore) DeletePrefix(_ context.Context, _ string) error     { return s.err }
+func (s *failingStore) PutSkill(_ context.Context, _, _ string) error      { return s.err }
+func (s *failingStore) SnapshotSkills(_ context.Context, _ string) error   { return s.err }
+
+// testLLM implements dream.LLM for command-level tests.
+type testLLM struct {
+	reflectResponse string
+	learnResponse   string
+	err             error
+}
+
+func (m *testLLM) Converse(_ context.Context, system, _ string, _ ...llm.ConverseOption) (string, llm.Usage, error) {
+	if m.err != nil {
+		return "", llm.Usage{}, m.err
+	}
+	usage := llm.Usage{InputTokens: 100, OutputTokens: 50}
+	if strings.Contains(system, "distilling observations") {
+		return m.learnResponse, usage, nil
+	}
+	return m.reflectResponse, usage, nil
+}


### PR DESCRIPTION
## Summary
- Fix variable shadowing in `cmd/muse/dream.go` where `:=` inside `if/else` branches created block-scoped `err` variables that silently discarded errors from `dream.Run()` / `dream.LearnOnly()`, causing a nil pointer dereference on `result`
- Declare `learnLLM`, `reflectLLM`, and `result` before the `if/else` block and use `=` so errors propagate to the outer scope
- Add command-level tests for the dream cobra handler

Closes #23