### PR TITLE
Show token counts and costs on all LLM operations

### DIFF
--- a/cmd/muse/ask.go
+++ b/cmd/muse/ask.go
@@ -33,7 +33,7 @@ questions ("Is X a good approach for Y?") rather than factual lookups.`,
 			}
 			question := strings.Join(args, " ")
 			var wroteOutput bool
-			_, err = m.Ask(ctx, muse.AskInput{
+			result, err := m.Ask(ctx, muse.AskInput{
 				Question: question,
 				StreamFunc: bedrock.StreamFunc(func(delta string) {
 					fmt.Fprint(os.Stdout, delta)
@@ -43,7 +43,12 @@ questions ("Is X a good approach for Y?") rather than factual lookups.`,
 			if wroteOutput {
 				fmt.Fprintln(os.Stdout) // trailing newline after stream completes
 			}
-			return err
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "tokens: %d in / %d out · $%.4f\n",
+				result.Usage.InputTokens, result.Usage.OutputTokens, result.Usage.Cost())
+			return nil
 		},
 	}
 }

--- a/cmd/muse/dream.go
+++ b/cmd/muse/dream.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ellistarn/muse/internal/bedrock"
 	"github.com/ellistarn/muse/internal/dream"
+	"github.com/ellistarn/muse/internal/inference"
 	"github.com/ellistarn/muse/internal/log"
 	"github.com/ellistarn/muse/internal/muse"
 	"github.com/ellistarn/muse/internal/storage"
@@ -115,5 +116,8 @@ func runDream(ctx context.Context, stdout, stderr io.Writer, store storage.Store
 	}
 	fmt.Fprintf(stdout, "Soul distilled (%dk input, %dk output tokens, $%.2f)\n",
 		result.Usage.InputTokens/1000, result.Usage.OutputTokens/1000, result.Usage.Cost())
+	if result.Soul != "" {
+		fmt.Fprintf(stdout, "soul.md: ~%d tokens\n", inference.EstimateTokens(result.Soul))
+	}
 	return nil
 }

--- a/cmd/muse/soul.go
+++ b/cmd/muse/soul.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ellistarn/muse/internal/bedrock"
+	"github.com/ellistarn/muse/internal/inference"
 	"github.com/ellistarn/muse/internal/log"
 	"github.com/ellistarn/muse/internal/storage"
 )
@@ -43,6 +44,7 @@ Use --diff to summarize what changed since the last dream.`,
 				return nil
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), strings.TrimSpace(soul))
+			fmt.Fprintf(cmd.ErrOrStderr(), "soul.md: ~%d tokens\n", inference.EstimateTokens(soul))
 			return nil
 		},
 	}
@@ -97,5 +99,7 @@ func runDiff(cmd *cobra.Command, store storage.Store) error {
 	}
 	log.Printf("Diff complete ($%.4f)\n", usage.Cost())
 	fmt.Fprintf(cmd.OutOrStdout(), "Changes since %s:\n\n%s\n", prevTimestamp, strings.TrimSpace(summary))
+	fmt.Fprintf(cmd.ErrOrStderr(), "tokens: %d in / %d out · $%.4f\n",
+		usage.InputTokens, usage.OutputTokens, usage.Cost())
 	return nil
 }

--- a/internal/dream/dream.go
+++ b/internal/dream/dream.go
@@ -27,6 +27,7 @@ type Result struct {
 	Pruned    int
 	Remaining int // memories still pending reflection
 	Usage     inference.Usage
+	Soul      string // the distilled soul document
 	Warnings  []string
 }
 
@@ -38,10 +39,8 @@ type Options struct {
 	Limit int
 }
 
-// estimateTokens returns a rough token count for a string (~4 chars per token).
-func estimateTokens(s string) int {
-	return len(s) / 4
-}
+// estimateTokens is a convenience alias for inference.EstimateTokens.
+var estimateTokens = inference.EstimateTokens
 
 // Run executes the dream pipeline: reflect on new memories, then learn a soul
 // from all reflections. Reflections are the source of truth for what has been
@@ -179,7 +178,7 @@ func Run(ctx context.Context, store storage.Store, reflectLLM, learnLLM LLM, opt
 	}
 
 	log.Printf("Distilling soul from %d reflections...\n", len(allReflections))
-	learnUsage, err := learn(ctx, learnLLM, store, allReflections)
+	soul, learnUsage, err := learn(ctx, learnLLM, store, allReflections)
 	if err != nil {
 		return nil, fmt.Errorf("learn failed: %w", err)
 	}
@@ -194,6 +193,7 @@ func Run(ctx context.Context, store storage.Store, reflectLLM, learnLLM LLM, opt
 		Pruned:    pruned,
 		Remaining: remaining,
 		Usage:     reflectUsage.Add(learnUsage),
+		Soul:      soul,
 		Warnings:  warnings,
 	}, nil
 }
@@ -210,7 +210,7 @@ func LearnOnly(ctx context.Context, store storage.Store, learnLLM LLM) (*Result,
 	}
 
 	log.Printf("Re-distilling soul from %d reflections...\n", len(allReflections))
-	usage, err := learn(ctx, learnLLM, store, allReflections)
+	soul, usage, err := learn(ctx, learnLLM, store, allReflections)
 	if err != nil {
 		return nil, fmt.Errorf("learn failed: %w", err)
 	}
@@ -218,6 +218,7 @@ func LearnOnly(ctx context.Context, store storage.Store, learnLLM LLM) (*Result,
 
 	return &Result{
 		Usage:    usage,
+		Soul:     soul,
 		Warnings: nil,
 	}, nil
 }
@@ -342,21 +343,21 @@ func buildHumanFocusedView(ctx context.Context, client LLM, turns []turn) ([]str
 	return chunks, totalUsage, nil
 }
 
-func learn(ctx context.Context, client LLM, store storage.Store, observations []string) (inference.Usage, error) {
+func learn(ctx context.Context, client LLM, store storage.Store, observations []string) (string, inference.Usage, error) {
 	if len(observations) == 0 {
-		return inference.Usage{}, nil
+		return "", inference.Usage{}, nil
 	}
 	input := strings.Join(observations, "\n\n---\n\n")
 	soul, usage, err := client.Converse(ctx, prompts.Learn, input, inference.WithThinking(16000))
 	if err != nil {
-		return usage, err
+		return "", usage, err
 	}
 	// Strip markdown code fences the LLM sometimes wraps output in
 	soul = stripCodeFences(soul)
 	if err := writeSoul(ctx, store, soul); err != nil {
-		return usage, fmt.Errorf("failed to write soul: %w", err)
+		return "", usage, fmt.Errorf("failed to write soul: %w", err)
 	}
-	return usage, nil
+	return soul, usage, nil
 }
 
 // stripCodeFences removes wrapping ```markdown ... ``` from LLM output.

--- a/internal/inference/tokens.go
+++ b/internal/inference/tokens.go
@@ -1,0 +1,10 @@
+package inference
+
+// EstimateTokens returns an approximate token count for a string.
+// Claude's tokenizer averages ~4.5 characters per token on English prose,
+// measured empirically against Bedrock's reported usage on representative
+// documents (soul.md, prompt templates). Use provider-reported usage for
+// operational costs; use this for sizing artifacts.
+func EstimateTokens(s string) int {
+	return len(s) * 2 / 9 // ~4.5 chars per token
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/ellistarn/muse/internal/log"
 	"github.com/ellistarn/muse/internal/muse"
 	"github.com/ellistarn/muse/prompts"
 )
@@ -34,6 +35,8 @@ func NewServer(m *muse.Muse) *server.MCPServer {
 				return mcp.NewToolResultError(fmt.Sprintf("failed to ask: %v", err)), nil
 			}
 			sessionID = result.SessionID
+			log.Printf("tokens: %d in / %d out · $%.4f\n",
+				result.Usage.InputTokens, result.Usage.OutputTokens, result.Usage.Cost())
 			return mcp.NewToolResultText(result.Response), nil
 		},
 	)

--- a/internal/muse/muse.go
+++ b/internal/muse/muse.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 
 	"github.com/ellistarn/muse/internal/bedrock"
+	"github.com/ellistarn/muse/internal/inference"
 	"github.com/ellistarn/muse/internal/log"
 	"github.com/ellistarn/muse/internal/memory"
 	"github.com/ellistarn/muse/internal/storage"
@@ -32,8 +33,9 @@ type AskInput struct {
 
 // AskResult contains the output from an Ask call.
 type AskResult struct {
-	Response  string // the muse's response text
-	SessionID string // session ID for continuing the conversation
+	Response  string          // the muse's response text
+	SessionID string          // session ID for continuing the conversation
+	Usage     inference.Usage // token usage and cost for this call
 }
 
 // Muse holds the state needed for all operations.
@@ -134,6 +136,7 @@ func (m *Muse) Ask(ctx context.Context, input AskInput) (*AskResult, error) {
 	return &AskResult{
 		Response:  result.Text,
 		SessionID: sessionID,
+		Usage:     result.Usage,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- Add `EstimateTokens()` using `len(s)*2/9` (~4.5 chars/token), calibrated empirically against Bedrock's reported usage on soul.md and prompt templates
- Show soul.md token size after `dream` and `soul` commands
- Show `tokens: X in / Y out · $Z.ZZZZ` after `ask`, `soul --diff`, and MCP `listen` calls
- Return `Usage` from `Ask()` so all callers have access to provider-reported token counts

Every LLM call site now surfaces cost. Artifact sizing uses the estimate with `~` prefix; operational costs use exact provider-reported numbers.

Note: based on `rename-cli-commands` — this PR's unique commit is `a332083`.