### PR TITLE
Pass toolConfig on synthesis call to satisfy Bedrock validation

### DIFF
--- a/internal/bedrock/client.go
+++ b/internal/bedrock/client.go
@@ -216,12 +216,13 @@ func (c *Client) ConverseWithTools(ctx context.Context, system, user string, too
 			Content: toolResults,
 		})
 	}
-	// Synthesize: one final call without tools to produce the user-facing answer.
+	// Synthesize: one final call to produce the user-facing answer. We pass
+	// toolConfig so Bedrock accepts the toolUse/toolResult blocks in history.
 	messages = append(messages, types.Message{
 		Role:    types.ConversationRoleUser,
 		Content: []types.ContentBlock{&types.ContentBlockMemberText{Value: synthesisPrompt}},
 	})
-	text, usage, _, _, err := c.converseRaw(ctx, system, messages, nil, llm.ConverseOptions{})
+	text, usage, _, _, err := c.converseRaw(ctx, system, messages, toolConfig, llm.ConverseOptions{})
 	return text, totalUsage.Add(usage), err
 }
 


### PR DESCRIPTION
## Summary
- Fixes `ValidationException: The toolConfig field must be defined when using toolUse and toolResult content blocks`
- The synthesis call at the end of `ConverseWithTools` was passing `nil` for `toolConfig` while the message history contained `toolUse`/`toolResult` blocks from earlier tool-use rounds
- Now passes `toolConfig` through so Bedrock accepts the request