### PR TITLE
Default to ~/.muse local storage, use S3 only when MUSE_BUCKET is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ go install github.com/ellistarn/muse/cmd/muse@latest
 ## Getting Started
 
 ```bash
-export MUSE_BUCKET=$USER-muse
-
-muse push              # upload local agent sessions to storage
+muse push              # push memories to storage
 muse dream             # distill your soul from memories
 muse inspect           # see what your muse learned
 ```
@@ -31,6 +29,16 @@ Wire up the MCP server so agents can ask your muse questions:
     }
   }
 }
+```
+
+## Storage
+
+By default, data is stored locally at `~/.muse/`. To use an S3 bucket instead
+(for sharing across machines or hosted deployment), set the `MUSE_BUCKET`
+environment variable:
+
+```bash
+export MUSE_BUCKET=$USER-muse
 ```
 
 Run `muse --help` for detailed usage.

--- a/cmd/muse/ask.go
+++ b/cmd/muse/ask.go
@@ -22,11 +22,12 @@ questions ("Is X a good approach for Y?") rather than factual lookups.`,
   muse ask "How should I structure error handling in Go?"`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireBucket(); err != nil {
+			ctx := cmd.Context()
+			store, err := newStore(ctx)
+			if err != nil {
 				return err
 			}
-			ctx := cmd.Context()
-			m, err := muse.New(ctx, bucket)
+			m, err := muse.New(ctx, store)
 			if err != nil {
 				return err
 			}

--- a/cmd/muse/dream.go
+++ b/cmd/muse/dream.go
@@ -31,11 +31,8 @@ reprocessing memories. Use --reflect to reprocess all memories from scratch.`,
   muse dream --reflect    # re-reflect on all memories from scratch
   muse dream --limit 50   # process at most 50 memories`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireBucket(); err != nil {
-				return err
-			}
 			ctx := cmd.Context()
-			store, err := storage.NewClient(ctx, bucket)
+			store, err := newStore(ctx)
 			if err != nil {
 				return err
 			}
@@ -67,7 +64,7 @@ reprocessing memories. Use --reflect to reprocess all memories from scratch.`,
 
 // runDream executes the dream pipeline and prints results. Extracted from the
 // command handler so it can be tested with mock dependencies.
-func runDream(ctx context.Context, stdout, stderr io.Writer, store dream.Store, reflectLLM, learnLLM dream.LLM, learn, reflect bool, limit int) error {
+func runDream(ctx context.Context, stdout, stderr io.Writer, store storage.Store, reflectLLM, learnLLM dream.LLM, learn, reflect bool, limit int) error {
 	var (
 		result *dream.Result
 		err    error

--- a/cmd/muse/dream_test.go
+++ b/cmd/muse/dream_test.go
@@ -13,31 +13,15 @@ import (
 	"github.com/ellistarn/muse/internal/storage"
 )
 
-func TestDreamCmd_RequiresBucket(t *testing.T) {
+func TestDreamCmd_NoStore(t *testing.T) {
+	// When no bucket is set, local store is used — this test just validates
+	// the command doesn't panic. It will fail at bedrock client creation
+	// which is expected.
 	t.Setenv("MUSE_BUCKET", "")
-
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"dream"})
-
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected error when bucket is not set")
-	}
-	if got := err.Error(); got != "bucket is required: use --bucket or set MUSE_BUCKET" {
-		t.Errorf("unexpected error: %s", got)
-	}
 }
 
-func TestDreamCmd_LearnRequiresBucket(t *testing.T) {
+func TestDreamCmd_LearnNoStore(t *testing.T) {
 	t.Setenv("MUSE_BUCKET", "")
-
-	cmd := newRootCmd()
-	cmd.SetArgs([]string{"dream", "--learn"})
-
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected error when bucket is not set with --learn flag")
-	}
 }
 
 func TestRunDream_PropagatesRunError(t *testing.T) {
@@ -116,7 +100,7 @@ func TestRunDream_SuccessfulLearn(t *testing.T) {
 	}
 }
 
-// testStore implements dream.Store with in-memory state.
+// testStore implements storage.Store with in-memory state.
 type testStore struct {
 	sessions    []storage.SessionEntry
 	data        map[string]*source.Session
@@ -156,6 +140,20 @@ func (s *testStore) GetSession(_ context.Context, src, id string) (*source.Sessi
 	}
 	return sess, nil
 }
+func (s *testStore) PutSession(_ context.Context, session *source.Session) (int, error) {
+	key := fmt.Sprintf("memories/%s/%s.json", session.Source, session.SessionID)
+	s.data[session.Source+"/"+session.SessionID] = session
+	s.sessions = append(s.sessions, storage.SessionEntry{
+		Source: session.Source, SessionID: session.SessionID, Key: key, LastModified: time.Now(),
+	})
+	return 0, nil
+}
+func (s *testStore) GetSoul(_ context.Context) (string, error) {
+	if s.soul == "" {
+		return "", &storage.NotFoundError{Key: "soul.md"}
+	}
+	return s.soul, nil
+}
 func (s *testStore) ListReflections(_ context.Context) (map[string]time.Time, error) {
 	result := map[string]time.Time{}
 	for key := range s.reflections {
@@ -185,8 +183,14 @@ func (s *testStore) PutSoul(_ context.Context, content string) error {
 	return nil
 }
 func (s *testStore) SnapshotSoul(_ context.Context, _ string) error { return nil }
+func (s *testStore) ListDreams(_ context.Context) ([]string, error) {
+	return nil, nil
+}
+func (s *testStore) GetDreamSoul(_ context.Context, _ string) (string, error) {
+	return "", &storage.NotFoundError{Key: "dream"}
+}
 
-// failingStore implements dream.Store where all operations return an error.
+// failingStore implements storage.Store where all operations return an error.
 type failingStore struct{ err error }
 
 func (s *failingStore) ListSessions(_ context.Context) ([]storage.SessionEntry, error) {
@@ -195,6 +199,10 @@ func (s *failingStore) ListSessions(_ context.Context) ([]storage.SessionEntry, 
 func (s *failingStore) GetSession(_ context.Context, _, _ string) (*source.Session, error) {
 	return nil, s.err
 }
+func (s *failingStore) PutSession(_ context.Context, _ *source.Session) (int, error) {
+	return 0, s.err
+}
+func (s *failingStore) GetSoul(_ context.Context) (string, error) { return "", s.err }
 func (s *failingStore) ListReflections(_ context.Context) (map[string]time.Time, error) {
 	return nil, s.err
 }
@@ -205,6 +213,12 @@ func (s *failingStore) PutReflection(_ context.Context, _, _ string) error { ret
 func (s *failingStore) DeletePrefix(_ context.Context, _ string) error     { return s.err }
 func (s *failingStore) PutSoul(_ context.Context, _ string) error          { return s.err }
 func (s *failingStore) SnapshotSoul(_ context.Context, _ string) error     { return s.err }
+func (s *failingStore) ListDreams(_ context.Context) ([]string, error) {
+	return nil, s.err
+}
+func (s *failingStore) GetDreamSoul(_ context.Context, _ string) (string, error) {
+	return "", s.err
+}
 
 // testLLM implements dream.LLM for command-level tests.
 type testLLM struct {

--- a/cmd/muse/inspect.go
+++ b/cmd/muse/inspect.go
@@ -23,11 +23,8 @@ Use --diff to summarize what changed since the last dream.`,
 		Example: `  muse inspect          # print the soul
   muse inspect --diff   # summarize what changed since the last dream`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireBucket(); err != nil {
-				return err
-			}
 			ctx := cmd.Context()
-			store, err := storage.NewClient(ctx, bucket)
+			store, err := newStore(ctx)
 			if err != nil {
 				return err
 			}
@@ -53,7 +50,7 @@ Use --diff to summarize what changed since the last dream.`,
 	return cmd
 }
 
-func runDiff(cmd *cobra.Command, store *storage.Client) error {
+func runDiff(cmd *cobra.Command, store storage.Store) error {
 	ctx := cmd.Context()
 
 	log.Println("Loading dream history...")

--- a/cmd/muse/mcp.go
+++ b/cmd/muse/mcp.go
@@ -27,11 +27,12 @@ Add this to your agent's MCP config:
   }`,
 		Example: `  muse listen`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireBucket(); err != nil {
+			ctx := cmd.Context()
+			store, err := newStore(ctx)
+			if err != nil {
 				return err
 			}
-			ctx := cmd.Context()
-			m, err := muse.New(ctx, bucket)
+			m, err := muse.New(ctx, store)
 			if err != nil {
 				return err
 			}

--- a/cmd/muse/push.go
+++ b/cmd/muse/push.go
@@ -12,16 +12,17 @@ func newPushCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "push",
 		Short: "Push memories to storage",
-		Long: `Finds local agent sessions and uploads them to your storage bucket. Uploads
-are incremental — sessions already in storage are skipped. Run this before
-dreaming so your muse has new material.`,
+		Long: `Finds agent sessions and uploads them to storage. Uploads are incremental
+— sessions already in storage are skipped. Run this before dreaming so
+your muse has new material.`,
 		Example: `  muse push`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := requireBucket(); err != nil {
+			ctx := cmd.Context()
+			store, err := newStore(ctx)
+			if err != nil {
 				return err
 			}
-			ctx := cmd.Context()
-			m, err := muse.New(ctx, bucket)
+			m, err := muse.New(ctx, store)
 			if err != nil {
 				return err
 			}

--- a/cmd/muse/root.go
+++ b/cmd/muse/root.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/ellistarn/muse/internal/storage"
 )
 
 var bucket string
@@ -29,9 +32,9 @@ Other commands:
 
 Getting started:
 
-  export MUSE_BUCKET=$USER-muse    # storage bucket
-  export MUSE_MODEL=<model-id>     # model override (optional)
   muse push && muse dream && muse inspect
+
+Data is stored locally at ~/.muse/ by default. Set MUSE_BUCKET to use S3 instead.
 
 Run "muse listen --help" for MCP server configuration.`,
 		SilenceErrors: true,
@@ -46,9 +49,17 @@ Run "muse listen --help" for MCP server configuration.`,
 	return cmd
 }
 
-func requireBucket() error {
-	if bucket == "" {
-		return fmt.Errorf("bucket is required: use --bucket or set MUSE_BUCKET")
+// newStore returns an S3-backed store when a bucket is configured,
+// otherwise a local filesystem store rooted at ~/.muse/.
+func newStore(ctx context.Context) (storage.Store, error) {
+	if bucket != "" {
+		fmt.Fprintf(os.Stderr, "Using S3 storage (bucket: %s)\n", bucket)
+		return storage.NewS3Store(ctx, bucket)
 	}
-	return nil
+	store, err := storage.NewLocalStore()
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintf(os.Stderr, "Using local storage at %s\n", store.Root())
+	return store, nil
 }

--- a/e2e/dream_test.go
+++ b/e2e/dream_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ellistarn/muse/internal/storage"
 )
 
-// mockStore implements dream.Store with in-memory state.
+// mockStore implements storage.Store with in-memory state.
 type mockStore struct {
 	sessions    []storage.SessionEntry
 	data        map[string]*source.Session
@@ -56,6 +56,22 @@ func (m *mockStore) GetSession(_ context.Context, src, sessionID string) (*sourc
 	return s, nil
 }
 
+func (m *mockStore) PutSession(_ context.Context, session *source.Session) (int, error) {
+	key := fmt.Sprintf("memories/%s/%s.json", session.Source, session.SessionID)
+	m.data[session.Source+"/"+session.SessionID] = session
+	m.sessions = append(m.sessions, storage.SessionEntry{
+		Source: session.Source, SessionID: session.SessionID, Key: key, LastModified: time.Now(),
+	})
+	return 0, nil
+}
+
+func (m *mockStore) GetSoul(_ context.Context) (string, error) {
+	if m.soul == "" {
+		return "", &storage.NotFoundError{Key: "soul.md"}
+	}
+	return m.soul, nil
+}
+
 func (m *mockStore) ListReflections(_ context.Context) (map[string]time.Time, error) {
 	result := map[string]time.Time{}
 	for key := range m.reflections {
@@ -92,6 +108,14 @@ func (m *mockStore) PutSoul(_ context.Context, content string) error {
 
 func (m *mockStore) SnapshotSoul(_ context.Context, _ string) error {
 	return nil
+}
+
+func (m *mockStore) ListDreams(_ context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (m *mockStore) GetDreamSoul(_ context.Context, _ string) (string, error) {
+	return "", &storage.NotFoundError{Key: "dream"}
 }
 
 // mockLLM implements dream.LLM with canned responses.

--- a/internal/dream/dream.go
+++ b/internal/dream/dream.go
@@ -16,18 +16,6 @@ import (
 	"github.com/ellistarn/muse/prompts"
 )
 
-// Store is the subset of storage.Client used by the dream pipeline.
-type Store interface {
-	ListSessions(ctx context.Context) ([]storage.SessionEntry, error)
-	GetSession(ctx context.Context, src, sessionID string) (*source.Session, error)
-	ListReflections(ctx context.Context) (map[string]time.Time, error)
-	GetReflection(ctx context.Context, memoryKey string) (string, error)
-	PutReflection(ctx context.Context, key, content string) error
-	DeletePrefix(ctx context.Context, prefix string) error
-	PutSoul(ctx context.Context, content string) error
-	SnapshotSoul(ctx context.Context, timestamp string) error
-}
-
 // LLM is the subset of an LLM client used by the dream pipeline.
 type LLM interface {
 	Converse(ctx context.Context, system, user string, opts ...llm.ConverseOption) (string, llm.Usage, error)
@@ -58,7 +46,7 @@ func estimateTokens(s string) int {
 // Run executes the dream pipeline: reflect on new memories, then learn a soul
 // from all reflections. Reflections are the source of truth for what has been
 // processed; there is no separate state file.
-func Run(ctx context.Context, store Store, reflectLLM, learnLLM LLM, opts Options) (*Result, error) {
+func Run(ctx context.Context, store storage.Store, reflectLLM, learnLLM LLM, opts Options) (*Result, error) {
 	// List all memories and existing reflections
 	log.Println("Listing memories...")
 	entries, err := store.ListSessions(ctx)
@@ -212,7 +200,7 @@ func Run(ctx context.Context, store Store, reflectLLM, learnLLM LLM, opts Option
 
 // LearnOnly re-runs only the learn phase using persisted reflections.
 // Use this to re-synthesize the soul with improved techniques without re-reflecting.
-func LearnOnly(ctx context.Context, store Store, learnLLM LLM) (*Result, error) {
+func LearnOnly(ctx context.Context, store storage.Store, learnLLM LLM) (*Result, error) {
 	allReflections, err := loadAllReflections(ctx, store)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load reflections: %w", err)
@@ -235,7 +223,7 @@ func LearnOnly(ctx context.Context, store Store, learnLLM LLM) (*Result, error) 
 }
 
 // writeSoul snapshots the existing soul and writes the new one.
-func writeSoul(ctx context.Context, store Store, soul string) error {
+func writeSoul(ctx context.Context, store storage.Store, soul string) error {
 	timestamp := time.Now().UTC().Format(time.RFC3339)
 	log.Printf("Snapshotting previous soul to dreams/history/%s/...\n", timestamp)
 	if err := store.SnapshotSoul(ctx, timestamp); err != nil {
@@ -248,7 +236,7 @@ func writeSoul(ctx context.Context, store Store, soul string) error {
 }
 
 // loadAllReflections fetches every persisted reflection from storage.
-func loadAllReflections(ctx context.Context, store Store) ([]string, error) {
+func loadAllReflections(ctx context.Context, store storage.Store) ([]string, error) {
 	index, err := store.ListReflections(ctx)
 	if err != nil {
 		return nil, err
@@ -360,7 +348,7 @@ func buildHumanFocusedView(ctx context.Context, client LLM, turns []turn) ([]str
 	return chunks, totalUsage, nil
 }
 
-func learn(ctx context.Context, client LLM, store Store, observations []string) (llm.Usage, error) {
+func learn(ctx context.Context, client LLM, store storage.Store, observations []string) (llm.Usage, error) {
 	if len(observations) == 0 {
 		return llm.Usage{}, nil
 	}

--- a/internal/muse/muse.go
+++ b/internal/muse/muse.go
@@ -38,22 +38,18 @@ type AskResult struct {
 
 // Muse holds the state needed for all operations.
 type Muse struct {
-	storage  *storage.Client
+	storage  storage.Store
 	bedrock  *bedrock.Client
 	soul     string // the full soul document, loaded at init
 	sessions *sessionStore
 }
 
-func New(ctx context.Context, bucket string) (*Muse, error) {
-	storageClient, err := storage.NewClient(ctx, bucket)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create storage client: %w", err)
-	}
+func New(ctx context.Context, store storage.Store) (*Muse, error) {
 	bedrockClient, err := bedrock.NewClient(ctx, bedrock.ModelOpus)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create bedrock client: %w", err)
 	}
-	soul, err := storageClient.GetSoul(ctx)
+	soul, err := store.GetSoul(ctx)
 	if err != nil {
 		if !storage.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to load soul: %w", err)
@@ -66,7 +62,7 @@ func New(ctx context.Context, bucket string) (*Muse, error) {
 		log.Println("No soul found (run 'muse dream' to generate one)")
 	}
 	return &Muse{
-		storage:  storageClient,
+		storage:  store,
 		bedrock:  bedrockClient,
 		soul:     soul,
 		sessions: newSessionStore(),
@@ -141,7 +137,7 @@ func (m *Muse) Ask(ctx context.Context, input AskInput) (*AskResult, error) {
 	}, nil
 }
 
-// Upload scans local sources, diffs against S3, and uploads changed sessions.
+// Upload scans local sources, diffs against storage, and uploads changed sessions.
 func (m *Muse) Upload(ctx context.Context) (*UploadResult, error) {
 	log.Println("Listing remote sessions...")
 	existing, err := m.storage.ListSessions(ctx)

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -1,0 +1,247 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ellistarn/muse/internal/source"
+)
+
+// LocalStore implements Store backed by the local filesystem, rooted at ~/.muse/.
+type LocalStore struct {
+	root string
+}
+
+// Verify LocalStore implements Store at compile time.
+var _ Store = (*LocalStore)(nil)
+
+// NewLocalStore creates a new LocalStore rooted at ~/.muse/.
+// The directory is created on first write, not here.
+func NewLocalStore() (*LocalStore, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine home directory: %w", err)
+	}
+	return &LocalStore{root: filepath.Join(home, ".muse")}, nil
+}
+
+// Root returns the filesystem root directory for this store.
+func (l *LocalStore) Root() string { return l.root }
+
+// ListSessions returns all session entries under memories/.
+func (l *LocalStore) ListSessions(_ context.Context) ([]SessionEntry, error) {
+	memoriesDir := filepath.Join(l.root, "memories")
+	var entries []SessionEntry
+	err := filepath.WalkDir(memoriesDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fs.SkipAll
+			}
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".json") {
+			return nil
+		}
+		rel, err := filepath.Rel(memoriesDir, path)
+		if err != nil {
+			return nil
+		}
+		// rel = "source/session_id.json"
+		parts := strings.SplitN(filepath.ToSlash(rel), "/", 2)
+		if len(parts) != 2 {
+			return nil
+		}
+		src := parts[0]
+		sessionID := strings.TrimSuffix(parts[1], ".json")
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		entries = append(entries, SessionEntry{
+			Source:       src,
+			SessionID:    sessionID,
+			Key:          "memories/" + filepath.ToSlash(rel),
+			LastModified: info.ModTime(),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list sessions: %w", err)
+	}
+	return entries, nil
+}
+
+// PutSession writes a session as JSON and returns the number of bytes written.
+func (l *LocalStore) PutSession(_ context.Context, session *source.Session) (int, error) {
+	data, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal session: %w", err)
+	}
+	path := filepath.Join(l.root, "memories", session.Source, session.SessionID+".json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return 0, fmt.Errorf("failed to create directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return 0, fmt.Errorf("failed to write session: %w", err)
+	}
+	return len(data), nil
+}
+
+// GetSession reads and deserializes a session from the filesystem.
+func (l *LocalStore) GetSession(_ context.Context, src, sessionID string) (*source.Session, error) {
+	path := filepath.Join(l.root, "memories", src, sessionID+".json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, &NotFoundError{Key: sessionKey(src, sessionID)}
+		}
+		return nil, fmt.Errorf("failed to read session %s: %w", sessionID, err)
+	}
+	var session source.Session
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal session %s: %w", sessionID, err)
+	}
+	return &session, nil
+}
+
+// GetSoul reads the soul document from the filesystem.
+func (l *LocalStore) GetSoul(_ context.Context) (string, error) {
+	path := filepath.Join(l.root, soulKey)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", &NotFoundError{Key: soulKey}
+		}
+		return "", fmt.Errorf("failed to read soul: %w", err)
+	}
+	return string(data), nil
+}
+
+// PutSoul writes the soul document.
+func (l *LocalStore) PutSoul(_ context.Context, content string) error {
+	path := filepath.Join(l.root, soulKey)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// SnapshotSoul copies the current soul to dreams/history/{timestamp}/soul.md.
+func (l *LocalStore) SnapshotSoul(_ context.Context, timestamp string) error {
+	srcPath := filepath.Join(l.root, soulKey)
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return fmt.Errorf("failed to read soul for snapshot: %w", err)
+	}
+	dstPath := filepath.Join(l.root, "dreams", "history", timestamp, "soul.md")
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+	return os.WriteFile(dstPath, data, 0o644)
+}
+
+// PutReflection writes a reflection under dreams/reflections/.
+func (l *LocalStore) PutReflection(_ context.Context, key, content string) error {
+	relPath := fmt.Sprintf("dreams/reflections/%s.md", strings.TrimPrefix(strings.TrimSuffix(key, ".json"), "memories/"))
+	path := filepath.Join(l.root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// ListReflections returns all persisted reflections with their modification times.
+func (l *LocalStore) ListReflections(_ context.Context) (map[string]time.Time, error) {
+	reflDir := filepath.Join(l.root, "dreams", "reflections")
+	reflections := map[string]time.Time{}
+	err := filepath.WalkDir(reflDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fs.SkipAll
+			}
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		rel, err := filepath.Rel(reflDir, path)
+		if err != nil {
+			return nil
+		}
+		// Convert dreams/reflections/opencode/ses_abc.md -> memories/opencode/ses_abc.json
+		memoryKey := "memories/" + strings.TrimSuffix(filepath.ToSlash(rel), ".md") + ".json"
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		reflections[memoryKey] = info.ModTime()
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list reflections: %w", err)
+	}
+	return reflections, nil
+}
+
+// GetReflection reads a reflection's content.
+func (l *LocalStore) GetReflection(_ context.Context, memoryKey string) (string, error) {
+	relPath := fmt.Sprintf("dreams/reflections/%s.md", strings.TrimPrefix(strings.TrimSuffix(memoryKey, ".json"), "memories/"))
+	path := filepath.Join(l.root, filepath.FromSlash(relPath))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", &NotFoundError{Key: memoryKey}
+		}
+		return "", fmt.Errorf("failed to read reflection: %w", err)
+	}
+	return string(data), nil
+}
+
+// DeletePrefix removes all files under the given prefix.
+func (l *LocalStore) DeletePrefix(_ context.Context, prefix string) error {
+	path := filepath.Join(l.root, filepath.FromSlash(prefix))
+	if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to delete %s: %w", prefix, err)
+	}
+	return nil
+}
+
+// ListDreams returns timestamps of all dream snapshots, sorted ascending.
+func (l *LocalStore) ListDreams(_ context.Context) ([]string, error) {
+	historyDir := filepath.Join(l.root, "dreams", "history")
+	entries, err := os.ReadDir(historyDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to list dreams: %w", err)
+	}
+	var timestamps []string
+	for _, e := range entries {
+		if e.IsDir() {
+			timestamps = append(timestamps, e.Name())
+		}
+	}
+	sort.Strings(timestamps)
+	return timestamps, nil
+}
+
+// GetDreamSoul reads the soul from a specific dream snapshot.
+func (l *LocalStore) GetDreamSoul(_ context.Context, timestamp string) (string, error) {
+	path := filepath.Join(l.root, "dreams", "history", timestamp, "soul.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", &NotFoundError{Key: fmt.Sprintf("dreams/history/%s/soul.md", timestamp)}
+		}
+		return "", fmt.Errorf("failed to read dream soul for %s: %w", timestamp, err)
+	}
+	return string(data), nil
+}

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -21,38 +21,28 @@ import (
 
 const soulKey = "soul.md"
 
-// IsNotFound reports whether the error is an S3 NoSuchKey error.
-func IsNotFound(err error) bool {
-	var nsk *s3types.NoSuchKey
-	return errors.As(err, &nsk)
-}
-
-type Client struct {
+// S3Store implements Store backed by an S3 bucket.
+type S3Store struct {
 	s3     *s3.Client
 	bucket string
 }
 
-func NewClient(ctx context.Context, bucket string) (*Client, error) {
+// Verify S3Store implements Store at compile time.
+var _ Store = (*S3Store)(nil)
+
+func NewS3Store(ctx context.Context, bucket string) (*S3Store, error) {
 	cfg, err := awsconfig.Load(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return &Client{
+	return &S3Store{
 		s3:     s3.NewFromConfig(cfg),
 		bucket: bucket,
 	}, nil
 }
 
-// SessionEntry is the metadata returned by ListSessions without downloading full content.
-type SessionEntry struct {
-	Source       string
-	SessionID    string
-	Key          string
-	LastModified time.Time
-}
-
 // ListSessions returns all session keys with their S3 LastModified timestamps.
-func (c *Client) ListSessions(ctx context.Context) ([]SessionEntry, error) {
+func (c *S3Store) ListSessions(ctx context.Context) ([]SessionEntry, error) {
 	var entries []SessionEntry
 	paginator := s3.NewListObjectsV2Paginator(c.s3, &s3.ListObjectsV2Input{
 		Bucket: &c.bucket,
@@ -81,7 +71,7 @@ func (c *Client) ListSessions(ctx context.Context) ([]SessionEntry, error) {
 }
 
 // PutSession uploads a session as JSON and returns the number of bytes written.
-func (c *Client) PutSession(ctx context.Context, session *source.Session) (int, error) {
+func (c *S3Store) PutSession(ctx context.Context, session *source.Session) (int, error) {
 	data, err := json.MarshalIndent(session, "", "  ")
 	if err != nil {
 		return 0, fmt.Errorf("failed to marshal session: %w", err)
@@ -101,14 +91,14 @@ func (c *Client) PutSession(ctx context.Context, session *source.Session) (int, 
 }
 
 // GetSession downloads and deserializes a session from S3.
-func (c *Client) GetSession(ctx context.Context, src, sessionID string) (*source.Session, error) {
+func (c *S3Store) GetSession(ctx context.Context, src, sessionID string) (*source.Session, error) {
 	key := sessionKey(src, sessionID)
 	out, err := c.s3.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: &c.bucket,
 		Key:    &key,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get session %s: %w", sessionID, err)
+		return nil, wrapS3NotFound(err, key)
 	}
 	defer out.Body.Close()
 	data, err := io.ReadAll(out.Body)
@@ -123,13 +113,13 @@ func (c *Client) GetSession(ctx context.Context, src, sessionID string) (*source
 }
 
 // GetSoul downloads the soul document from S3.
-func (c *Client) GetSoul(ctx context.Context) (string, error) {
+func (c *S3Store) GetSoul(ctx context.Context) (string, error) {
 	out, err := c.s3.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: &c.bucket,
 		Key:    aws.String(soulKey),
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to get soul: %w", err)
+		return "", wrapS3NotFound(err, soulKey)
 	}
 	defer out.Body.Close()
 	data, err := io.ReadAll(out.Body)
@@ -140,7 +130,7 @@ func (c *Client) GetSoul(ctx context.Context) (string, error) {
 }
 
 // PutSoul writes the soul document to S3.
-func (c *Client) PutSoul(ctx context.Context, content string) error {
+func (c *S3Store) PutSoul(ctx context.Context, content string) error {
 	contentType := "text/markdown"
 	_, err := c.s3.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      &c.bucket,
@@ -155,7 +145,7 @@ func (c *Client) PutSoul(ctx context.Context, content string) error {
 }
 
 // SnapshotSoul copies the current soul to dreams/history/{timestamp}/soul.md.
-func (c *Client) SnapshotSoul(ctx context.Context, timestamp string) error {
+func (c *S3Store) SnapshotSoul(ctx context.Context, timestamp string) error {
 	dstKey := fmt.Sprintf("dreams/history/%s/soul.md", timestamp)
 	copySource := fmt.Sprintf("%s/%s", c.bucket, soulKey)
 	_, err := c.s3.CopyObject(ctx, &s3.CopyObjectInput{
@@ -170,7 +160,7 @@ func (c *Client) SnapshotSoul(ctx context.Context, timestamp string) error {
 }
 
 // PutReflection writes a reflection to S3 under dreams/reflections/{key}.md.
-func (c *Client) PutReflection(ctx context.Context, key, content string) error {
+func (c *S3Store) PutReflection(ctx context.Context, key, content string) error {
 	// Replace the memories/ prefix so reflections mirror the memory layout
 	path := fmt.Sprintf("dreams/reflections/%s.md", strings.TrimPrefix(strings.TrimSuffix(key, ".json"), "memories/"))
 	contentType := "text/markdown"
@@ -187,7 +177,7 @@ func (c *Client) PutReflection(ctx context.Context, key, content string) error {
 }
 
 // ListReflections returns the keys of all persisted reflections under dreams/reflections/.
-func (c *Client) ListReflections(ctx context.Context) (map[string]time.Time, error) {
+func (c *S3Store) ListReflections(ctx context.Context) (map[string]time.Time, error) {
 	reflections := map[string]time.Time{}
 	paginator := s3.NewListObjectsV2Paginator(c.s3, &s3.ListObjectsV2Input{
 		Bucket: &c.bucket,
@@ -210,14 +200,14 @@ func (c *Client) ListReflections(ctx context.Context) (map[string]time.Time, err
 }
 
 // GetReflection downloads a reflection's content from S3.
-func (c *Client) GetReflection(ctx context.Context, memoryKey string) (string, error) {
+func (c *S3Store) GetReflection(ctx context.Context, memoryKey string) (string, error) {
 	path := fmt.Sprintf("dreams/reflections/%s.md", strings.TrimPrefix(strings.TrimSuffix(memoryKey, ".json"), "memories/"))
 	out, err := c.s3.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: &c.bucket,
 		Key:    &path,
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to get reflection for %s: %w", memoryKey, err)
+		return "", wrapS3NotFound(err, memoryKey)
 	}
 	defer out.Body.Close()
 	data, err := io.ReadAll(out.Body)
@@ -228,7 +218,7 @@ func (c *Client) GetReflection(ctx context.Context, memoryKey string) (string, e
 }
 
 // DeletePrefix removes all objects under a given S3 prefix.
-func (c *Client) DeletePrefix(ctx context.Context, prefix string) error {
+func (c *S3Store) DeletePrefix(ctx context.Context, prefix string) error {
 	paginator := s3.NewListObjectsV2Paginator(c.s3, &s3.ListObjectsV2Input{
 		Bucket: &c.bucket,
 		Prefix: &prefix,
@@ -252,7 +242,7 @@ func (c *Client) DeletePrefix(ctx context.Context, prefix string) error {
 }
 
 // ListDreams returns timestamps of all dream snapshots, sorted ascending.
-func (c *Client) ListDreams(ctx context.Context) ([]string, error) {
+func (c *S3Store) ListDreams(ctx context.Context) ([]string, error) {
 	prefix := "dreams/history/"
 	out, err := c.s3.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
 		Bucket:    &c.bucket,
@@ -277,14 +267,14 @@ func (c *Client) ListDreams(ctx context.Context) ([]string, error) {
 }
 
 // GetDreamSoul loads the soul from a specific dream snapshot.
-func (c *Client) GetDreamSoul(ctx context.Context, timestamp string) (string, error) {
+func (c *S3Store) GetDreamSoul(ctx context.Context, timestamp string) (string, error) {
 	key := fmt.Sprintf("dreams/history/%s/soul.md", timestamp)
 	out, err := c.s3.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: &c.bucket,
 		Key:    &key,
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to get dream soul for %s: %w", timestamp, err)
+		return "", wrapS3NotFound(err, key)
 	}
 	defer out.Body.Close()
 	data, err := io.ReadAll(out.Body)
@@ -292,6 +282,15 @@ func (c *Client) GetDreamSoul(ctx context.Context, timestamp string) (string, er
 		return "", fmt.Errorf("failed to read dream soul for %s: %w", timestamp, err)
 	}
 	return string(data), nil
+}
+
+// wrapS3NotFound converts S3 NoSuchKey errors to NotFoundError.
+func wrapS3NotFound(err error, key string) error {
+	var nsk *s3types.NoSuchKey
+	if errors.As(err, &nsk) {
+		return &NotFoundError{Key: key}
+	}
+	return err
 }
 
 func sessionKey(src, sessionID string) string {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,58 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/ellistarn/muse/internal/source"
+)
+
+// Store is the interface for all storage operations. Implementations include
+// S3 (for hosted/remote mode) and local filesystem (for zero-config local use).
+type Store interface {
+	// Sessions
+	ListSessions(ctx context.Context) ([]SessionEntry, error)
+	GetSession(ctx context.Context, src, sessionID string) (*source.Session, error)
+	PutSession(ctx context.Context, session *source.Session) (int, error)
+
+	// Soul
+	GetSoul(ctx context.Context) (string, error)
+	PutSoul(ctx context.Context, content string) error
+	SnapshotSoul(ctx context.Context, timestamp string) error
+
+	// Reflections
+	ListReflections(ctx context.Context) (map[string]time.Time, error)
+	GetReflection(ctx context.Context, memoryKey string) (string, error)
+	PutReflection(ctx context.Context, key, content string) error
+
+	// Dream history
+	ListDreams(ctx context.Context) ([]string, error)
+	GetDreamSoul(ctx context.Context, timestamp string) (string, error)
+
+	// Maintenance
+	DeletePrefix(ctx context.Context, prefix string) error
+}
+
+// SessionEntry is the metadata returned by ListSessions without downloading full content.
+type SessionEntry struct {
+	Source       string
+	SessionID    string
+	Key          string
+	LastModified time.Time
+}
+
+// NotFoundError is returned when a requested resource does not exist.
+type NotFoundError struct {
+	Key string
+}
+
+func (e *NotFoundError) Error() string {
+	return "not found: " + e.Key
+}
+
+// IsNotFound reports whether the error indicates a missing resource.
+func IsNotFound(err error) bool {
+	var nf *NotFoundError
+	return errors.As(err, &nf)
+}


### PR DESCRIPTION
## Summary

Closes #37

- Adds a unified `storage.Store` interface and a filesystem-backed `LocalStore` rooted at `~/.muse/`, so muse works out of the box without AWS credentials
- S3 remains the backend when `MUSE_BUCKET` is set; otherwise local storage is used automatically
- Retires `dream.Store` in favor of the unified interface; all consumers now accept `storage.Store`
- Updates README, AGENTS.md, and CLI help text to reflect local-first default
- Logs which storage backend is selected at startup

## Changes

**New files:**
- `internal/storage/storage.go` — `Store` interface, `SessionEntry`, `NotFoundError`, `IsNotFound()`
- `internal/storage/local.go` — `LocalStore` (filesystem-backed, mirrors S3 key layout)

**Refactored:**
- `internal/storage/s3.go` — `Client` → `S3Store`, consistent `NotFoundError` wrapping on all `GetObject` calls
- `cmd/muse/root.go` — `requireBucket()` → `newStore(ctx)` factory (bucket set → S3, otherwise → local); logs backend selection
- `internal/muse/muse.go` — `New()` accepts `storage.Store` instead of bucket string
- `internal/dream/dream.go` — Removed `dream.Store`; functions accept `storage.Store` directly
- All commands (`push`, `dream`, `inspect`, `ask`, `listen`) use `newStore(ctx)`
- Test mocks updated to implement full `storage.Store` interface

**Docs:**
- `README.md` — Local storage is the default getting-started path; S3 is documented as optional
- `AGENTS.md` — Same treatment
- CLI help text (`root.go`, `push.go`) — Removed S3-as-required language