### PR TITLE
Rename dream command to distill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Muse
 
-A muse absorbs memories from your conversations, distills them into a document
+A muse reflects on memories of your conversations, distills them into a document
 (muse.md), and embodies your unique thought processes when asked questions.
 
 ## Install
@@ -12,7 +12,7 @@ go install github.com/ellistarn/muse/cmd/muse@latest
 ## Getting Started
 
 ```bash
-muse dream                # discover memories and distill muse.md
+muse distill                # discover memories and distill muse.md
 muse ask "your question"  # ask your muse directly
 muse listen               # start MCP server
 muse show                 # print muse.md

--- a/cmd/muse/distill.go
+++ b/cmd/muse/distill.go
@@ -8,19 +8,19 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ellistarn/muse/internal/bedrock"
-	"github.com/ellistarn/muse/internal/dream"
+	"github.com/ellistarn/muse/internal/distill"
 	"github.com/ellistarn/muse/internal/inference"
 	"github.com/ellistarn/muse/internal/log"
 	"github.com/ellistarn/muse/internal/muse"
 	"github.com/ellistarn/muse/internal/storage"
 )
 
-func newDreamCmd() *cobra.Command {
+func newDistillCmd() *cobra.Command {
 	var reflect bool
 	var learn bool
 	var limit int
 	cmd := &cobra.Command{
-		Use:   "dream",
+		Use:   "distill",
 		Short: "Distill a muse from memories",
 		Long: `Discovers new memories, reflects on them, and distills a muse.md
 that captures how you think. Safe to run repeatedly — only new
@@ -32,10 +32,10 @@ then learn reduces all observations into a single muse.md.
 
 Use --learn to re-distill the muse from existing reflections without
 reprocessing memories. Use --reflect to reprocess all memories from scratch.`,
-		Example: `  muse dream              # discover memories, reflect, and distill muse
-  muse dream --learn      # re-distill muse from existing reflections
-  muse dream --reflect    # re-reflect on all memories from scratch
-  muse dream --limit 50   # process at most 50 memories`,
+		Example: `  muse distill              # discover memories, reflect, and distill muse
+  muse distill --learn      # re-distill muse from existing reflections
+  muse distill --reflect    # re-reflect on all memories from scratch
+  muse distill --limit 50   # process at most 50 memories`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			store, err := newStore(ctx)
@@ -70,7 +70,7 @@ reprocessing memories. Use --reflect to reprocess all memories from scratch.`,
 					return cerr
 				}
 				log.Printf("Learning with %s\n", client.Model())
-				return runDream(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), store, nil, client, true, false, 0)
+				return runDistill(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), store, nil, client, true, false, 0)
 			}
 			reflectClient, err := bedrock.NewClient(ctx, bedrock.ModelSonnet)
 			if err != nil {
@@ -81,7 +81,7 @@ reprocessing memories. Use --reflect to reprocess all memories from scratch.`,
 				return err
 			}
 			log.Printf("Reflecting with %s, learning with %s\n", reflectClient.Model(), learnClient.Model())
-			return runDream(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), store, reflectClient, learnClient, false, reflect, limit)
+			return runDistill(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), store, reflectClient, learnClient, false, reflect, limit)
 		},
 	}
 	cmd.Flags().BoolVar(&reflect, "reflect", false, "re-reflect on all memories from scratch")
@@ -90,17 +90,17 @@ reprocessing memories. Use --reflect to reprocess all memories from scratch.`,
 	return cmd
 }
 
-// runDream executes the dream pipeline and prints results. Extracted from the
+// runDistill executes the distill pipeline and prints results. Extracted from the
 // command handler so it can be tested with mock dependencies.
-func runDream(ctx context.Context, stdout, stderr io.Writer, store storage.Store, reflectLLM, learnLLM dream.LLM, learn, reflect bool, limit int) error {
+func runDistill(ctx context.Context, stdout, stderr io.Writer, store storage.Store, reflectLLM, learnLLM distill.LLM, learn, reflect bool, limit int) error {
 	var (
-		result *dream.Result
+		result *distill.Result
 		err    error
 	)
 	if learn {
-		result, err = dream.LearnOnly(ctx, store, learnLLM)
+		result, err = distill.LearnOnly(ctx, store, learnLLM)
 	} else {
-		result, err = dream.Run(ctx, store, reflectLLM, learnLLM, dream.Options{Reflect: reflect, Limit: limit})
+		result, err = distill.Run(ctx, store, reflectLLM, learnLLM, distill.Options{Reflect: reflect, Limit: limit})
 	}
 	if err != nil {
 		return err
@@ -111,7 +111,7 @@ func runDream(ctx context.Context, stdout, stderr io.Writer, store storage.Store
 	if !learn {
 		fmt.Fprintf(stdout, "Processed %d memories (%d pruned)\n", result.Processed, result.Pruned)
 		if result.Remaining > 0 {
-			fmt.Fprintf(stdout, "%d memories still pending reflection (run dream again)\n", result.Remaining)
+			fmt.Fprintf(stdout, "%d memories still pending reflection (run distill again)\n", result.Remaining)
 		}
 	}
 	fmt.Fprintf(stdout, "Muse distilled (%dk input, %dk output tokens, $%.2f)\n",

--- a/cmd/muse/distill_test.go
+++ b/cmd/muse/distill_test.go
@@ -13,23 +13,23 @@ import (
 	"github.com/ellistarn/muse/internal/testutil"
 )
 
-func TestDreamCmd_NoStore(t *testing.T) {
+func TestDistillCmd_NoStore(t *testing.T) {
 	// When no bucket is set, local store is used — this test just validates
 	// the command doesn't panic. It will fail at bedrock client creation
 	// which is expected.
 	t.Setenv("MUSE_BUCKET", "")
 }
 
-func TestDreamCmd_LearnNoStore(t *testing.T) {
+func TestDistillCmd_LearnNoStore(t *testing.T) {
 	t.Setenv("MUSE_BUCKET", "")
 }
 
-func TestRunDream_PropagatesRunError(t *testing.T) {
+func TestRunDistill_PropagatesRunError(t *testing.T) {
 	store := &failingStore{err: fmt.Errorf("storage unavailable")}
 	ctx := context.Background()
 	var stdout, stderr bytes.Buffer
 
-	err := runDream(ctx, &stdout, &stderr, store, &testutil.MockLLM{}, &testutil.MockLLM{}, false, false, 100)
+	err := runDistill(ctx, &stdout, &stderr, store, &testutil.MockLLM{}, &testutil.MockLLM{}, false, false, 100)
 	if err == nil {
 		t.Fatal("expected error from failing store, got nil")
 	}
@@ -38,13 +38,13 @@ func TestRunDream_PropagatesRunError(t *testing.T) {
 	}
 }
 
-func TestRunDream_PropagatesLearnError(t *testing.T) {
+func TestRunDistill_PropagatesLearnError(t *testing.T) {
 	store := testutil.NewMemoryStore()
 	store.Reflections["memories/test/sess-1.json"] = "- observation"
 	ctx := context.Background()
 	var stdout, stderr bytes.Buffer
 
-	err := runDream(ctx, &stdout, &stderr, store, nil, &testutil.MockLLM{Err: fmt.Errorf("learn failed")}, true, false, 0)
+	err := runDistill(ctx, &stdout, &stderr, store, nil, &testutil.MockLLM{Err: fmt.Errorf("learn failed")}, true, false, 0)
 	if err == nil {
 		t.Fatal("expected error from failing LLM, got nil")
 	}
@@ -53,7 +53,7 @@ func TestRunDream_PropagatesLearnError(t *testing.T) {
 	}
 }
 
-func TestRunDream_SuccessfulRun(t *testing.T) {
+func TestRunDistill_SuccessfulRun(t *testing.T) {
 	store := testutil.NewMemoryStore()
 	store.AddSession("test", "sess-1", time.Now(), []memory.Message{
 		{Role: "user", Content: "use tabs"},
@@ -69,7 +69,7 @@ func TestRunDream_SuccessfulRun(t *testing.T) {
 	ctx := context.Background()
 	var stdout, stderr bytes.Buffer
 
-	err := runDream(ctx, &stdout, &stderr, store, mockLLM, mockLLM, false, false, 100)
+	err := runDistill(ctx, &stdout, &stderr, store, mockLLM, mockLLM, false, false, 100)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestRunDream_SuccessfulRun(t *testing.T) {
 	}
 }
 
-func TestRunDream_SuccessfulLearn(t *testing.T) {
+func TestRunDistill_SuccessfulLearn(t *testing.T) {
 	store := testutil.NewMemoryStore()
 	store.Reflections["memories/test/sess-1.json"] = "- observation"
 	mockLLM := &testutil.MockLLM{
@@ -91,7 +91,7 @@ func TestRunDream_SuccessfulLearn(t *testing.T) {
 	ctx := context.Background()
 	var stdout, stderr bytes.Buffer
 
-	err := runDream(ctx, &stdout, &stderr, store, nil, mockLLM, true, false, 0)
+	err := runDistill(ctx, &stdout, &stderr, store, nil, mockLLM, true, false, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/muse/root.go
+++ b/cmd/muse/root.go
@@ -21,14 +21,14 @@ muse.md, and embodies your unique thought processes when asked questions.
 
 Workflow:
 
-  1. muse dream      Discover memories, reflect, and distill muse.md
+  1. muse distill    Discover memories, reflect, and distill muse.md
   2. muse show       Print muse.md
   3. muse ask        Ask your muse a question (stateless, one-shot)
   4. muse listen     Start an MCP server so agents can ask your muse
 
 Getting started:
 
-  muse dream && muse show
+  muse distill && muse show
 
 Data is stored locally at ~/.muse/ by default. Set MUSE_BUCKET to use S3 instead.
 
@@ -37,7 +37,7 @@ Run "muse listen --help" for MCP server configuration.`,
 		SilenceUsage:  true,
 	}
 	cmd.PersistentFlags().StringVar(&bucket, "bucket", os.Getenv("MUSE_BUCKET"), "S3 bucket name (or set MUSE_BUCKET)")
-	cmd.AddCommand(newDreamCmd())
+	cmd.AddCommand(newDistillCmd())
 	cmd.AddCommand(newShowCmd())
 	cmd.AddCommand(newListenCmd())
 	cmd.AddCommand(newAskCmd())

--- a/cmd/muse/show.go
+++ b/cmd/muse/show.go
@@ -18,11 +18,11 @@ func newShowCmd() *cobra.Command {
 		Use:   "show",
 		Short: "Print muse.md",
 		Long: `Prints your current muse.md to stdout. If no muse exists yet, prompts
-you to run 'muse dream'.
+you to run 'muse distill'.
 
-Use --diff to summarize what changed since the last dream.`,
+Use --diff to summarize what changed since the last distill.`,
 		Example: `  muse show          # print the muse
-  muse show --diff   # summarize what changed since the last dream`,
+  muse show --diff   # summarize what changed since the last distill`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			store, err := newStore(ctx)
@@ -40,7 +40,7 @@ Use --diff to summarize what changed since the last dream.`,
 				if !storage.IsNotFound(err) {
 					return fmt.Errorf("failed to load muse: %w", err)
 				}
-				fmt.Fprintln(cmd.OutOrStdout(), "No muse found. Run 'muse dream' to generate one from memories.")
+				fmt.Fprintln(cmd.OutOrStdout(), "No muse found. Run 'muse distill' to generate one from memories.")
 				return nil
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), strings.TrimSpace(soul))
@@ -48,7 +48,7 @@ Use --diff to summarize what changed since the last dream.`,
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&diff, "diff", false, "summarize what changed since the last dream")
+	cmd.Flags().BoolVar(&diff, "diff", false, "summarize what changed since the last distill")
 	return cmd
 }
 

--- a/e2e/distill_test.go
+++ b/e2e/distill_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ellistarn/muse/internal/dream"
+	"github.com/ellistarn/muse/internal/distill"
 	"github.com/ellistarn/muse/internal/memory"
 	"github.com/ellistarn/muse/internal/testutil"
 )
 
-func TestDreamPipeline(t *testing.T) {
+func TestDistillPipeline(t *testing.T) {
 	store := testutil.NewMemoryStore()
 	store.AddSession("claude-code", "sess-1", time.Now(), []memory.Message{
 		{Role: "user", Content: "use kebab-case for file names"},
@@ -32,7 +32,7 @@ func TestDreamPipeline(t *testing.T) {
 		LearnResponse:   "## Naming\n\nI use kebab-case for file names.\n\n## Commits\n\nNo emojis. Keep them short.",
 	}
 
-	result, err := dream.Run(context.Background(), store, llm, llm, dream.Options{})
+	result, err := distill.Run(context.Background(), store, llm, llm, distill.Options{})
 	if err != nil {
 		t.Fatalf("Run() error: %v", err)
 	}
@@ -61,11 +61,11 @@ func TestDreamPipeline(t *testing.T) {
 	}
 }
 
-func TestDreamPipelineNoMemories(t *testing.T) {
+func TestDistillPipelineNoMemories(t *testing.T) {
 	store := testutil.NewMemoryStore()
 	llm := &testutil.MockLLM{}
 
-	result, err := dream.Run(context.Background(), store, llm, llm, dream.Options{})
+	result, err := distill.Run(context.Background(), store, llm, llm, distill.Options{})
 	if err != nil {
 		t.Fatalf("Run() error: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestDreamPipelineNoMemories(t *testing.T) {
 	}
 }
 
-func TestDreamPipelineLimit(t *testing.T) {
+func TestDistillPipelineLimit(t *testing.T) {
 	store := testutil.NewMemoryStore()
 	for i := 0; i < 5; i++ {
 		store.AddSession("test", fmt.Sprintf("sess-%d", i), time.Now(), []memory.Message{
@@ -93,7 +93,7 @@ func TestDreamPipelineLimit(t *testing.T) {
 		LearnResponse:   "## Test\n\nContent here.",
 	}
 
-	result, err := dream.Run(context.Background(), store, llm, llm, dream.Options{Limit: 2})
+	result, err := distill.Run(context.Background(), store, llm, llm, distill.Options{Limit: 2})
 	if err != nil {
 		t.Fatalf("Run() error: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestDreamPipelineLimit(t *testing.T) {
 	}
 }
 
-func TestDreamPipelineLimitIncludesPreviousReflections(t *testing.T) {
+func TestDistillPipelineLimitIncludesPreviousReflections(t *testing.T) {
 	store := testutil.NewMemoryStore()
 	for i := 0; i < 4; i++ {
 		store.AddSession("test", fmt.Sprintf("sess-%d", i), time.Now(), []memory.Message{
@@ -126,7 +126,7 @@ func TestDreamPipelineLimitIncludesPreviousReflections(t *testing.T) {
 	}
 
 	// First run: limit to 2, should reflect 2 and learn from 2
-	result, err := dream.Run(context.Background(), store, llm, llm, dream.Options{Limit: 2})
+	result, err := distill.Run(context.Background(), store, llm, llm, distill.Options{Limit: 2})
 	if err != nil {
 		t.Fatalf("first Run() error: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestDreamPipelineLimitIncludesPreviousReflections(t *testing.T) {
 
 	// Second run: limit to 2 again, should reflect 2 more and learn from all 4
 	llm.Calls = nil
-	result, err = dream.Run(context.Background(), store, llm, llm, dream.Options{Limit: 2})
+	result, err = distill.Run(context.Background(), store, llm, llm, distill.Options{Limit: 2})
 	if err != nil {
 		t.Fatalf("second Run() error: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestDreamPipelineLimitIncludesPreviousReflections(t *testing.T) {
 	}
 }
 
-func TestDreamPipelineEmptyConversation(t *testing.T) {
+func TestDistillPipelineEmptyConversation(t *testing.T) {
 	store := testutil.NewMemoryStore()
 	// Session with only empty messages produces no observations
 	store.AddSession("test", "empty", time.Now(), []memory.Message{
@@ -179,7 +179,7 @@ func TestDreamPipelineEmptyConversation(t *testing.T) {
 
 	llm := &testutil.MockLLM{}
 
-	result, err := dream.Run(context.Background(), store, llm, llm, dream.Options{})
+	result, err := distill.Run(context.Background(), store, llm, llm, distill.Options{})
 	if err != nil {
 		t.Fatalf("Run() error: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestDreamPipelineEmptyConversation(t *testing.T) {
 	}
 }
 
-func TestDreamPipelineReflect(t *testing.T) {
+func TestDistillPipelineReflect(t *testing.T) {
 	store := testutil.NewMemoryStore()
 	store.AddSession("test", "sess-1", time.Now(), []memory.Message{
 		{Role: "user", Content: "hello"},
@@ -204,14 +204,14 @@ func TestDreamPipelineReflect(t *testing.T) {
 	}
 
 	// First run
-	_, err := dream.Run(context.Background(), store, llm, llm, dream.Options{})
+	_, err := distill.Run(context.Background(), store, llm, llm, distill.Options{})
 	if err != nil {
 		t.Fatalf("first Run() error: %v", err)
 	}
 
 	// With Reprocess, it should process again even though state would normally prune it
 	llm.Calls = nil
-	result, err := dream.Run(context.Background(), store, llm, llm, dream.Options{Reflect: true})
+	result, err := distill.Run(context.Background(), store, llm, llm, distill.Options{Reflect: true})
 	if err != nil {
 		t.Fatalf("reprocess Run() error: %v", err)
 	}

--- a/internal/distill/distill.go
+++ b/internal/distill/distill.go
@@ -1,4 +1,4 @@
-package dream
+package distill
 
 import (
 	"context"
@@ -16,12 +16,12 @@ import (
 	"github.com/ellistarn/muse/prompts"
 )
 
-// LLM is the subset of an LLM client used by the dream pipeline.
+// LLM is the subset of an LLM client used by the distill pipeline.
 type LLM interface {
 	Converse(ctx context.Context, system, user string, opts ...inference.ConverseOption) (string, inference.Usage, error)
 }
 
-// Result summarizes a dream run.
+// Result summarizes a distill run.
 type Result struct {
 	Processed int
 	Pruned    int
@@ -31,7 +31,7 @@ type Result struct {
 	Warnings  []string
 }
 
-// Options configures a dream run.
+// Options configures a distill run.
 type Options struct {
 	// Reflect ignores persisted reflections and re-reflects all memories.
 	Reflect bool
@@ -42,7 +42,7 @@ type Options struct {
 // estimateTokens is a convenience alias for inference.EstimateTokens.
 var estimateTokens = inference.EstimateTokens
 
-// Run executes the dream pipeline: reflect on new memories, then learn a muse
+// Run executes the distill pipeline: reflect on new memories, then learn a muse
 // from all reflections. Reflections are the source of truth for what has been
 // processed; there is no separate state file.
 func Run(ctx context.Context, store storage.Store, reflectLLM, learnLLM LLM, opts Options) (*Result, error) {
@@ -165,7 +165,7 @@ func Run(ctx context.Context, store storage.Store, reflectLLM, learnLLM LLM, opt
 
 	remaining := totalPending - len(pending)
 	if remaining > 0 {
-		log.Printf("%d memories still pending reflection (run dream again to continue)\n", remaining)
+		log.Printf("%d memories still pending reflection (run distill again to continue)\n", remaining)
 	}
 
 	// Learn from ALL reflections (not just new ones)

--- a/internal/muse/muse.go
+++ b/internal/muse/muse.go
@@ -56,12 +56,12 @@ func New(ctx context.Context, store storage.Store) (*Muse, error) {
 		if !storage.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to load muse: %w", err)
 		}
-		soul = "" // no muse yet — first run before any dreams
+		soul = "" // no muse yet — first run before any distills
 	}
 	if soul != "" {
 		log.Printf("Loaded muse (%d bytes)\n", len(soul))
 	} else {
-		log.Println("No muse found (run 'muse dream' to generate one)")
+		log.Println("No muse found (run 'muse distill' to generate one)")
 	}
 	return &Muse{
 		storage:  store,
@@ -102,7 +102,7 @@ func (m *Muse) Ask(ctx context.Context, input AskInput) (*AskResult, error) {
 		// New conversation
 		soul := m.soul
 		if soul == "" {
-			soul = "No muse available yet. Run 'muse dream' to generate one from memories."
+			soul = "No muse available yet. Run 'muse distill' to generate one from memories."
 		}
 		session = &Session{
 			System: fmt.Sprintf(systemPrompt, soul),

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ellistarn/muse/internal/dream"
+	"github.com/ellistarn/muse/internal/distill"
 	"github.com/ellistarn/muse/internal/inference"
 	"github.com/ellistarn/muse/internal/memory"
 	"github.com/ellistarn/muse/internal/storage"
@@ -17,7 +17,7 @@ import (
 // Compile-time interface checks.
 var (
 	_ storage.Store = (*MemoryStore)(nil)
-	_ dream.LLM     = (*MockLLM)(nil)
+	_ distill.LLM   = (*MockLLM)(nil)
 )
 
 // ---------------------------------------------------------------------------
@@ -152,7 +152,7 @@ type LLMCall struct {
 	User   string
 }
 
-// MockLLM is a test double for dream.LLM that returns canned responses.
+// MockLLM is a test double for distill.LLM that returns canned responses.
 // It dispatches based on whether the system prompt contains
 // "distilling observations" (learn phase) or not (reflect phase).
 type MockLLM struct {

--- a/plans/improve-reflections.md
+++ b/plans/improve-reflections.md
@@ -1,8 +1,8 @@
 # Plan: Improve Reflections
 
-The reflect step is the atomic unit of the dream pipeline: one conversation in, observations out. Even as the pipeline around it evolves, reflect stays. Getting it right is the highest-leverage move.
+The reflect step is the atomic unit of the distill pipeline: one conversation in, observations out. Even as the pipeline around it evolves, reflect stays. Getting it right is the highest-leverage move.
 
-Three changes, all in `internal/dream/`. No new packages.
+Three changes, all in `internal/distill/`. No new packages.
 
 ## 1. Rewrite `reflectPrompt` in `prompts.go`
 
@@ -57,7 +57,7 @@ Key differences from current:
 
 The SKILL.md is the human-readable source of truth. The prompt is its operational form. Keep them in sync. Same changes: default to "produce nothing," emphasize reasoning over surface patterns, add the good/bad example.
 
-## 3. Strip tool data in `formatSession` at `dream.go:284-293`
+## 3. Strip tool data in `formatSession` at `distill.go:284-293`
 
 `formatSession` currently dumps `[role]: content` for every message. Tool call inputs/outputs are the highest-PII payload (file contents, command outputs, API responses). The role/content pairs already capture the human's words and the assistant's reasoning, which is where all the signal lives.
 
@@ -67,9 +67,9 @@ Change: if a message role is `tool` or the content is a tool result, skip it or 
 
 | File | Change |
 |------|--------|
-| `internal/dream/prompts.go:6-21` | Rewrite `reflectPrompt` |
+| `internal/distill/prompts.go:6-21` | Rewrite `reflectPrompt` |
 | `skills/reflect/SKILL.md` | Update to match new prompt |
-| `internal/dream/dream.go:284-293` | Strip tool payloads in `formatSession` |
+| `internal/distill/distill.go:284-293` | Strip tool payloads in `formatSession` |
 
 ## What this does NOT include
 
@@ -80,7 +80,7 @@ Change: if a message role is `tool` or the content is a tool result, skip it or 
 
 ## How to validate
 
-Run `muse dream --reflect` on existing memories and diff the old vs new reflections. Look for:
+Run `muse distill --reflect` on existing memories and diff the old vs new reflections. Look for:
 
 - More `NO_OBSERVATIONS` outputs (good -- means it's not inventing signal)
 - Observations that include reasoning ("because...") rather than just preferences

--- a/plans/pii-defense-in-depth.md
+++ b/plans/pii-defense-in-depth.md
@@ -41,7 +41,7 @@ What it preserves:
 
 Supports user-provided custom redaction terms via config (your name, company names, project names).
 
-Hooks into `reflectOnSession` in `dream.go`, scrubbing the formatted conversation before the LLM call.
+Hooks into `reflectOnSession` in `distill.go`, scrubbing the formatted conversation before the LLM call.
 
 ### Layer 2: Strip tool data in `formatSession`
 
@@ -63,7 +63,7 @@ In `Ask()`, scrub the LLM response before returning it. Last line of defense. If
 
 ### Layer 5: Storage hygiene
 
-After a successful dream, purge processed memories from S3. Raw conversations are only needed until they're reflected on. Skills are the durable artifact. Add `PurgeProcessedMemories` to the storage client.
+After a successful distill, purge processed memories from S3. Raw conversations are only needed until they're reflected on. Skills are the durable artifact. Add `PurgeProcessedMemories` to the storage client.
 
 Also: S3 bucket should have server-side encryption enabled and public access blocked.
 
@@ -88,7 +88,7 @@ The scrubber loads these at initialization and adds them to the pattern list. Th
 | `internal/scrub/scrub.go` (new) | Deterministic regex scrubber |
 | `internal/scrub/patterns.go` (new) | Pattern definitions |
 | `internal/scrub/scrub_test.go` (new) | Table-driven tests for every pattern |
-| `internal/dream/dream.go` | Scrub conversation before reflect, scrub skills after learn |
+| `internal/distill/distill.go` | Scrub conversation before reflect, scrub skills after learn |
 | `internal/muse/muse.go` | Scrub response in `Ask()` |
 | `internal/storage/s3.go` | Add `PurgeProcessedMemories()` |
 


### PR DESCRIPTION
## Summary
- Renames the `dream` CLI command to `distill` — the name now describes the operation (reducing a corpus to its essence) rather than decorating it with a metaphor.
- Updates package name (`internal/dream` -> `internal/distill`), all Go source references, tests, CLI help text, and documentation.