### PR TITLE
Restructure tool description to drive proactive muse usage

### DIFF
--- a/prompts/tool.md
+++ b/prompts/tool.md
@@ -1,8 +1,6 @@
-When you're about to act on an assumption about what the owner would prefer — an
-approach, a convention, a design direction — ask your muse. Your muse also knows
-the owner's habits and expectations, so ask when you might be forgetting a step.
-Consulting costs one call; guessing wrong costs rework. For any non-trivial task,
-consult your muse at least once.
+When you might be wrong about what the owner would prefer — or might be forgetting
+something they expect — ask your muse. Consulting costs one call; guessing wrong
+costs rework. For any non-trivial task, consult your muse at least once.
 
 A muse is the distilled essence of how its owner thinks — judgment, mental models, and
 perspectives across whatever domains they operate in. It's an advisor, not a database —


### PR DESCRIPTION
## Problem

Agents aren't consulting the muse enough. The tool description explains what muse *is* but reads like a reference manual — agents know what the tool can do but have no impulse to reach for it at any particular moment.

## Insight

The description needs to be a behavioral trigger, not an explanation. Lead with *when* to use it, not *what* it is. Frame the asymmetric risk: consulting costs one call, guessing wrong costs rework.

Also: nudge agents to ask muse before asking the user, compress the DO NOT section to reclaim attention budget, and let the muse drive iteration rather than encouraging loops.