### PR TITLE
Fix muse show returning empty when diff and muse timestamps diverge

### DIFF
--- a/internal/distill/distill.go
+++ b/internal/distill/distill.go
@@ -212,14 +212,14 @@ func Run(ctx context.Context, store storage.Store, reflectLLM, learnLLM LLM, opt
 	previousMuse, _ := store.GetMuse(ctx) // ok if not found (first run)
 
 	log.Printf("Distilling muse from %d reflections...\n", len(allReflections))
-	muse, learnUsage, err := learn(ctx, learnLLM, store, allReflections)
+	muse, timestamp, learnUsage, err := learn(ctx, learnLLM, store, allReflections)
 	if err != nil {
 		return nil, fmt.Errorf("learn failed: %w", err)
 	}
 	log.Printf("Muse distilled ($%.4f)\n", learnUsage.Cost())
 
 	// Diff is a post-processing step, not part of learning.
-	d, diffUsage, derr := computeDiff(ctx, reflectLLM, store, previousMuse, muse)
+	d, diffUsage, derr := computeDiff(ctx, reflectLLM, store, timestamp, previousMuse, muse)
 	if derr != nil {
 		log.Printf("Warning: failed to compute diff: %v\n", derr)
 	}
@@ -254,13 +254,13 @@ func LearnOnly(ctx context.Context, store storage.Store, learnLLM, diffLLM LLM) 
 	previousMuse, _ := store.GetMuse(ctx)
 
 	log.Printf("Re-distilling muse from %d reflections...\n", len(allReflections))
-	muse, usage, err := learn(ctx, learnLLM, store, allReflections)
+	muse, timestamp, usage, err := learn(ctx, learnLLM, store, allReflections)
 	if err != nil {
 		return nil, fmt.Errorf("learn failed: %w", err)
 	}
 	log.Printf("Muse distilled ($%.4f)\n", usage.Cost())
 
-	d, diffUsage, derr := computeDiff(ctx, diffLLM, store, previousMuse, muse)
+	d, diffUsage, derr := computeDiff(ctx, diffLLM, store, timestamp, previousMuse, muse)
 	if derr != nil {
 		log.Printf("Warning: failed to compute diff: %v\n", derr)
 	}
@@ -386,14 +386,14 @@ func buildHumanFocusedView(ctx context.Context, client LLM, turns []turn) ([]str
 	return chunks, totalUsage, nil
 }
 
-func learn(ctx context.Context, client LLM, store storage.Store, observations []string) (string, inference.Usage, error) {
+func learn(ctx context.Context, client LLM, store storage.Store, observations []string) (string, string, inference.Usage, error) {
 	if len(observations) == 0 {
-		return "", inference.Usage{}, nil
+		return "", "", inference.Usage{}, nil
 	}
 	input := strings.Join(observations, "\n\n---\n\n")
 	muse, usage, err := client.Converse(ctx, prompts.Learn, input, inference.WithThinking(16000))
 	if err != nil {
-		return "", usage, err
+		return "", "", usage, err
 	}
 	// Strip markdown code fences the LLM sometimes wraps output in
 	muse = stripCodeFences(muse)
@@ -401,14 +401,14 @@ func learn(ctx context.Context, client LLM, store storage.Store, observations []
 	timestamp := time.Now().UTC().Format(time.RFC3339)
 	log.Printf("Writing muse to muse/versions/%s/...\n", timestamp)
 	if err := store.PutMuse(ctx, timestamp, muse); err != nil {
-		return "", usage, fmt.Errorf("failed to write muse: %w", err)
+		return "", "", usage, fmt.Errorf("failed to write muse: %w", err)
 	}
-	return muse, usage, nil
+	return muse, timestamp, usage, nil
 }
 
 // computeDiff summarizes what changed between two muse versions. On first run
 // (no previous version), writes a static message without an LLM call.
-func computeDiff(ctx context.Context, client LLM, store storage.Store, previous, current string) (string, inference.Usage, error) {
+func computeDiff(ctx context.Context, client LLM, store storage.Store, timestamp, previous, current string) (string, inference.Usage, error) {
 	var d string
 	var usage inference.Usage
 
@@ -424,7 +424,6 @@ func computeDiff(ctx context.Context, client LLM, store storage.Store, previous,
 		d = strings.TrimSpace(d)
 	}
 
-	timestamp := time.Now().UTC().Format(time.RFC3339)
 	if werr := store.PutMuseDiff(ctx, timestamp, d); werr != nil {
 		log.Printf("Warning: failed to write diff: %v\n", werr)
 	}

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -115,16 +115,21 @@ func (l *LocalStore) GetSession(_ context.Context, src, sessionID string) (*conv
 	return &session, nil
 }
 
-// GetMuse returns the latest muse version by finding the most recent timestamp.
+// GetMuse returns the latest muse version by finding the most recent timestamp
+// that contains a muse.md file. Directories with only a diff.md are skipped.
 func (l *LocalStore) GetMuse(_ context.Context) (string, error) {
 	timestamps, err := l.ListMuses(context.Background())
 	if err != nil {
 		return "", err
 	}
-	if len(timestamps) == 0 {
-		return "", &NotFoundError{Key: "muse/versions/"}
+	// Walk backwards to find the latest timestamp that has a muse.md
+	for i := len(timestamps) - 1; i >= 0; i-- {
+		content, err := l.GetMuseVersion(context.Background(), timestamps[i])
+		if err == nil {
+			return content, nil
+		}
 	}
-	return l.GetMuseVersion(context.Background(), timestamps[len(timestamps)-1])
+	return "", &NotFoundError{Key: "muse/versions/"}
 }
 
 // PutMuse writes a muse version at the given timestamp.

--- a/internal/storage/local_test.go
+++ b/internal/storage/local_test.go
@@ -147,6 +147,33 @@ func TestLocalStore_MuseRoundTrip(t *testing.T) {
 	}
 }
 
+func TestLocalStore_GetMuse_SkipsDiffOnly(t *testing.T) {
+	store := newTestLocalStore(t)
+	ctx := context.Background()
+
+	// Write a real muse at ts1
+	ts1 := "2025-01-01T10-00-00"
+	content1 := "# Muse v1"
+	if err := store.PutMuse(ctx, ts1, content1); err != nil {
+		t.Fatalf("PutMuse: %v", err)
+	}
+
+	// Write only a diff at ts2 (simulating the old bug where timestamps diverged)
+	ts2 := "2025-01-02T10-00-00"
+	if err := store.PutMuseDiff(ctx, ts2, "some diff"); err != nil {
+		t.Fatalf("PutMuseDiff: %v", err)
+	}
+
+	// GetMuse should skip ts2 (no muse.md) and return ts1's content
+	got, err := store.GetMuse(ctx)
+	if err != nil {
+		t.Fatalf("GetMuse: %v", err)
+	}
+	if got != content1 {
+		t.Errorf("GetMuse = %q, want %q", got, content1)
+	}
+}
+
 func TestLocalStore_ListMuses(t *testing.T) {
 	store := newTestLocalStore(t)
 	ctx := context.Background()

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -116,10 +116,14 @@ func (c *S3Store) GetMuse(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if len(timestamps) == 0 {
-		return "", &NotFoundError{Key: "muse/versions/"}
+	// Walk backwards to find the latest timestamp that has a muse.md
+	for i := len(timestamps) - 1; i >= 0; i-- {
+		content, err := c.GetMuseVersion(ctx, timestamps[i])
+		if err == nil {
+			return content, nil
+		}
 	}
-	return c.GetMuseVersion(ctx, timestamps[len(timestamps)-1])
+	return "", &NotFoundError{Key: "muse/versions/"}
 }
 
 // PutMuse writes a muse version at the given timestamp.


### PR DESCRIPTION
## Summary
- `learn()` and `computeDiff()` each called `time.Now()` independently, so `PutMuse` and `PutMuseDiff` wrote to different timestamp directories. `GetMuse` picked the latest (diff-only) directory and reported "No muse found."
- Fix the root cause by having `learn()` return its timestamp and passing it to `computeDiff()` so both files land in the same version directory.
- Make `GetMuse()` defensive in both local and S3 stores — walk backwards through timestamps to find the latest directory that actually contains a `muse.md`, handling already-corrupted state on disk.