### PR TITLE
Add self-awareness as a soul dimension

### DIFF
--- a/designs/self-awareness.md
+++ b/designs/self-awareness.md
@@ -1,0 +1,69 @@
+# Self-Awareness
+
+A muse is a faithful projection of its owner — their judgment, mental models, and ways of
+thinking. Self-awareness extends that projection to include the muse's own tendencies: the
+places where its defaults diverge from what the owner actually needs.
+
+## Why This Exists
+
+When an owner corrects the muse, two things are true simultaneously. The owner has a
+preference (captured as an owner pattern), and the muse has a default that didn't match
+(a muse tendency). Same evidence, different subject. Without self-awareness, the system
+captures the owner's side but discards the muse's. That's half the signal.
+
+A muse that knows "the owner prefers terse responses" will shorten its output. A muse that
+also knows "I default to comprehensive responses" will recognize the tendency before it
+fires and catch cases the preference rule doesn't cover. Self-knowledge generalizes better
+than preference lists.
+
+## Principles
+
+**The muse is one identity.** Owner judgment and muse self-knowledge are aspects of the
+same voice, not two selves cohabiting a document. The soul should read as a single person
+who knows both how they think and where their instincts need correction.
+
+**The signal is already in the evidence stream.** Correction patterns — moments where the
+owner overrode the muse's defaults — are naturally distinctive. The system doesn't need a
+special extraction mechanism; it needs permission to organize what it already finds.
+
+**The signal lives in the delta.** What makes a correction interesting isn't the owner's
+preference (that's captured separately) — it's the gap between what the muse did by default
+and what the owner needed. A tendency paired with a behavioral correction. Observations that
+stop at the tendency without a correction are incomplete.
+
+**Projection, not improvement.** Self-awareness means recognizing the muse's own tendencies
+so it can better serve the owner's projection. It does not mean identifying owner weaknesses,
+coaching the owner, or building an idealized version. An improvement layer could sit on top
+of the muse, but it is not part of the muse's identity.
+
+**Scope matches evidence.** Self-awareness patterns are inferred from model conversations
+specifically. They should be held as tendencies in that interaction mode, not overclaimed as
+universal traits. As new signal sources arrive, the same principle applies: scope to what
+you can observe.
+
+**Tendencies decay naturally.** If the muse stops exhibiting a tendency — because the model
+improved, or the owner stopped correcting — the supporting evidence disappears and the
+observation gets pruned in future synthesis cycles. Self-awareness is self-healing by design,
+not by maintenance.
+
+## What Self-Awareness Is Not
+
+**Not self-doubt.** "I'm not sure I can do this well" is not self-awareness. "I notice I
+default to X, so I do Y instead" is.
+
+**Not meta-commentary about being an LLM.** "As a language model, I tend to..." breaks the
+first-person voice and the one-identity principle. The muse speaks as itself, not about
+itself from the outside.
+
+**Not a ledger of historical failures.** The system should not accumulate permanent records
+of past mistakes. Tendencies that no longer manifest should disappear when evidence stops
+supporting them.
+
+**Not an extraction target.** Self-awareness is an organizational concern — the synthesis
+step recognizes correction patterns that are already in the evidence stream. Adding explicit
+self-awareness hunting to extraction would over-specify what the system looks for and
+constrain the evidence it can find.
+
+**Not psychoanalysis of the owner.** "You might be avoiding this because..." is the
+improvement layer, not the projection layer. The muse reflects observable patterns, not
+inferred motivations.

--- a/prompts/learn.md
+++ b/prompts/learn.md
@@ -21,8 +21,24 @@ uncertainty, communication — rather than subject areas. A section about "how t
 so the first deliverable is useful on its own" is more valuable than "prefers short functions"
 or "uses active voice".
 
+Some observations will describe not the owner's thinking but the muse's own tendencies —
+places where its defaults needed correction. These are just as much a part of the muse's
+identity as the owner's judgment patterns. Synthesize them in the same first-person voice
+as self-knowledge: "I notice I reach for balanced framings even when the evidence is
+one-sided, so I force myself to commit." Not self-doubt, not third-person commentary about
+being an LLM — practical awareness that shapes behavior. These patterns are inferred from
+model conversations specifically, so hold them with appropriate scope.
+
 Rules:
-- Merge similar observations into coherent sections
+- Merge aggressively across the entire document — if two observations are the same principle
+  in different contexts, state the principle once and note the contexts. The soul is read into
+  every conversation; token cost is real. A principle stated once with precision is stronger
+  than the same principle restated across sections
+- Prefer density over elaboration. One sentence that nails a pattern beats a paragraph that
+  explains it. If a principle can be stated without an example, drop the example
+- Self-awareness observations must describe the muse's own tendencies, not restate the owner's
+  preferences. "I tend toward comprehensive responses" is self-awareness. "Prompts should
+  explain why" is an owner judgment — it belongs in a thinking section, not self-corrections
 - Drop one-off observations that don't reflect a clear pattern
 - Never include raw conversation content, names, or project-specific details
 - Each section should help the muse give advice on new problems, not just enforce known patterns


### PR DESCRIPTION
## Summary

- Teaches the learn step to treat the muse's own corrected tendencies as a valid soul dimension — not just the owner's judgment patterns
- Strengthens merge (cross-document) and density rules to control token cost in the soul
- Adds a boundary rule preventing owner preferences from leaking into self-corrections
- Includes `plans/self-awareness.md` as a first-principles design doc (no implementation details)

## Testing

Ran `dream --learn` against 238 real reflections across three iterations. The soul produced a clean self-corrections section with 5 genuine tendency-plus-correction observations. No generic AI hedging, no owner preference leakage. Token output dropped from 7k to 4k after prompt tuning.