### PR TITLE
Rename push to load

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ go install github.com/ellistarn/muse/cmd/muse@latest
 ## Getting Started
 
 ```bash
-muse push              # push memories to storage
+muse load              # load memories into storage
 muse dream             # distill your soul from memories
 muse inspect           # see what your muse learned
 ```

--- a/cmd/muse/load.go
+++ b/cmd/muse/load.go
@@ -8,14 +8,14 @@ import (
 	"github.com/ellistarn/muse/internal/muse"
 )
 
-func newPushCmd() *cobra.Command {
+func newLoadCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "push",
-		Short: "Push memories to storage",
-		Long: `Finds agent sessions and uploads them to storage. Uploads are incremental
+		Use:   "load",
+		Short: "Load memories into storage",
+		Long: `Finds agent sessions and loads them into storage. Loads are incremental
 — sessions already in storage are skipped. Run this before dreaming so
 your muse has new material.`,
-		Example: `  muse push`,
+		Example: `  muse load`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			store, err := newStore(ctx)
@@ -35,7 +35,7 @@ your muse has new material.`,
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Found %d local sessions\n", result.Total)
 			if result.Uploaded > 0 {
-				fmt.Fprintf(cmd.OutOrStdout(), "Uploaded %d sessions (%s), %d unchanged\n", result.Uploaded, muse.FormatBytes(result.Bytes), result.Skipped)
+				fmt.Fprintf(cmd.OutOrStdout(), "Loaded %d sessions (%s), %d unchanged\n", result.Uploaded, muse.FormatBytes(result.Bytes), result.Skipped)
 			} else {
 				fmt.Fprintf(cmd.OutOrStdout(), "All %d sessions unchanged\n", result.Skipped)
 			}

--- a/cmd/muse/root.go
+++ b/cmd/muse/root.go
@@ -21,7 +21,7 @@ soul document, and embodies your unique thought processes when asked questions.
 
 Workflow:
 
-  1. muse push       Collect local agent sessions and upload them to storage
+  1. muse load       Load memories from agent sessions into storage
   2. muse dream      Reflect on memories and distill a soul document
   3. muse ask        Ask your muse a question (stateless, one-shot)
   4. muse listen     Start an MCP server so agents can ask your muse
@@ -32,7 +32,7 @@ Other commands:
 
 Getting started:
 
-  muse push && muse dream && muse inspect
+  muse load && muse dream && muse inspect
 
 Data is stored locally at ~/.muse/ by default. Set MUSE_BUCKET to use S3 instead.
 
@@ -41,7 +41,7 @@ Run "muse listen --help" for MCP server configuration.`,
 		SilenceUsage:  true,
 	}
 	cmd.PersistentFlags().StringVar(&bucket, "bucket", os.Getenv("MUSE_BUCKET"), "S3 bucket name (or set MUSE_BUCKET)")
-	cmd.AddCommand(newPushCmd())
+	cmd.AddCommand(newLoadCmd())
 	cmd.AddCommand(newDreamCmd())
 	cmd.AddCommand(newInspectCmd())
 	cmd.AddCommand(newListenCmd())


### PR DESCRIPTION
## Summary

Renames `muse push` to `muse load`.

The lifecycle: `muse load → muse dream → muse listen`

`push` implied local→remote (like git push), which doesn't fit local-first storage. `load` captures the Matrix-style direct memory transfer — the muse loads memories from agent sessions, dreams on them, then listens.

## Changes

- `cmd/muse/push.go` → `cmd/muse/load.go`
- Updated CLI help text, README, AGENTS.md
- Output says "Loaded N sessions" instead of "Uploaded"