### PR TITLE
Rewrite sync help text to be workflow-oriented

### DIFF
--- a/cmd/muse/sync.go
+++ b/cmd/muse/sync.go
@@ -25,7 +25,7 @@ that don't exist in the source are left alone.
 
 Endpoints:
   local   Local filesystem (~/.muse/)
-  s3      S3 bucket (requires MUSE_BUCKET)
+  s3      S3 bucket (export MUSE_BUCKET=...)
 
 By default all data is synced. You can limit to a category (memories,
 reflections, souls) but you rarely need to.`,


### PR DESCRIPTION
## Summary
- Rewrites `muse sync --help` from a reference card into workflow-oriented guidance
- Leads with the most important behavioral detail: additive only, existing data is never modified or deleted
- Frames pull vs push in terms of when you'd use each (new machine vs backup)
- De-emphasizes category filtering since syncing everything is the right default