### PR TITLE
Fix Claude Code parser dropping assistant messages from tool-heavy sessions

### DIFF
--- a/internal/source/claudecode.go
+++ b/internal/source/claudecode.go
@@ -177,8 +177,8 @@ func parseClaudeSession(path, sessionID string, titles map[string]string) (*Sess
 		if err := json.Unmarshal(event.Message, &cm); err != nil {
 			continue
 		}
-		// For assistant messages, skip streaming partials.
-		if event.Type == "assistant" && (cm.StopReason == nil || *cm.StopReason != "end_turn") {
+		// For assistant messages, skip streaming partials (which have no stop reason).
+		if event.Type == "assistant" && cm.StopReason == nil {
 			continue
 		}
 		msg := Message{
@@ -192,6 +192,9 @@ func parseClaudeSession(path, sessionID string, titles map[string]string) (*Sess
 		}
 		// Parse content: string for user, array of blocks for assistant.
 		msg.Content, msg.ToolCalls = parseClaudeContent(cm.Content)
+		if msg.Content == "" && len(msg.ToolCalls) == 0 {
+			continue
+		}
 		session.Messages = append(session.Messages, msg)
 	}
 


### PR DESCRIPTION
## Summary
- Keep all completed assistant turns (not just `end_turn`) by filtering on `StopReason == nil` instead of `StopReason != "end_turn"`. This retains `tool_use` and `max_tokens` turns that were previously dropped.
- Filter empty-content messages (no text and no tool calls) to reduce noise, matching the Kiro parser pattern.

Fixes #29