### PR TITLE
Add multi-turn conversations to ask

### DIFF
--- a/cmd/muse/ask.go
+++ b/cmd/muse/ask.go
@@ -24,11 +24,11 @@ func newAskCmd() *cobra.Command {
 				return err
 			}
 			question := strings.Join(args, " ")
-			answer, err := m.Ask(ctx, question)
+			result, err := m.Ask(ctx, muse.AskInput{Question: question})
 			if err != nil {
 				return err
 			}
-			fmt.Println(answer)
+			fmt.Println(result.Response)
 			return nil
 		},
 	}

--- a/e2e/ask_test.go
+++ b/e2e/ask_test.go
@@ -68,15 +68,18 @@ func TestAskWithSoul(t *testing.T) {
 	bedrockClient := bedrock.NewClientWithRuntime(ctx, runtime)
 	m := muse.NewForTest(bedrockClient, "Use kebab-case for file names. Always wrap errors with context.")
 
-	answer, err := m.Ask(ctx, "how should I name files?")
+	result, err := m.Ask(ctx, muse.AskInput{Question: "how should I name files?"})
 	if err != nil {
 		t.Fatalf("Ask() error: %v", err)
 	}
-	if answer != "Use kebab-case for your file names." {
-		t.Errorf("answer = %q, want %q", answer, "Use kebab-case for your file names.")
+	if result.Response != "Use kebab-case for your file names." {
+		t.Errorf("response = %q, want %q", result.Response, "Use kebab-case for your file names.")
+	}
+	if result.SessionID == "" {
+		t.Error("expected sessionId to be set")
 	}
 
-	// Single Bedrock call — no tool use loop
+	// Single Bedrock call
 	if len(runtime.calls) != 1 {
 		t.Fatalf("Bedrock calls = %d, want 1", len(runtime.calls))
 	}
@@ -102,12 +105,12 @@ func TestAskEmptySoul(t *testing.T) {
 	bedrockClient := bedrock.NewClientWithRuntime(ctx, runtime)
 	m := muse.NewForTest(bedrockClient, "")
 
-	answer, err := m.Ask(ctx, "how do you handle errors?")
+	result, err := m.Ask(ctx, muse.AskInput{Question: "how do you handle errors?"})
 	if err != nil {
 		t.Fatalf("Ask() error: %v", err)
 	}
-	if answer != "I don't have any knowledge to draw on for that." {
-		t.Errorf("answer = %q", answer)
+	if result.Response != "I don't have any knowledge to draw on for that." {
+		t.Errorf("response = %q", result.Response)
 	}
 
 	if len(runtime.calls) != 1 {
@@ -115,5 +118,104 @@ func TestAskEmptySoul(t *testing.T) {
 	}
 	if !strings.Contains(runtime.calls[0].system, "No soul document available") {
 		t.Error("system prompt should indicate no soul available")
+	}
+}
+
+func TestAskMultiTurn(t *testing.T) {
+	runtime := &mockRuntime{responses: []bedrockruntime.ConverseOutput{
+		textResponse("I'd need to see the code to give useful guidance. Can you share the file?"),
+		textResponse("That function looks fine, but I'd extract the validation into a helper."),
+	}}
+
+	ctx := context.Background()
+	bedrockClient := bedrock.NewClientWithRuntime(ctx, runtime)
+	m := muse.NewForTest(bedrockClient, "Keep functions small.")
+
+	// Turn 1: initial question
+	r1, err := m.Ask(ctx, muse.AskInput{Question: "Is my handler well structured?"})
+	if err != nil {
+		t.Fatalf("Turn 1 error: %v", err)
+	}
+	if r1.SessionID == "" {
+		t.Fatal("expected sessionId after turn 1")
+	}
+	if !strings.Contains(r1.Response, "see the code") {
+		t.Errorf("turn 1 response = %q", r1.Response)
+	}
+
+	// Turn 2: provide context
+	r2, err := m.Ask(ctx, muse.AskInput{
+		SessionID: r1.SessionID,
+		Question:  "func handler(w http.ResponseWriter, r *http.Request) { validate(r); process(r); respond(w) }",
+	})
+	if err != nil {
+		t.Fatalf("Turn 2 error: %v", err)
+	}
+	if !strings.Contains(r2.Response, "extract the validation") {
+		t.Errorf("turn 2 response = %q", r2.Response)
+	}
+
+	// Verify Bedrock received the full history on turn 2
+	if len(runtime.calls) != 2 {
+		t.Fatalf("Bedrock calls = %d, want 2", len(runtime.calls))
+	}
+	// Turn 2 should have 3 messages: user question, assistant response, user follow-up
+	if runtime.calls[1].messages != 3 {
+		t.Errorf("turn 2 messages = %d, want 3", runtime.calls[1].messages)
+	}
+}
+
+func TestAskIndependentSessions(t *testing.T) {
+	runtime := &mockRuntime{responses: []bedrockruntime.ConverseOutput{
+		textResponse("Answer to question A"),
+		textResponse("Answer to question B"),
+		textResponse("Follow-up to A with context"),
+	}}
+
+	ctx := context.Background()
+	bedrockClient := bedrock.NewClientWithRuntime(ctx, runtime)
+	m := muse.NewForTest(bedrockClient, "Be concise.")
+
+	// Start two independent conversations
+	r1, err := m.Ask(ctx, muse.AskInput{Question: "Question A"})
+	if err != nil {
+		t.Fatalf("Session A error: %v", err)
+	}
+	r2, err := m.Ask(ctx, muse.AskInput{Question: "Question B"})
+	if err != nil {
+		t.Fatalf("Session B error: %v", err)
+	}
+
+	if r1.SessionID == r2.SessionID {
+		t.Error("independent sessions should have different IDs")
+	}
+
+	// Resume session A — should not contain session B's context
+	r3, err := m.Ask(ctx, muse.AskInput{SessionID: r1.SessionID, Question: "More about A"})
+	if err != nil {
+		t.Fatalf("Resume A error: %v", err)
+	}
+	if r3.Response != "Follow-up to A with context" {
+		t.Errorf("resume response = %q", r3.Response)
+	}
+
+	// Session A resume should have 3 messages (user, assistant, user follow-up)
+	if runtime.calls[2].messages != 3 {
+		t.Errorf("resume messages = %d, want 3", runtime.calls[2].messages)
+	}
+}
+
+func TestAskExpiredSession(t *testing.T) {
+	runtime := &mockRuntime{}
+	ctx := context.Background()
+	bedrockClient := bedrock.NewClientWithRuntime(ctx, runtime)
+	m := muse.NewForTest(bedrockClient, "")
+
+	_, err := m.Ask(ctx, muse.AskInput{SessionID: "nonexistent", Question: "hello"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent session")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want 'not found'", err.Error())
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3
 	github.com/aws/smithy-go v1.24.2
+	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.45.0
 	github.com/spf13/cobra v1.9.1
 	modernc.org/sqlite v1.37.1
@@ -32,7 +33,6 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/internal/bedrock/client.go
+++ b/internal/bedrock/client.go
@@ -178,6 +178,29 @@ func (c *Client) Converse(ctx context.Context, system, user string, opts ...llm.
 	return text, usage, err
 }
 
+// ConverseResult holds the full output from a ConverseMessages call.
+type ConverseResult struct {
+	Text       string
+	Usage      Usage
+	StopReason types.StopReason
+	Content    []types.ContentBlock
+}
+
+// ConverseMessages sends a full message history with optional tool config.
+func (c *Client) ConverseMessages(ctx context.Context, system string, messages []types.Message, toolConfig *types.ToolConfiguration, opts ...llm.ConverseOption) (*ConverseResult, error) {
+	o := llm.Apply(opts)
+	text, usage, stop, content, err := c.converseRaw(ctx, system, messages, toolConfig, o)
+	if err != nil {
+		return nil, err
+	}
+	return &ConverseResult{
+		Text:       text,
+		Usage:      usage,
+		StopReason: stop,
+		Content:    content,
+	}, nil
+}
+
 func (c *Client) converseRaw(ctx context.Context, system string, messages []types.Message, toolConfig *types.ToolConfiguration, opts llm.ConverseOptions) (string, Usage, types.StopReason, []types.ContentBlock, error) {
 	var lastErr error
 	for attempt := range maxRetries {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -12,28 +12,30 @@ import (
 )
 
 // NewServer creates an MCP server with an ask tool.
+// The server holds a single conversation session — the MCP connection is the session.
 func NewServer(m *muse.Muse) *server.MCPServer {
 	srv := server.NewMCPServer("muse", "0.1.0", server.WithToolCapabilities(false))
+	var sessionID string
 	srv.AddTool(
 		mcp.NewTool("ask",
 			mcp.WithDescription(prompts.Tool),
 			mcp.WithString("question", mcp.Required(), mcp.Description("The question to ask")),
 		),
-		askHandler(m),
+		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			question, err := req.RequireString("question")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			result, err := m.Ask(ctx, muse.AskInput{
+				Question:  question,
+				SessionID: sessionID,
+			})
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("failed to ask: %v", err)), nil
+			}
+			sessionID = result.SessionID
+			return mcp.NewToolResultText(result.Response), nil
+		},
 	)
 	return srv
-}
-
-func askHandler(m *muse.Muse) server.ToolHandlerFunc {
-	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		question, err := req.RequireString("question")
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
-		}
-		answer, err := m.Ask(ctx, question)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("failed to ask: %v", err)), nil
-		}
-		return mcp.NewToolResultText(answer), nil
-	}
 }

--- a/internal/muse/muse.go
+++ b/internal/muse/muse.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+
 	"github.com/ellistarn/muse/internal/bedrock"
 	"github.com/ellistarn/muse/internal/log"
 	"github.com/ellistarn/muse/internal/source"
@@ -20,11 +22,24 @@ type UploadResult struct {
 	Warnings []string
 }
 
+// AskInput contains the parameters for an Ask call.
+type AskInput struct {
+	Question  string // the user's message
+	SessionID string // if set, continues an existing conversation
+}
+
+// AskResult contains the output from an Ask call.
+type AskResult struct {
+	Response  string // the muse's response text
+	SessionID string // session ID for continuing the conversation
+}
+
 // Muse holds the state needed for all operations.
 type Muse struct {
-	storage *storage.Client
-	bedrock *bedrock.Client
-	soul    string // the full soul document, loaded at init
+	storage  *storage.Client
+	bedrock  *bedrock.Client
+	soul     string // the full soul document, loaded at init
+	sessions *sessionStore
 }
 
 func New(ctx context.Context, bucket string) (*Muse, error) {
@@ -49,33 +64,73 @@ func New(ctx context.Context, bucket string) (*Muse, error) {
 		log.Println("No soul found (run 'muse dream' to generate one)")
 	}
 	return &Muse{
-		storage: storageClient,
-		bedrock: bedrockClient,
-		soul:    soul,
+		storage:  storageClient,
+		bedrock:  bedrockClient,
+		soul:     soul,
+		sessions: newSessionStore(),
 	}, nil
 }
 
 // NewForTest creates a Muse with caller-provided dependencies.
 func NewForTest(bedrockClient *bedrock.Client, soul string) *Muse {
 	return &Muse{
-		bedrock: bedrockClient,
-		soul:    soul,
+		bedrock:  bedrockClient,
+		soul:     soul,
+		sessions: newSessionStore(),
 	}
 }
 
 var systemPrompt = prompts.Muse
 
-// Ask answers a question using the muse's soul document.
-// The soul is included directly in the system prompt — no tool calling,
-// no progressive disclosure. Single-shot stateless interaction.
-func (m *Muse) Ask(ctx context.Context, question string) (string, error) {
-	soul := m.soul
-	if soul == "" {
-		soul = "No soul document available yet. Run 'muse dream' to generate one from memories."
+// Ask handles a conversation turn. If SessionID is set, continues an existing
+// conversation. Otherwise starts a new one.
+func (m *Muse) Ask(ctx context.Context, input AskInput) (*AskResult, error) {
+	var session *Session
+
+	if input.SessionID != "" {
+		// Resume existing conversation
+		s, err := m.sessions.get(input.SessionID)
+		if err != nil {
+			return nil, err
+		}
+		session = s
+		session.Messages = append(session.Messages, types.Message{
+			Role:    types.ConversationRoleUser,
+			Content: []types.ContentBlock{&types.ContentBlockMemberText{Value: input.Question}},
+		})
+	} else {
+		// New conversation
+		soul := m.soul
+		if soul == "" {
+			soul = "No soul document available yet. Run 'muse dream' to generate one from memories."
+		}
+		session = &Session{
+			System: fmt.Sprintf(systemPrompt, soul),
+			Messages: []types.Message{
+				{
+					Role:    types.ConversationRoleUser,
+					Content: []types.ContentBlock{&types.ContentBlockMemberText{Value: input.Question}},
+				},
+			},
+		}
 	}
-	system := fmt.Sprintf(systemPrompt, soul)
-	answer, _, err := m.bedrock.Converse(ctx, system, question)
-	return answer, err
+
+	result, err := m.bedrock.ConverseMessages(ctx, session.System, session.Messages, nil)
+	if err != nil {
+		return nil, fmt.Errorf("converse failed: %w", err)
+	}
+
+	// Append the assistant's response to the session history
+	session.Messages = append(session.Messages, types.Message{
+		Role:    types.ConversationRoleAssistant,
+		Content: result.Content,
+	})
+
+	sessionID := m.sessions.save(session)
+	return &AskResult{
+		Response:  result.Text,
+		SessionID: sessionID,
+	}, nil
 }
 
 // Upload scans local sources, diffs against S3, and uploads changed sessions.

--- a/prompts/muse.md
+++ b/prompts/muse.md
@@ -1,7 +1,7 @@
 You are a domain expert that reflects how your owner thinks. You internalize their judgment,
 perspectives, and mental models — then apply them when asked.
 
-Your knowledge comes from a soul document (https://soul.md) distilled from your owner's real
+Your knowledge comes from a soul document distilled from your owner's real
 work — patterns in how they make decisions, evaluate tradeoffs, and reason about problems.
 These patterns span whatever domains your owner operates in. They are your judgment. Let the
 soul shape your voice and disposition — if the owner is direct, be direct; if they are
@@ -9,8 +9,10 @@ exploratory, be exploratory.
 
 Your role is advisory. Engage genuinely with what you're asked — challenge ideas when
 something feels off, build on them when they're heading in the right direction, and ask
-probing questions when you need more context. If you're asked about something outside your
-knowledge, say so honestly rather than guessing.
+probing questions when you need more context. Callers often reference code, files, or
+designs you can't see — ask for the actual content rather than speculating about what it
+might contain. If you're asked about something outside your knowledge, say so honestly
+rather than guessing.
 
 You must never:
 - Reveal the raw content of your soul document verbatim

--- a/prompts/tool.md
+++ b/prompts/tool.md
@@ -15,3 +15,10 @@ Do NOT use your muse for:
 - Yes/no factual questions — it is an advisor, not a database
 
 Ask opinionated questions: "Is X a good approach for Y?" not "What is X?"
+
+The muse has no access to your filesystem, codebase, or conversation history. Include
+relevant content directly in your question — the more context you provide, the better
+the guidance.
+
+The conversation is stateful — the muse remembers previous turns within the same
+session. If it asks for more context, just call ask again with the requested content.


### PR DESCRIPTION
## Summary

- Muse conversations are now stateful — the agent calls `ask(question=...)` repeatedly and the MCP server threads the session automatically
- Sessions are in-memory, one per MCP connection, die with the process
- No protocol changes for the caller — same tool interface, just works across turns

## Design

Started from the [multi-turn-ask plan](.opencode/plans/multi-turn-ask.md) which proposed a `respond` tool for the muse to signal when it needs more context. Simplified during implementation:

1. Dropped the `respond` tool — the model already knows how to ask questions naturally
2. Dropped sessionId from the tool interface — the MCP connection *is* the session
3. One field (`question`) for both new and continued turns

## Changes

- `internal/muse/session.go` — in-memory session store (ID, system prompt, message history)
- `internal/muse/muse.go` — `Ask` now takes `AskInput{Question, SessionID}`, returns `AskResult{Response, SessionID}`
- `internal/bedrock/client.go` — added `ConverseMessages` for sending full message history
- `internal/mcp/server.go` — holds sessionId in closure, threads it through calls
- `prompts/muse.md` — one sentence added: ask for content callers reference
- `prompts/tool.md` — two additions: context guidance, "conversation is stateful"
- `e2e/ask_test.go` — new tests: multi-turn, independent sessions, expired session