### PR TITLE
Rename internal/source to internal/memory

### DIFF
--- a/cmd/muse/dream_test.go
+++ b/cmd/muse/dream_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/ellistarn/muse/internal/llm"
-	"github.com/ellistarn/muse/internal/source"
+	"github.com/ellistarn/muse/internal/memory"
 	"github.com/ellistarn/muse/internal/storage"
 )
 
@@ -55,7 +55,7 @@ func TestRunDream_PropagatesLearnError(t *testing.T) {
 
 func TestRunDream_SuccessfulRun(t *testing.T) {
 	store := newTestStore()
-	store.addSession("test", "sess-1", []source.Message{
+	store.addSession("test", "sess-1", []memory.Message{
 		{Role: "user", Content: "use tabs"},
 		{Role: "assistant", Content: "ok"},
 		{Role: "user", Content: "also no emojis"},
@@ -103,19 +103,19 @@ func TestRunDream_SuccessfulLearn(t *testing.T) {
 // testStore implements storage.Store with in-memory state.
 type testStore struct {
 	sessions    []storage.SessionEntry
-	data        map[string]*source.Session
+	data        map[string]*memory.Session
 	soul        string
 	reflections map[string]string
 }
 
 func newTestStore() *testStore {
 	return &testStore{
-		data:        map[string]*source.Session{},
+		data:        map[string]*memory.Session{},
 		reflections: map[string]string{},
 	}
 }
 
-func (s *testStore) addSession(src, id string, messages []source.Message) {
+func (s *testStore) addSession(src, id string, messages []memory.Message) {
 	key := fmt.Sprintf("memories/%s/%s.json", src, id)
 	s.sessions = append(s.sessions, storage.SessionEntry{
 		Source:       src,
@@ -123,7 +123,7 @@ func (s *testStore) addSession(src, id string, messages []source.Message) {
 		Key:          key,
 		LastModified: time.Now(),
 	})
-	s.data[src+"/"+id] = &source.Session{
+	s.data[src+"/"+id] = &memory.Session{
 		Source:    src,
 		SessionID: id,
 		Messages:  messages,
@@ -133,14 +133,14 @@ func (s *testStore) addSession(src, id string, messages []source.Message) {
 func (s *testStore) ListSessions(_ context.Context) ([]storage.SessionEntry, error) {
 	return s.sessions, nil
 }
-func (s *testStore) GetSession(_ context.Context, src, id string) (*source.Session, error) {
+func (s *testStore) GetSession(_ context.Context, src, id string) (*memory.Session, error) {
 	sess, ok := s.data[src+"/"+id]
 	if !ok {
 		return nil, fmt.Errorf("session not found: %s/%s", src, id)
 	}
 	return sess, nil
 }
-func (s *testStore) PutSession(_ context.Context, session *source.Session) (int, error) {
+func (s *testStore) PutSession(_ context.Context, session *memory.Session) (int, error) {
 	key := fmt.Sprintf("memories/%s/%s.json", session.Source, session.SessionID)
 	s.data[session.Source+"/"+session.SessionID] = session
 	s.sessions = append(s.sessions, storage.SessionEntry{
@@ -196,10 +196,10 @@ type failingStore struct{ err error }
 func (s *failingStore) ListSessions(_ context.Context) ([]storage.SessionEntry, error) {
 	return nil, s.err
 }
-func (s *failingStore) GetSession(_ context.Context, _, _ string) (*source.Session, error) {
+func (s *failingStore) GetSession(_ context.Context, _, _ string) (*memory.Session, error) {
 	return nil, s.err
 }
-func (s *failingStore) PutSession(_ context.Context, _ *source.Session) (int, error) {
+func (s *failingStore) PutSession(_ context.Context, _ *memory.Session) (int, error) {
 	return 0, s.err
 }
 func (s *failingStore) GetSoul(_ context.Context) (string, error) { return "", s.err }

--- a/e2e/dream_test.go
+++ b/e2e/dream_test.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/ellistarn/muse/internal/dream"
 	"github.com/ellistarn/muse/internal/llm"
-	"github.com/ellistarn/muse/internal/source"
+	"github.com/ellistarn/muse/internal/memory"
 	"github.com/ellistarn/muse/internal/storage"
 )
 
 // mockStore implements storage.Store with in-memory state.
 type mockStore struct {
 	sessions    []storage.SessionEntry
-	data        map[string]*source.Session
+	data        map[string]*memory.Session
 	soul        string
 	reflections map[string]string // memoryKey -> content
 	deleted     []string
@@ -24,12 +24,12 @@ type mockStore struct {
 
 func newMockStore() *mockStore {
 	return &mockStore{
-		data:        map[string]*source.Session{},
+		data:        map[string]*memory.Session{},
 		reflections: map[string]string{},
 	}
 }
 
-func (m *mockStore) addSession(src, id string, modified time.Time, messages []source.Message) {
+func (m *mockStore) addSession(src, id string, modified time.Time, messages []memory.Message) {
 	key := fmt.Sprintf("memories/%s/%s.json", src, id)
 	m.sessions = append(m.sessions, storage.SessionEntry{
 		Source:       src,
@@ -37,7 +37,7 @@ func (m *mockStore) addSession(src, id string, modified time.Time, messages []so
 		Key:          key,
 		LastModified: modified,
 	})
-	m.data[src+"/"+id] = &source.Session{
+	m.data[src+"/"+id] = &memory.Session{
 		Source:    src,
 		SessionID: id,
 		Messages:  messages,
@@ -48,7 +48,7 @@ func (m *mockStore) ListSessions(_ context.Context) ([]storage.SessionEntry, err
 	return m.sessions, nil
 }
 
-func (m *mockStore) GetSession(_ context.Context, src, sessionID string) (*source.Session, error) {
+func (m *mockStore) GetSession(_ context.Context, src, sessionID string) (*memory.Session, error) {
 	s, ok := m.data[src+"/"+sessionID]
 	if !ok {
 		return nil, fmt.Errorf("session not found: %s/%s", src, sessionID)
@@ -56,7 +56,7 @@ func (m *mockStore) GetSession(_ context.Context, src, sessionID string) (*sourc
 	return s, nil
 }
 
-func (m *mockStore) PutSession(_ context.Context, session *source.Session) (int, error) {
+func (m *mockStore) PutSession(_ context.Context, session *memory.Session) (int, error) {
 	key := fmt.Sprintf("memories/%s/%s.json", session.Source, session.SessionID)
 	m.data[session.Source+"/"+session.SessionID] = session
 	m.sessions = append(m.sessions, storage.SessionEntry{
@@ -141,13 +141,13 @@ func (m *mockLLM) Converse(_ context.Context, system, user string, _ ...llm.Conv
 
 func TestDreamPipeline(t *testing.T) {
 	store := newMockStore()
-	store.addSession("claude-code", "sess-1", time.Now(), []source.Message{
+	store.addSession("claude-code", "sess-1", time.Now(), []memory.Message{
 		{Role: "user", Content: "use kebab-case for file names"},
 		{Role: "assistant", Content: "OK, I'll rename them."},
 		{Role: "user", Content: "also use lowercase"},
 		{Role: "assistant", Content: "Done."},
 	})
-	store.addSession("claude-code", "sess-2", time.Now(), []source.Message{
+	store.addSession("claude-code", "sess-2", time.Now(), []memory.Message{
 		{Role: "user", Content: "never use emojis in commit messages"},
 		{Role: "assistant", Content: "Understood."},
 		{Role: "user", Content: "and keep them short"},
@@ -207,7 +207,7 @@ func TestDreamPipelineNoMemories(t *testing.T) {
 func TestDreamPipelineLimit(t *testing.T) {
 	store := newMockStore()
 	for i := 0; i < 5; i++ {
-		store.addSession("test", fmt.Sprintf("sess-%d", i), time.Now(), []source.Message{
+		store.addSession("test", fmt.Sprintf("sess-%d", i), time.Now(), []memory.Message{
 			{Role: "user", Content: fmt.Sprintf("message %d", i)},
 			{Role: "assistant", Content: "ok"},
 			{Role: "user", Content: "follow up"},
@@ -239,7 +239,7 @@ func TestDreamPipelineLimit(t *testing.T) {
 func TestDreamPipelineLimitIncludesPreviousReflections(t *testing.T) {
 	store := newMockStore()
 	for i := 0; i < 4; i++ {
-		store.addSession("test", fmt.Sprintf("sess-%d", i), time.Now(), []source.Message{
+		store.addSession("test", fmt.Sprintf("sess-%d", i), time.Now(), []memory.Message{
 			{Role: "user", Content: fmt.Sprintf("message %d", i)},
 			{Role: "assistant", Content: "ok"},
 			{Role: "user", Content: "follow up"},
@@ -299,7 +299,7 @@ func TestDreamPipelineLimitIncludesPreviousReflections(t *testing.T) {
 func TestDreamPipelineEmptyConversation(t *testing.T) {
 	store := newMockStore()
 	// Session with only empty messages produces no observations
-	store.addSession("test", "empty", time.Now(), []source.Message{
+	store.addSession("test", "empty", time.Now(), []memory.Message{
 		{Role: "user", Content: ""},
 		{Role: "assistant", Content: ""},
 	})
@@ -318,7 +318,7 @@ func TestDreamPipelineEmptyConversation(t *testing.T) {
 
 func TestDreamPipelineReflect(t *testing.T) {
 	store := newMockStore()
-	store.addSession("test", "sess-1", time.Now(), []source.Message{
+	store.addSession("test", "sess-1", time.Now(), []memory.Message{
 		{Role: "user", Content: "hello"},
 		{Role: "assistant", Content: "hi"},
 		{Role: "user", Content: "one more thing"},

--- a/internal/dream/dream.go
+++ b/internal/dream/dream.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/ellistarn/muse/internal/llm"
 	"github.com/ellistarn/muse/internal/log"
-	"github.com/ellistarn/muse/internal/source"
+	"github.com/ellistarn/muse/internal/memory"
 	"github.com/ellistarn/muse/internal/storage"
 	"github.com/ellistarn/muse/prompts"
 )
@@ -260,7 +260,7 @@ type turn struct {
 	humanContent     string // human's message
 }
 
-func reflectOnSession(ctx context.Context, client LLM, session *source.Session) (string, llm.Usage, error) {
+func reflectOnSession(ctx context.Context, client LLM, session *memory.Session) (string, llm.Usage, error) {
 	turns := extractTurns(session)
 	if len(turns) == 0 {
 		return "", llm.Usage{}, nil
@@ -388,7 +388,7 @@ const maxChunkChars = 200_000
 // the assistant message that preceded a human response with that human message.
 // Sessions with fewer than 2 human turns are skipped (no corrections or
 // preferences were expressed).
-func extractTurns(session *source.Session) []turn {
+func extractTurns(session *memory.Session) []turn {
 	var userTurns int
 	for _, msg := range session.Messages {
 		if msg.Role == "user" && len(msg.Content) > 0 {

--- a/internal/memory/claudecode.go
+++ b/internal/memory/claudecode.go
@@ -1,4 +1,4 @@
-package source
+package memory
 
 import (
 	"bufio"

--- a/internal/memory/kiro.go
+++ b/internal/memory/kiro.go
@@ -1,4 +1,4 @@
-package source
+package memory
 
 import (
 	"encoding/json"

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -1,4 +1,4 @@
-package source
+package memory
 
 import (
 	"fmt"

--- a/internal/memory/opencode.go
+++ b/internal/memory/opencode.go
@@ -1,4 +1,4 @@
-package source
+package memory
 
 import (
 	"database/sql"

--- a/internal/memory/types.go
+++ b/internal/memory/types.go
@@ -1,4 +1,4 @@
-package source
+package memory
 
 import (
 	"encoding/json"

--- a/internal/muse/muse.go
+++ b/internal/muse/muse.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ellistarn/muse/internal/bedrock"
 	"github.com/ellistarn/muse/internal/log"
-	"github.com/ellistarn/muse/internal/source"
+	"github.com/ellistarn/muse/internal/memory"
 	"github.com/ellistarn/muse/internal/storage"
 	"github.com/ellistarn/muse/prompts"
 )
@@ -153,15 +153,15 @@ func (m *Muse) Upload(ctx context.Context) (*UploadResult, error) {
 	log.Println("Scanning local sessions...")
 	type result struct {
 		name     string
-		sessions []source.Session
+		sessions []memory.Session
 		err      error
 	}
-	providers := source.Providers()
+	providers := memory.Providers()
 	results := make([]result, len(providers))
 	var wg sync.WaitGroup
 	for i, provider := range providers {
 		wg.Add(1)
-		go func(i int, p source.Provider) {
+		go func(i int, p memory.Provider) {
 			defer wg.Done()
 			sessions, err := p.Sessions()
 			results[i] = result{name: p.Name(), sessions: sessions, err: err}
@@ -169,7 +169,7 @@ func (m *Muse) Upload(ctx context.Context) (*UploadResult, error) {
 	}
 	wg.Wait()
 
-	var local []source.Session
+	var local []memory.Session
 	var warnings []string
 	for _, r := range results {
 		if r.err != nil {

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ellistarn/muse/internal/source"
+	"github.com/ellistarn/muse/internal/memory"
 )
 
 // LocalStore implements Store backed by the local filesystem, rooted at ~/.muse/.
@@ -79,7 +79,7 @@ func (l *LocalStore) ListSessions(_ context.Context) ([]SessionEntry, error) {
 }
 
 // PutSession writes a session as JSON and returns the number of bytes written.
-func (l *LocalStore) PutSession(_ context.Context, session *source.Session) (int, error) {
+func (l *LocalStore) PutSession(_ context.Context, session *memory.Session) (int, error) {
 	data, err := json.MarshalIndent(session, "", "  ")
 	if err != nil {
 		return 0, fmt.Errorf("failed to marshal session: %w", err)
@@ -95,7 +95,7 @@ func (l *LocalStore) PutSession(_ context.Context, session *source.Session) (int
 }
 
 // GetSession reads and deserializes a session from the filesystem.
-func (l *LocalStore) GetSession(_ context.Context, src, sessionID string) (*source.Session, error) {
+func (l *LocalStore) GetSession(_ context.Context, src, sessionID string) (*memory.Session, error) {
 	path := filepath.Join(l.root, "memories", src, sessionID+".json")
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -104,7 +104,7 @@ func (l *LocalStore) GetSession(_ context.Context, src, sessionID string) (*sour
 		}
 		return nil, fmt.Errorf("failed to read session %s: %w", sessionID, err)
 	}
-	var session source.Session
+	var session memory.Session
 	if err := json.Unmarshal(data, &session); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal session %s: %w", sessionID, err)
 	}

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -16,7 +16,7 @@ import (
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 
 	"github.com/ellistarn/muse/internal/awsconfig"
-	"github.com/ellistarn/muse/internal/source"
+	"github.com/ellistarn/muse/internal/memory"
 )
 
 const soulKey = "soul.md"
@@ -71,7 +71,7 @@ func (c *S3Store) ListSessions(ctx context.Context) ([]SessionEntry, error) {
 }
 
 // PutSession uploads a session as JSON and returns the number of bytes written.
-func (c *S3Store) PutSession(ctx context.Context, session *source.Session) (int, error) {
+func (c *S3Store) PutSession(ctx context.Context, session *memory.Session) (int, error) {
 	data, err := json.MarshalIndent(session, "", "  ")
 	if err != nil {
 		return 0, fmt.Errorf("failed to marshal session: %w", err)
@@ -91,7 +91,7 @@ func (c *S3Store) PutSession(ctx context.Context, session *source.Session) (int,
 }
 
 // GetSession downloads and deserializes a session from S3.
-func (c *S3Store) GetSession(ctx context.Context, src, sessionID string) (*source.Session, error) {
+func (c *S3Store) GetSession(ctx context.Context, src, sessionID string) (*memory.Session, error) {
 	key := sessionKey(src, sessionID)
 	out, err := c.s3.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: &c.bucket,
@@ -105,7 +105,7 @@ func (c *S3Store) GetSession(ctx context.Context, src, sessionID string) (*sourc
 	if err != nil {
 		return nil, fmt.Errorf("failed to read session %s: %w", sessionID, err)
 	}
-	var session source.Session
+	var session memory.Session
 	if err := json.Unmarshal(data, &session); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal session %s: %w", sessionID, err)
 	}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/ellistarn/muse/internal/source"
+	"github.com/ellistarn/muse/internal/memory"
 )
 
 // Store is the interface for all storage operations. Implementations include
@@ -13,8 +13,8 @@ import (
 type Store interface {
 	// Sessions
 	ListSessions(ctx context.Context) ([]SessionEntry, error)
-	GetSession(ctx context.Context, src, sessionID string) (*source.Session, error)
-	PutSession(ctx context.Context, session *source.Session) (int, error)
+	GetSession(ctx context.Context, src, sessionID string) (*memory.Session, error)
+	PutSession(ctx context.Context, session *memory.Session) (int, error)
 
 	// Soul
 	GetSoul(ctx context.Context) (string, error)


### PR DESCRIPTION
## Summary
- Renames `internal/source` → `internal/memory` to align with the domain language
- `memory.Provider`, `memory.Session` read better than `source.Provider`, `source.Session`
- No behavioral changes — pure rename across package declaration, imports, and qualifiers

Follow-up to #39. Prep for #38.