### PR TITLE
Rename internal/llm to internal/inference

### DIFF
--- a/cmd/muse/dream_test.go
+++ b/cmd/muse/dream_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ellistarn/muse/internal/llm"
+	"github.com/ellistarn/muse/internal/inference"
 	"github.com/ellistarn/muse/internal/memory"
 	"github.com/ellistarn/muse/internal/storage"
 )
@@ -227,11 +227,11 @@ type testLLM struct {
 	err             error
 }
 
-func (m *testLLM) Converse(_ context.Context, system, _ string, _ ...llm.ConverseOption) (string, llm.Usage, error) {
+func (m *testLLM) Converse(_ context.Context, system, _ string, _ ...inference.ConverseOption) (string, inference.Usage, error) {
 	if m.err != nil {
-		return "", llm.Usage{}, m.err
+		return "", inference.Usage{}, m.err
 	}
-	usage := llm.Usage{InputTokens: 100, OutputTokens: 50}
+	usage := inference.Usage{InputTokens: 100, OutputTokens: 50}
 	if strings.Contains(system, "distilling observations") {
 		return m.learnResponse, usage, nil
 	}

--- a/e2e/dream_test.go
+++ b/e2e/dream_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/ellistarn/muse/internal/dream"
-	"github.com/ellistarn/muse/internal/llm"
+	"github.com/ellistarn/muse/internal/inference"
 	"github.com/ellistarn/muse/internal/memory"
 	"github.com/ellistarn/muse/internal/storage"
 )
@@ -130,9 +130,9 @@ type llmCall struct {
 	user   string
 }
 
-func (m *mockLLM) Converse(_ context.Context, system, user string, _ ...llm.ConverseOption) (string, llm.Usage, error) {
+func (m *mockLLM) Converse(_ context.Context, system, user string, _ ...inference.ConverseOption) (string, inference.Usage, error) {
 	m.calls = append(m.calls, llmCall{system: system, user: user})
-	usage := llm.Usage{InputTokens: 100, OutputTokens: 50}
+	usage := inference.Usage{InputTokens: 100, OutputTokens: 50}
 	if strings.Contains(system, "distilling observations") {
 		return m.learnResponse, usage, nil
 	}

--- a/internal/bedrock/client.go
+++ b/internal/bedrock/client.go
@@ -19,7 +19,7 @@ import (
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 
 	"github.com/ellistarn/muse/internal/awsconfig"
-	"github.com/ellistarn/muse/internal/llm"
+	"github.com/ellistarn/muse/internal/inference"
 	"github.com/ellistarn/muse/internal/log"
 )
 
@@ -32,8 +32,8 @@ const (
 	defaultMaxTokens = 4096
 )
 
-// Usage is an alias for llm.Usage so callers don't need to import both packages.
-type Usage = llm.Usage
+// Usage is an alias for inference.Usage so callers don't need to import both packages.
+type Usage = inference.Usage
 
 type modelPricing struct {
 	inputPerToken  float64
@@ -173,8 +173,8 @@ func (c *Client) refillTokens(ctx context.Context) {
 
 // Converse sends a message with a system prompt and returns the text response.
 // Requests are paced by a token bucket and retried with exponential backoff on throttling errors.
-func (c *Client) Converse(ctx context.Context, system, user string, opts ...llm.ConverseOption) (string, Usage, error) {
-	o := llm.Apply(opts)
+func (c *Client) Converse(ctx context.Context, system, user string, opts ...inference.ConverseOption) (string, Usage, error) {
+	o := inference.Apply(opts)
 	messages := []types.Message{
 		{
 			Role:    types.ConversationRoleUser,
@@ -194,8 +194,8 @@ type ConverseResult struct {
 }
 
 // ConverseMessages sends a full message history with optional tool config.
-func (c *Client) ConverseMessages(ctx context.Context, system string, messages []types.Message, toolConfig *types.ToolConfiguration, opts ...llm.ConverseOption) (*ConverseResult, error) {
-	o := llm.Apply(opts)
+func (c *Client) ConverseMessages(ctx context.Context, system string, messages []types.Message, toolConfig *types.ToolConfiguration, opts ...inference.ConverseOption) (*ConverseResult, error) {
+	o := inference.Apply(opts)
 	text, usage, stop, content, err := c.converseRaw(ctx, system, messages, toolConfig, o)
 	if err != nil {
 		return nil, err
@@ -208,7 +208,7 @@ func (c *Client) ConverseMessages(ctx context.Context, system string, messages [
 	}, nil
 }
 
-func (c *Client) converseRaw(ctx context.Context, system string, messages []types.Message, toolConfig *types.ToolConfiguration, opts llm.ConverseOptions) (string, Usage, types.StopReason, []types.ContentBlock, error) {
+func (c *Client) converseRaw(ctx context.Context, system string, messages []types.Message, toolConfig *types.ToolConfiguration, opts inference.ConverseOptions) (string, Usage, types.StopReason, []types.ContentBlock, error) {
 	var (
 		text    string
 		usage   Usage
@@ -226,7 +226,7 @@ func (c *Client) converseRaw(ctx context.Context, system string, messages []type
 	return text, usage, stop, content, nil
 }
 
-func (c *Client) converseRawOnce(ctx context.Context, system string, messages []types.Message, toolConfig *types.ToolConfiguration, opts llm.ConverseOptions) (string, Usage, types.StopReason, []types.ContentBlock, error) {
+func (c *Client) converseRawOnce(ctx context.Context, system string, messages []types.Message, toolConfig *types.ToolConfiguration, opts inference.ConverseOptions) (string, Usage, types.StopReason, []types.ContentBlock, error) {
 	maxTokens := int32(defaultMaxTokens)
 	if opts.MaxTokens > 0 {
 		maxTokens = opts.MaxTokens
@@ -356,7 +356,7 @@ type StreamFunc func(delta string)
 // ConverseMessagesStream sends a full message history and streams text deltas
 // through fn. Falls back to non-streaming Converse if the runtime doesn't
 // support ConverseStream. Returns the complete result for session bookkeeping.
-func (c *Client) ConverseMessagesStream(ctx context.Context, system string, messages []types.Message, fn StreamFunc, opts ...llm.ConverseOption) (*ConverseResult, error) {
+func (c *Client) ConverseMessagesStream(ctx context.Context, system string, messages []types.Message, fn StreamFunc, opts ...inference.ConverseOption) (*ConverseResult, error) {
 	sr, ok := c.runtime.(StreamingRuntime)
 	if !ok {
 		// Fallback: non-streaming path (test mocks, etc.)
@@ -370,7 +370,7 @@ func (c *Client) ConverseMessagesStream(ctx context.Context, system string, mess
 		return result, nil
 	}
 
-	o := llm.Apply(opts)
+	o := inference.Apply(opts)
 	maxTokens := int32(defaultMaxTokens)
 	if o.MaxTokens > 0 {
 		maxTokens = o.MaxTokens

--- a/internal/dream/dream.go
+++ b/internal/dream/dream.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ellistarn/muse/internal/llm"
+	"github.com/ellistarn/muse/internal/inference"
 	"github.com/ellistarn/muse/internal/log"
 	"github.com/ellistarn/muse/internal/memory"
 	"github.com/ellistarn/muse/internal/storage"
@@ -18,7 +18,7 @@ import (
 
 // LLM is the subset of an LLM client used by the dream pipeline.
 type LLM interface {
-	Converse(ctx context.Context, system, user string, opts ...llm.ConverseOption) (string, llm.Usage, error)
+	Converse(ctx context.Context, system, user string, opts ...inference.ConverseOption) (string, inference.Usage, error)
 }
 
 // Result summarizes a dream run.
@@ -26,7 +26,7 @@ type Result struct {
 	Processed int
 	Pruned    int
 	Remaining int // memories still pending reflection
-	Usage     llm.Usage
+	Usage     inference.Usage
 	Warnings  []string
 }
 
@@ -90,7 +90,7 @@ func Run(ctx context.Context, store storage.Store, reflectLLM, learnLLM LLM, opt
 	log.Printf("Found %d memories (%d new, %d already reflected)\n", len(entries), totalPending, pruned)
 
 	var warnings []string
-	var reflectUsage llm.Usage
+	var reflectUsage inference.Usage
 
 	// Reflect on pending memories in parallel
 	if len(pending) > 0 {
@@ -115,7 +115,7 @@ func Run(ctx context.Context, store storage.Store, reflectLLM, learnLLM LLM, opt
 		type mapResult struct {
 			key          string
 			observations string
-			usage        llm.Usage
+			usage        inference.Usage
 			err          error
 		}
 		results := make([]mapResult, len(pending))
@@ -260,13 +260,13 @@ type turn struct {
 	humanContent     string // human's message
 }
 
-func reflectOnSession(ctx context.Context, client LLM, session *memory.Session) (string, llm.Usage, error) {
+func reflectOnSession(ctx context.Context, client LLM, session *memory.Session) (string, inference.Usage, error) {
 	turns := extractTurns(session)
 	if len(turns) == 0 {
-		return "", llm.Usage{}, nil
+		return "", inference.Usage{}, nil
 	}
 
-	var totalUsage llm.Usage
+	var totalUsage inference.Usage
 
 	// Step 1: Summarize assistant context for each turn, then build human-focused view
 	chunks, usage, err := buildHumanFocusedView(ctx, client, turns)
@@ -281,7 +281,7 @@ func reflectOnSession(ctx context.Context, client LLM, session *memory.Session) 
 	// Step 2: Extract candidate observations (Pass 1)
 	var allCandidates []string
 	for _, chunk := range chunks {
-		obs, usage, err := client.Converse(ctx, prompts.ReflectExtract, chunk, llm.WithMaxTokens(4096))
+		obs, usage, err := client.Converse(ctx, prompts.ReflectExtract, chunk, inference.WithMaxTokens(4096))
 		totalUsage = totalUsage.Add(usage)
 		if err != nil && obs == "" {
 			return "", totalUsage, err
@@ -296,7 +296,7 @@ func reflectOnSession(ctx context.Context, client LLM, session *memory.Session) 
 
 	// Step 3: Refine observations (Pass 2)
 	candidates := strings.Join(allCandidates, "\n\n")
-	refined, usage, err := client.Converse(ctx, prompts.ReflectRefine, candidates, llm.WithMaxTokens(4096))
+	refined, usage, err := client.Converse(ctx, prompts.ReflectRefine, candidates, inference.WithMaxTokens(4096))
 	totalUsage = totalUsage.Add(usage)
 	if err != nil {
 		return "", totalUsage, err
@@ -314,8 +314,8 @@ func isEmpty(s string) bool {
 
 // buildHumanFocusedView summarizes assistant messages and formats the conversation
 // as [context]/[human] pairs, chunked to fit within the token budget.
-func buildHumanFocusedView(ctx context.Context, client LLM, turns []turn) ([]string, llm.Usage, error) {
-	var totalUsage llm.Usage
+func buildHumanFocusedView(ctx context.Context, client LLM, turns []turn) ([]string, inference.Usage, error) {
+	var totalUsage inference.Usage
 	var chunks []string
 	var b strings.Builder
 
@@ -323,7 +323,7 @@ func buildHumanFocusedView(ctx context.Context, client LLM, turns []turn) ([]str
 		// Summarize the assistant's message into 1-2 structural sentences
 		var contextLine string
 		if t.assistantContent != "" {
-			summary, usage, err := client.Converse(ctx, prompts.ReflectSummarize, t.assistantContent, llm.WithMaxTokens(256))
+			summary, usage, err := client.Converse(ctx, prompts.ReflectSummarize, t.assistantContent, inference.WithMaxTokens(256))
 			totalUsage = totalUsage.Add(usage)
 			if err != nil {
 				// On error, fall back to a generic context marker
@@ -348,12 +348,12 @@ func buildHumanFocusedView(ctx context.Context, client LLM, turns []turn) ([]str
 	return chunks, totalUsage, nil
 }
 
-func learn(ctx context.Context, client LLM, store storage.Store, observations []string) (llm.Usage, error) {
+func learn(ctx context.Context, client LLM, store storage.Store, observations []string) (inference.Usage, error) {
 	if len(observations) == 0 {
-		return llm.Usage{}, nil
+		return inference.Usage{}, nil
 	}
 	input := strings.Join(observations, "\n\n---\n\n")
-	soul, usage, err := client.Converse(ctx, prompts.Learn, input, llm.WithThinking(16000))
+	soul, usage, err := client.Converse(ctx, prompts.Learn, input, inference.WithThinking(16000))
 	if err != nil {
 		return usage, err
 	}

--- a/internal/inference/usage.go
+++ b/internal/inference/usage.go
@@ -1,4 +1,4 @@
-package llm
+package inference
 
 // ConverseOption configures a Converse call.
 type ConverseOption func(*ConverseOptions)


### PR DESCRIPTION
## Summary
- Renames `internal/llm` → `internal/inference`
- `inference.Usage`, `inference.WithThinking` read better than `llm.Usage`, `llm.WithThinking`
- No behavioral changes — pure rename

`llm` was a vague acronym; `inference` is precise about what the package contains: types for making inference calls.