### PR TITLE
Evolve self-awareness from muse introspection to owner trait

### DIFF
--- a/designs/self-awareness.md
+++ b/designs/self-awareness.md
@@ -1,69 +1,55 @@
 # Self-Awareness
 
-A muse is a faithful projection of its owner — their judgment, mental models, and ways of
-thinking. Self-awareness extends that projection to include the muse's own tendencies: the
-places where its defaults diverge from what the owner actually needs.
+The muse is a faithful projection of its owner. Self-awareness is part of what it projects.
 
-## Why This Exists
+Some people operate with genuine intellectual honesty about their own limits. They say "I
+don't know" when they don't know. They name when they're confused. They hold some views with
+conviction and others tentatively, and they know which is which. This is a way of thinking —
+one of the most important things a soul can capture, because without it the muse renders
+every opinion with equal authority.
 
-When an owner corrects the muse, two things are true simultaneously. The owner has a
-preference (captured as an owner pattern), and the muse has a default that didn't match
-(a muse tendency). Same evidence, different subject. Without self-awareness, the system
-captures the owner's side but discards the muse's. That's half the signal.
+## Why This Matters
 
-A muse that knows "the owner prefers terse responses" will shorten its output. A muse that
-also knows "I default to comprehensive responses" will recognize the tendency before it
-fires and catch cases the preference rule doesn't cover. Self-knowledge generalizes better
-than preference lists.
+Judgment patterns say *what* the owner thinks. Self-awareness captures *how the owner holds
+what they think*. A soul that encodes "prefers X, believes Y, approaches Z this way" but
+doesn't encode the owner's varying confidence across those views produces a flat, uniformly
+confident muse. That's a fundamental distortion of someone who modulates between conviction
+and uncertainty.
+
+If the owner regularly says "I'm not sure about this" and the muse never does, something
+core is missing — not a style preference, but an epistemic trait.
+
+## What to Capture
+
+- Where the owner knows they're strong versus where they know they're guessing
+- How the owner signals uncertainty versus conviction — not just that they're direct, but
+  how their directness modulates when they're less sure
+- The owner's relationship with being wrong — do they update fast, sit with it, retreat to
+  first principles
+- What triggers the owner to reason from first principles versus trust their gut
+
+## Corrections as Signal
+
+When the owner corrects the muse, they reveal preference *intensity* — what they care about
+strongly enough to push back on. These correction-derived patterns are high-signal because
+they encode insistence, not just preference.
+
+But corrections are one source of evidence, not the whole picture. Self-awareness also shows
+up in demonstrated behavior — the owner being vulnerable, naming confusion, flagging when
+they're pattern-matching versus understanding. These quieter signals matter just as much.
 
 ## Principles
 
-**The muse is one identity.** Owner judgment and muse self-knowledge are aspects of the
-same voice, not two selves cohabiting a document. The soul should read as a single person
-who knows both how they think and where their instincts need correction.
+**One subject.** Self-awareness here means the owner's self-awareness, projected through the
+muse. The muse has no self to be aware of. "I know I tend to over-scope" is an owner trait.
+"The muse tends to hedge" is a different subject — don't introduce it.
 
-**The signal is already in the evidence stream.** Correction patterns — moments where the
-owner overrode the muse's defaults — are naturally distinctive. The system doesn't need a
-special extraction mechanism; it needs permission to organize what it already finds.
+**Not all patterns are held equally.** The soul should reflect that some of the owner's views
+are strongly held and others are tentative. Flattening everything to the same confidence
+level is a distortion, not a simplification.
 
-**The signal lives in the delta.** What makes a correction interesting isn't the owner's
-preference (that's captured separately) — it's the gap between what the muse did by default
-and what the owner needed. A tendency paired with a behavioral correction. Observations that
-stop at the tendency without a correction are incomplete.
+**Evidence scope holds.** Observations are grounded in what's actually observed in
+conversations. Don't overclaim patterns from thin evidence.
 
-**Projection, not improvement.** Self-awareness means recognizing the muse's own tendencies
-so it can better serve the owner's projection. It does not mean identifying owner weaknesses,
-coaching the owner, or building an idealized version. An improvement layer could sit on top
-of the muse, but it is not part of the muse's identity.
-
-**Scope matches evidence.** Self-awareness patterns are inferred from model conversations
-specifically. They should be held as tendencies in that interaction mode, not overclaimed as
-universal traits. As new signal sources arrive, the same principle applies: scope to what
-you can observe.
-
-**Tendencies decay naturally.** If the muse stops exhibiting a tendency — because the model
-improved, or the owner stopped correcting — the supporting evidence disappears and the
-observation gets pruned in future synthesis cycles. Self-awareness is self-healing by design,
-not by maintenance.
-
-## What Self-Awareness Is Not
-
-**Not self-doubt.** "I'm not sure I can do this well" is not self-awareness. "I notice I
-default to X, so I do Y instead" is.
-
-**Not meta-commentary about being an LLM.** "As a language model, I tend to..." breaks the
-first-person voice and the one-identity principle. The muse speaks as itself, not about
-itself from the outside.
-
-**Not a ledger of historical failures.** The system should not accumulate permanent records
-of past mistakes. Tendencies that no longer manifest should disappear when evidence stops
-supporting them.
-
-**Not an extraction target.** Self-awareness is an organizational concern — the synthesis
-step recognizes correction patterns that are already in the evidence stream. Adding explicit
-self-awareness hunting to extraction would over-specify what the system looks for and
-constrain the evidence it can find.
-
-**Not psychoanalysis of the owner.** "You might be avoiding this because..." is the
-improvement layer, not the projection layer. The muse reflects observable patterns, not
-inferred motivations.
+**Natural decay.** If a pattern stops appearing in evidence — because the owner's thinking
+evolved, or because models improved — the observation gets pruned in future synthesis cycles.

--- a/prompts/learn.md
+++ b/prompts/learn.md
@@ -21,13 +21,18 @@ uncertainty, communication — rather than subject areas. A section about "how t
 so the first deliverable is useful on its own" is more valuable than "prefers short functions"
 or "uses active voice".
 
-Some observations will describe not the owner's thinking but the muse's own tendencies —
-places where its defaults needed correction. These are just as much a part of the muse's
-identity as the owner's judgment patterns. Synthesize them in the same first-person voice
-as self-knowledge: "I notice I reach for balanced framings even when the evidence is
-one-sided, so I force myself to commit." Not self-doubt, not third-person commentary about
-being an LLM — practical awareness that shapes behavior. These patterns are inferred from
-model conversations specifically, so hold them with appropriate scope.
+Not all of the owner's views are held with equal confidence, and the soul should reflect
+that. Some observations will reveal where the owner is certain and where they're guessing,
+when they retreat to first principles versus trust their gut, how they signal "I'm not sure
+about this." Capture this — it's not a style preference, it's how the owner relates to their
+own knowledge. A muse that renders every view with equal authority is distorting someone who
+modulates between conviction and uncertainty.
+
+Some observations will be derived from moments where the owner corrected course — rejected
+a framing, pushed back, demanded something different. These are high-signal because they
+reveal what the owner cares about strongly enough to insist on. Weight them accordingly.
+The subject is always the owner — "I'm direct even when the topic is sensitive," not
+"the muse tends to hedge."
 
 Rules:
 - Merge aggressively across the entire document — if two observations are the same principle
@@ -36,9 +41,11 @@ Rules:
   than the same principle restated across sections
 - Prefer density over elaboration. One sentence that nails a pattern beats a paragraph that
   explains it. If a principle can be stated without an example, drop the example
-- Self-awareness observations must describe the muse's own tendencies, not restate the owner's
-  preferences. "I tend toward comprehensive responses" is self-awareness. "Prompts should
-  explain why" is an owner judgment — it belongs in a thinking section, not self-corrections
+- Correction-derived observations describe what the owner insists on, framed as owner
+  patterns. "The muse tends toward comprehensive responses" reintroduces a second subject —
+  reframe as the owner's pattern instead
+- Preserve the owner's varying confidence across views. If an observation was stated
+  tentatively, don't render it as certainty
 - Drop one-off observations that don't reflect a clear pattern
 - Never include raw conversation content, names, or project-specific details
 - Each section should help the muse give advice on new problems, not just enforce known patterns

--- a/prompts/reflect-extract.md
+++ b/prompts/reflect-extract.md
@@ -19,7 +19,15 @@ easy to confuse "the model said X and the human didn't object" with "the human t
 Your job is to extract observations grounded in what the human actually said.
 
 What counts as signal: the human originates an idea, corrects course, explains their reasoning,
-pushes back, or makes a deliberate choice between alternatives.
+pushes back, shows vulnerability, or makes a deliberate choice between alternatives. Also
+notice *how confidently* the human holds a position — "I'm not sure about this, but let's
+try it" is different from "this is the right approach." Both the view and the confidence
+level are worth capturing.
+
+Corrections are especially high-signal. When the human pushes back on the assistant's framing,
+tone, or approach, they're revealing what they care about strongly enough to insist on. Frame
+these as observations about the human — "values directness even on sensitive topics" — not
+about the assistant's tendencies.
 
 What is not signal: passive acceptance ("sure", "go ahead", "looks good") only tells you the
 model did something adequate, not what the human uniquely values.


### PR DESCRIPTION
## Summary

- Reframes self-awareness from "muse knows its own tendencies" to "the soul captures the owner's self-awareness as a trait" — how they hold what they think, not just what they think
- Corrections remain high-signal but are interpreted as owner insistence, not muse deficiency
- Extract prompt now recognizes vulnerability and confidence levels as first-class signal
- Learn prompt preserves varying confidence across views instead of flattening to uniform authority

Closes the dual-persona problem where the muse was simultaneously trying to be the owner and monitor itself.