### PR TITLE
Document logging convention at internal/log package

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,3 +1,7 @@
+// Package log provides timestamped logging to stderr for diagnostic and
+// progress output. All operational messages should use this package.
+// User-facing output (results, streaming responses) goes to stdout via fmt.
+// Never write directly to os.Stderr outside this package.
 package log
 
 import (


### PR DESCRIPTION
## Summary
- Add package doc comment to `internal/log` clarifying the two-tier logging convention: timestamped diagnostic output via this package, user-facing output via `fmt` to stdout.