### PR TITLE
Fix MCP server returning protocol errors instead of tool result errors

### DIFF
--- a/e2e/dream_test.go
+++ b/e2e/dream_test.go
@@ -181,9 +181,9 @@ Keep commit messages plain text, no emojis.`,
 		t.Errorf("expected DeletePrefix(\"skills/\"), got %v", store.deleted)
 	}
 
-	// Verify LLM was called: 2 reflect + 1 learn = 3 calls
-	if len(llm.calls) != 3 {
-		t.Errorf("LLM calls = %d, want 3", len(llm.calls))
+	// Verify LLM was called: 2 sessions * 3 reflect steps (summarize + extract + refine) + 1 learn = 7 calls
+	if len(llm.calls) != 7 {
+		t.Errorf("LLM calls = %d, want 7", len(llm.calls))
 	}
 }
 
@@ -239,8 +239,9 @@ Content here.`,
 	if result.Remaining != 3 {
 		t.Errorf("Remaining = %d, want 3", result.Remaining)
 	}
-	if len(llm.calls) != 3 {
-		t.Errorf("LLM calls = %d, want 3 (2 reflect + 1 learn)", len(llm.calls))
+	// 2 sessions * 3 reflect steps + 1 learn = 7
+	if len(llm.calls) != 7 {
+		t.Errorf("LLM calls = %d, want 7 (2 sessions * 3 reflect steps + 1 learn)", len(llm.calls))
 	}
 }
 
@@ -297,9 +298,9 @@ Content here.`,
 	if len(store.reflections) != 4 {
 		t.Errorf("reflections after second run = %d, want 4", len(store.reflections))
 	}
-	// 2 reflect + 1 learn, and learn should have received all 4 reflections
-	if len(llm.calls) != 3 {
-		t.Errorf("second run LLM calls = %d, want 3", len(llm.calls))
+	// 2 sessions * 3 reflect steps + 1 learn = 7, and learn should have received all 4 reflections
+	if len(llm.calls) != 7 {
+		t.Errorf("second run LLM calls = %d, want 7", len(llm.calls))
 	}
 	// The learn call (last one) should contain all 4 observations joined by ---
 	learnInput := llm.calls[len(llm.calls)-1].user

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -28,11 +28,11 @@ func askHandler(m *muse.Muse) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		question, err := req.RequireString("question")
 		if err != nil {
-			return nil, err
+			return mcp.NewToolResultError(err.Error()), nil
 		}
 		answer, err := m.Ask(ctx, question)
 		if err != nil {
-			return nil, fmt.Errorf("failed to ask: %w", err)
+			return mcp.NewToolResultError(fmt.Sprintf("failed to ask: %v", err)), nil
 		}
 		return mcp.NewToolResultText(answer), nil
 	}

--- a/internal/muse/muse.go
+++ b/internal/muse/muse.go
@@ -67,10 +67,12 @@ func New(ctx context.Context, bucket string) (*Muse, error) {
 
 // NewForTest creates a Muse with caller-provided dependencies.
 func NewForTest(s3Client skill.S3API, bedrockClient *bedrock.Client, bucket string) *Muse {
+	catalog, _ := skill.LoadCatalog(context.Background(), s3Client, bucket)
 	return &Muse{
 		s3:      s3Client,
 		bedrock: bedrockClient,
 		bucket:  bucket,
+		catalog: catalog,
 	}
 }
 


### PR DESCRIPTION
## Summary
- **MCP ask handler returned protocol-level errors instead of tool result errors** — `(nil, err)` from a tool handler is a transport failure in MCP, causing clients to disconnect or show unhelpful errors. Now returns `CallToolResult` with `IsError: true` so clients handle failures gracefully.
- **`NewForTest` wasn't loading the skill catalog** from the mock S3 client, so `Ask()` always told the LLM "No skills are currently available."
- **Dream test call count expectations were stale** — updated to match the three-step reflect pipeline (summarize + extract + refine).