### PR TITLE
designs: observations (#009), editorial composition (#010), generative evals (#011)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,27 @@ Or run as an MCP server so other agents can work with your muse:
 }
 ```
 
+## Peer Muses
+
+Build a muse for someone else from their public GitHub activity. Useful for anticipating
+how a reviewer thinks before submitting a PR.
+
+```bash
+muse compose github/ellistarn --project karpenter    # build a peer muse
+muse ask --peer github/ellistarn --project karpenter "Review this design"
+```
+
+`--project` narrows to specific repositories. Unqualified names (e.g. `karpenter`) resolve
+by searching GitHub for repos where the target has activity. Qualified names
+(e.g. `aws/karpenter-provider-aws`) match exactly.
+
+Peer muses are stored under `~/.muse/peers/` separately from the owner's muse. No
+credentials from the target are needed — the data is public.
+
+```bash
+muse eval --generative --peer github/ellistarn --project karpenter  # evaluate the peer muse
+```
+
 ## Sources
 
 Local sources are activated automatically on first run: **Claude Code**, **OpenCode**, **Codex**, **Kiro**.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ muse eval                 # evaluate the muse against a base model
 muse listen               # start MCP server
 muse show                 # print muse.md
 muse show -o muse.pdf     # export as PDF
+
+# build a peer muse from public GitHub activity
+muse compose github/ellistarn --project karpenter
+muse ask --peer github/ellistarn --project karpenter "Review this design"
 ```
 
 Work directly with your muse as agent:
@@ -38,27 +42,6 @@ Or run as an MCP server so other agents can work with your muse:
     }
   }
 }
-```
-
-## Peer Muses
-
-Build a muse for someone else from their public GitHub activity. Useful for anticipating
-how a reviewer thinks before submitting a PR.
-
-```bash
-muse compose github/ellistarn --project karpenter    # build a peer muse
-muse ask --peer github/ellistarn --project karpenter "Review this design"
-```
-
-`--project` narrows to specific repositories. Unqualified names (e.g. `karpenter`) resolve
-by searching GitHub for repos where the target has activity. Qualified names
-(e.g. `aws/karpenter-provider-aws`) match exactly.
-
-Peer muses are stored under `~/.muse/peers/` separately from the owner's muse. No
-credentials from the target are needed — the data is public.
-
-```bash
-muse eval --generative --peer github/ellistarn --project karpenter  # evaluate the peer muse
 ```
 
 ## Sources

--- a/cmd/compose_team.go
+++ b/cmd/compose_team.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ellistarn/muse/internal/inference"
+	"github.com/ellistarn/muse/internal/storage"
+)
+
+const teamComposePrompt = `You are synthesizing validated reviewer observations into a team review guide.
+
+Each observation has been scored by how well it predicts what the reviewer actually says in
+code reviews. Higher weights mean stronger predictive value. Negative weights mean the
+observation led the muse astray.
+
+RULES:
+
+1. Observations with weight >= 2 are validated signals. Preserve at full strength. If
+   distinctive to one reviewer, give prominent treatment.
+
+2. Observations with weight 0-2 are mild or unvalidated. Include only if they reinforce
+   higher-weighted patterns.
+
+3. Observations with negative weight are harmful. Cut them.
+
+4. Observations that score high for one reviewer but zero or negative for others are
+   DISTINCTIVE. These are the team muse's primary value over a base model. Give them
+   dedicated sections, not bullets in shared lists.
+
+5. Observations that score moderately across all reviewers are SHARED. The base model
+   catches most of these. Compress them.
+
+6. Order by signal strength: distinctive patterns first, shared patterns second.
+
+7. Write in third person, attributing patterns to specific reviewers. Every sentence
+   should change how the muse reviews code.`
+
+func newComposeTeamCmd() *cobra.Command {
+	var project string
+
+	cmd := &cobra.Command{
+		Use:   "compose-team",
+		Short: "Compose a team muse from validated observations",
+		Long: `Validates observations from multiple peer muses by asking each reviewer's muse
+to reinforce (+1), ignore (0), or reject (-1) each observation. Then composes a
+team muse weighted by the muse's own judgment of what matters.`,
+		Example: `  muse compose-team --project karpenter github/ellistarn github/jmdeal github/tzneal github/DerekFrank`,
+		Args:    cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			// Validate observations for each peer
+			var allWeighted []weightedObservation
+			for _, peerFlag := range args {
+				_, username, err := parsePeerFlag(peerFlag)
+				if err != nil {
+					return err
+				}
+				weighted, err := validateObservations(ctx, username, project)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "warning: skipping %s: %v\n", peerFlag, err)
+					continue
+				}
+				allWeighted = append(allWeighted, weighted...)
+			}
+
+			if len(allWeighted) == 0 {
+				return fmt.Errorf("no validated observations from any peer")
+			}
+
+			// Compose team muse from weighted observations
+			fmt.Fprintf(os.Stderr, "\ncomposing team muse from %d weighted observations...\n", len(allWeighted))
+			teamMuse, err := composeTeamMuse(ctx, allWeighted)
+			if err != nil {
+				return fmt.Errorf("compose team muse: %w", err)
+			}
+
+			// Save
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return err
+			}
+			teamDir := filepath.Join(home, ".muse", "peers", "github-karpenter-team", project)
+			teamStore := storage.NewLocalStoreWithRoot(teamDir)
+			ts := time.Now().UTC().Format(time.RFC3339)
+			if err := teamStore.PutMuse(ctx, ts, teamMuse); err != nil {
+				return fmt.Errorf("save team muse: %w", err)
+			}
+
+			fmt.Fprintf(os.Stderr, "team muse saved to %s\n", filepath.Join(teamDir, "muse.md"))
+			fmt.Print(teamMuse)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&project, "project", "", "project scope")
+	return cmd
+}
+
+// composeTeamMuse calls the LLM with weighted observations to produce a team muse.
+func composeTeamMuse(ctx context.Context, weighted []weightedObservation) (string, error) {
+	// Group by reviewer
+	byReviewer := make(map[string][]weightedObservation)
+	for _, w := range weighted {
+		byReviewer[w.Reviewer] = append(byReviewer[w.Reviewer], w)
+	}
+
+	// Build input: observations grouped by reviewer, sorted by weight descending
+	var parts []string
+	for reviewer, obs := range byReviewer {
+		sort.Slice(obs, func(i, j int) bool {
+			return obs[i].Weight > obs[j].Weight
+		})
+
+		var lines []string
+		lines = append(lines, fmt.Sprintf("## %s", reviewer))
+		lines = append(lines, "")
+		for _, o := range obs {
+			lines = append(lines, fmt.Sprintf("[%+.1f] %s", o.Weight, o.Text))
+		}
+		parts = append(parts, strings.Join(lines, "\n"))
+	}
+	input := strings.Join(parts, "\n\n---\n\n")
+
+	llm, err := newLLMClient(ctx, TierStrong)
+	if err != nil {
+		return "", err
+	}
+
+	resp, usage, err := inference.Converse(ctx, llm, teamComposePrompt, input, inference.WithMaxTokens(16384))
+	if err != nil {
+		return "", err
+	}
+	fmt.Fprintf(os.Stderr, "  tokens: input=%d output=%d\n", usage.InputTokens, usage.OutputTokens)
+	return resp, nil
+}

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -64,6 +64,11 @@ type cachedResponse struct {
 
 func newEvalCmd() *cobra.Command {
 	var evalDir string
+	var generative bool
+	var peer string
+	var project string
+	var genLimit int
+	var museOverride string
 
 	cmd := &cobra.Command{
 		Use:   "eval",
@@ -80,12 +85,27 @@ A separate preference judge picks which response demonstrates better overall
 judgment, capturing signal the dimension scores may miss.
 
 Questions include universal judgment probes plus domain-specific questions
-generated from the muse.md to measure transferability.`,
+generated from the muse.md to measure transferability.
+
+Use --generative to run held-out evaluation against real conversations:
+  muse eval --generative --peer github/ellistarn --project karpenter`,
 		Example: `  muse eval
   muse eval -v
-  muse eval --dir ./my-questions`,
+  muse eval --dir ./my-questions
+  muse eval --generative --peer github/ellistarn --project karpenter`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+
+			if generative {
+				if peer == "" {
+					return fmt.Errorf("--generative requires --peer (e.g. --peer github/ellistarn)")
+				}
+				_, username, err := parsePeerFlag(peer)
+				if err != nil {
+					return err
+				}
+				return runGenerativeEval(ctx, username, project, genLimit, museOverride)
+			}
 			store, err := newStore(ctx)
 			if err != nil {
 				return err
@@ -164,6 +184,11 @@ generated from the muse.md to measure transferability.`,
 		},
 	}
 	cmd.Flags().StringVar(&evalDir, "dir", "", "directory of additional .md question files")
+	cmd.Flags().BoolVar(&generative, "generative", false, "run held-out generative evaluation against real conversations")
+	cmd.Flags().StringVar(&peer, "peer", "", "peer muse to evaluate (e.g. github/ellistarn)")
+	cmd.Flags().StringVar(&project, "project", "", "project scope for generative eval")
+	cmd.Flags().IntVar(&genLimit, "cases", 0, "max test cases for generative eval (0 = auto)")
+	cmd.Flags().StringVar(&museOverride, "muse-override", "", "path to muse.md file to use instead of peer's own muse")
 	return cmd
 }
 

--- a/cmd/eval_generative.go
+++ b/cmd/eval_generative.go
@@ -1,0 +1,549 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/ellistarn/muse/internal/compose"
+	"github.com/ellistarn/muse/internal/conversation"
+	"github.com/ellistarn/muse/internal/inference"
+	"github.com/ellistarn/muse/internal/muse"
+	"github.com/ellistarn/muse/internal/storage"
+)
+
+// genEvalCase is a single test case for generative evaluation.
+type genEvalCase struct {
+	ConversationID string
+	Context        string // PR diff + prior comments (everything before the target's comment)
+	GroundTruth    string // what the person actually said
+	ContextType    string // "first-comment", "thread-response", "question-response"
+}
+
+// genEvalResult holds scores for one test case.
+type genEvalResult struct {
+	Case         genEvalCase
+	MuseResponse string
+	BaseResponse string
+	MuseScore    genScore
+	BaseScore    genScore
+	Error        error
+}
+
+// genScore holds alignment scores for one response against ground truth.
+type genScore struct {
+	Recall        float64 // weighted fraction of ground truth concerns identified
+	Precision     float64 // weighted fraction of response concerns matching ground truth
+	PriorityMatch bool    // top concern matches
+	MuseConcerns  int
+	TruthConcerns int
+	MatchedWeight float64 // sum of (match_score * severity_weight) for matched truth concerns
+	TotalWeight   float64 // sum of severity_weight for all truth concerns
+}
+
+// concern is an extracted review concern.
+type concern struct {
+	Text     string `json:"concern"`
+	Severity string `json:"severity"` // "blocking", "advisory", "suggestive"
+}
+
+// severityWeight returns the weight for a concern severity level.
+func severityWeight(severity string) float64 {
+	switch severity {
+	case "blocking":
+		return 1.0
+	case "advisory":
+		return 0.5
+	case "suggestive":
+		return 0.25
+	default:
+		return 0.5 // default to advisory
+	}
+}
+
+const extractPrompt = `Extract the distinct review concerns from this code review comment.
+Each concern is one actionable item — a distinct thing the reviewer wants changed or flagged.
+A broad claim supported by specific instances is one concern, not multiple.
+
+Classify each concern by severity:
+- "blocking": the reviewer is blocking on this, it must change ("this does not belong here", "this is wrong", "this will break")
+- "advisory": the reviewer wants a change but is not blocking ("consider", "should", "let's")
+- "suggestive": the reviewer is floating an idea or preference ("maybe", "might be nice", "could")
+
+Return a JSON array of objects with "concern" and "severity" fields.
+If the comment has no substantive review concerns (e.g. "LGTM", "looks good"), return an empty array.
+
+Review comment:
+%s`
+
+const alignPrompt = `You are comparing two lists of code review concerns to measure alignment.
+
+Ground truth concerns (what the reviewer actually said):
+%s
+
+Predicted concerns (what the muse predicted):
+%s
+
+For each ground truth concern, find the best matching predicted concern. Score each match:
+- 1.0 if the predicted concern identifies the same issue with similar reasoning
+- 0.5 if the predicted concern is in the same area but frames the issue differently
+- 0.0 if no predicted concern matches
+
+Also identify which predicted concerns have no match in ground truth.
+
+Return JSON:
+{
+  "matches": [{"truth": "...", "predicted": "...", "score": 0.0}],
+  "unmatched_predicted": ["..."],
+  "top_truth_concern": "...",
+  "top_predicted_concern": "..."
+}`
+
+// runGenerativeEval runs the held-out generative evaluation.
+// If museOverride is non-empty, it is read as a file path and used as the muse
+// document instead of the peer's own muse. This allows testing the team muse
+// against an individual reviewer's held-out conversations.
+func runGenerativeEval(ctx context.Context, peer, project string, limit int, museOverride string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	pd := fmt.Sprintf("github-%s", peer)
+	if project != "" {
+		pd = fmt.Sprintf("github-%s/%s", peer, project)
+	}
+	peerRoot := filepath.Join(home, ".muse", "peers", pd)
+	store := storage.NewLocalStoreWithRoot(peerRoot)
+
+	// Load muse: override file or peer's own muse
+	var document string
+	if museOverride != "" {
+		data, err := os.ReadFile(museOverride)
+		if err != nil {
+			return fmt.Errorf("failed to read muse override %s: %w", museOverride, err)
+		}
+		document = string(data)
+	} else {
+		doc, err := store.GetMuse(ctx)
+		if err != nil {
+			return fmt.Errorf("no muse found for peer %s (run: muse compose github/%s --project %s)", peer, peer, project)
+		}
+		document = doc
+	}
+
+	// Load all conversations
+	entries, err := store.ListConversations(ctx)
+	if err != nil {
+		return fmt.Errorf("list conversations: %w", err)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].LastModified.After(entries[j].LastModified)
+	})
+
+	// Split: 20% holdout, min 5, max 30
+	testSize := len(entries) / 5
+	if testSize < 5 {
+		testSize = 5
+	}
+	if testSize > 30 {
+		testSize = 30
+	}
+	if testSize > len(entries) {
+		return fmt.Errorf("not enough conversations (%d) for evaluation (need at least 5)", len(entries))
+	}
+	if limit > 0 && testSize > limit {
+		testSize = limit
+	}
+
+	// Scan more entries than testSize to find enough usable cases,
+	// since many conversations won't have context before the target's comment.
+	scanSize := testSize * 5
+	if scanSize > len(entries) {
+		scanSize = len(entries)
+	}
+	scanEntries := entries[:scanSize]
+
+	// Build test cases from held-out conversations
+	var cases []genEvalCase
+	for _, entry := range scanEntries {
+		conv, err := store.GetConversation(ctx, entry.Source, entry.ConversationID)
+		if err != nil {
+			continue
+		}
+		c := buildGenEvalCase(conv, peer)
+		if c != nil {
+			cases = append(cases, *c)
+			if testSize > 0 && len(cases) >= testSize {
+				break
+			}
+		}
+	}
+
+	if len(cases) == 0 {
+		return fmt.Errorf("no usable test cases found")
+	}
+
+	fmt.Fprintf(os.Stderr, "generative eval  %d cases  peer=github/%s/%s\n\n", len(cases), peer, project)
+
+	// Run evaluation
+	llm, err := newLLMClient(ctx, TierStrong)
+	if err != nil {
+		return err
+	}
+
+	withMuse := muse.New(llm, document)
+	withoutMuse := muse.New(llm, "")
+	museHash := compose.Fingerprint(document)[:12]
+
+	results := make([]genEvalResult, len(cases))
+	var mu sync.Mutex
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(8)
+
+	for i, c := range cases {
+		g.Go(func() error {
+			r := runGenEvalCase(ctx, llm, withMuse, withoutMuse, c, store, museHash)
+			mu.Lock()
+			results[i] = r
+			mu.Unlock()
+
+			symbol := "  "
+			if r.Error != nil {
+				symbol = "!"
+			} else if r.MuseScore.Recall > r.BaseScore.Recall {
+				symbol = "+"
+			} else if r.MuseScore.Recall < r.BaseScore.Recall {
+				symbol = "-"
+			}
+			fmt.Fprintf(os.Stderr, "  %s %-40s recall=%.2f/%.2f  precision=%.2f/%.2f\n",
+				symbol,
+				truncate(c.ConversationID, 40),
+				r.MuseScore.Recall, r.BaseScore.Recall,
+				r.MuseScore.Precision, r.BaseScore.Precision,
+			)
+			return nil
+		})
+	}
+	g.Wait()
+
+	// Print summary
+	printGenEvalSummary(os.Stdout, results)
+	return nil
+}
+
+// buildGenEvalCase extracts context and ground truth from a conversation.
+// The context is everything before the target's first substantive message.
+// The ground truth is the target's first substantive message.
+func buildGenEvalCase(conv *conversation.Conversation, targetUser string) *genEvalCase {
+	var contextParts []string
+	var groundTruth string
+	contextType := "first-comment"
+
+	for _, msg := range conv.Messages {
+		if msg.Role == "user" && groundTruth == "" {
+			// This is the target's first message — it's the ground truth
+			if len(strings.Fields(msg.Content)) < 10 {
+				return nil // too short to be a substantive review
+			}
+			groundTruth = msg.Content
+			if len(contextParts) > 0 {
+				contextType = "thread-response"
+			}
+		} else if groundTruth == "" {
+			// Context: everything before the target's first message
+			contextParts = append(contextParts, msg.Content)
+		}
+	}
+
+	if groundTruth == "" || len(contextParts) == 0 {
+		return nil
+	}
+
+	return &genEvalCase{
+		ConversationID: conv.ConversationID,
+		Context:        strings.Join(contextParts, "\n\n---\n\n"),
+		GroundTruth:    groundTruth,
+		ContextType:    contextType,
+	}
+}
+
+// runGenEvalCase evaluates a single test case with response caching.
+func runGenEvalCase(ctx context.Context, llm inference.Client, withMuse, withoutMuse *muse.Muse, c genEvalCase, store storage.Store, museHash string) genEvalResult {
+	result := genEvalResult{Case: c}
+	question := fmt.Sprintf("Review this code/discussion. What would you flag?\n\n%s", c.Context)
+
+	// Cache keys: conversation + model + muse hash
+	baseFP := compose.Fingerprint(c.ConversationID, llm.Model())
+	museFP := compose.Fingerprint(c.ConversationID, llm.Model(), museHash)
+	baseKey := fmt.Sprintf("eval/generative/baseline/%s.json", baseFP[:16])
+	museKey := fmt.Sprintf("eval/generative/muse/%s.json", museFP[:16])
+
+	// Generate muse response (cached)
+	if cached, err := loadCachedResponse(ctx, store, museKey, museFP); err == nil {
+		result.MuseResponse = cached
+	} else {
+		museResult, err := withMuse.Ask(ctx, muse.AskInput{Question: question, New: true})
+		if err != nil {
+			result.Error = fmt.Errorf("muse ask: %w", err)
+			return result
+		}
+		result.MuseResponse = museResult.Response
+		saveCachedResponse(ctx, store, museKey, museFP, result.MuseResponse)
+	}
+
+	// Generate baseline response (cached)
+	if cached, err := loadCachedResponse(ctx, store, baseKey, baseFP); err == nil {
+		result.BaseResponse = cached
+	} else {
+		baseResult, err := withoutMuse.Ask(ctx, muse.AskInput{Question: question, New: true})
+		if err != nil {
+			result.Error = fmt.Errorf("base ask: %w", err)
+			return result
+		}
+		result.BaseResponse = baseResult.Response
+		saveCachedResponse(ctx, store, baseKey, baseFP, result.BaseResponse)
+	}
+
+	// Score both against ground truth
+	result.MuseScore = scoreAlignment(ctx, llm, c.GroundTruth, result.MuseResponse)
+	result.BaseScore = scoreAlignment(ctx, llm, c.GroundTruth, result.BaseResponse)
+
+	return result
+}
+
+// scoreAlignment runs the three-step judge pipeline.
+func scoreAlignment(ctx context.Context, llm inference.Client, groundTruth, response string) genScore {
+	// Step 1: Extract concerns from ground truth
+	truthConcerns := extractConcerns(ctx, llm, groundTruth)
+	// Step 2: Extract concerns from response (same prompt)
+	responseConcerns := extractConcerns(ctx, llm, response)
+
+	totalWeight := 0.0
+	for _, c := range truthConcerns {
+		totalWeight += severityWeight(c.Severity)
+	}
+
+	if len(truthConcerns) == 0 {
+		return genScore{Recall: 1.0, Precision: 0.0, TruthConcerns: 0, MuseConcerns: len(responseConcerns), TotalWeight: 0}
+	}
+	if len(responseConcerns) == 0 {
+		return genScore{Recall: 0.0, Precision: 0.0, TruthConcerns: len(truthConcerns), MuseConcerns: 0, TotalWeight: totalWeight}
+	}
+
+	// Step 3: Align and score
+	alignment := alignConcerns(ctx, llm, truthConcerns, responseConcerns)
+	return alignment
+}
+
+// extractConcerns calls the LLM to extract review concerns with severity.
+func extractConcerns(ctx context.Context, llm inference.Client, text string) []concern {
+	prompt := fmt.Sprintf(extractPrompt, text)
+	resp, _, err := inference.Converse(ctx, llm, "You extract structured review concerns.", prompt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "    extractConcerns error: %v\n", err)
+		return nil
+	}
+	text = resp
+
+	// Parse JSON array from response
+	raw := strings.TrimSpace(text)
+	start := strings.Index(raw, "[")
+	end := strings.LastIndex(raw, "]")
+	if start < 0 || end < 0 || end <= start {
+		return nil
+	}
+	raw = raw[start : end+1]
+
+	var concerns []concern
+	if err := json.Unmarshal([]byte(raw), &concerns); err != nil {
+		return nil
+	}
+
+	var result []concern
+	for _, c := range concerns {
+		if c.Text != "" {
+			if c.Severity == "" {
+				c.Severity = "advisory"
+			}
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
+// alignResult is the parsed output of the alignment judge.
+type alignResult struct {
+	Matches             []alignMatch `json:"matches"`
+	UnmatchedPredicted  []string     `json:"unmatched_predicted"`
+	TopTruthConcern     string       `json:"top_truth_concern"`
+	TopPredictedConcern string       `json:"top_predicted_concern"`
+}
+
+type alignMatch struct {
+	Truth     string  `json:"truth"`
+	Predicted string  `json:"predicted"`
+	Score     float64 `json:"score"`
+}
+
+// alignConcerns calls the LLM to align two concern lists, weighting by severity.
+func alignConcerns(ctx context.Context, llm inference.Client, truthConcerns, responseConcerns []concern) genScore {
+	// Build severity lookup by concern text
+	severityMap := make(map[string]string)
+	for _, c := range truthConcerns {
+		severityMap[c.Text] = c.Severity
+	}
+
+	// Extract text for alignment prompt
+	truthTexts := make([]string, len(truthConcerns))
+	for i, c := range truthConcerns {
+		truthTexts[i] = c.Text
+	}
+	responseTexts := make([]string, len(responseConcerns))
+	for i, c := range responseConcerns {
+		responseTexts[i] = c.Text
+	}
+
+	truthJSON, _ := json.Marshal(truthTexts)
+	responseJSON, _ := json.Marshal(responseTexts)
+
+	prompt := fmt.Sprintf(alignPrompt, string(truthJSON), string(responseJSON))
+	text, _, err := inference.Converse(ctx, llm, "You align code review concerns.", prompt)
+	if err != nil {
+		return genScore{TruthConcerns: len(truthConcerns), MuseConcerns: len(responseConcerns)}
+	}
+
+	raw := strings.TrimSpace(text)
+	start := strings.Index(raw, "{")
+	end := strings.LastIndex(raw, "}")
+	if start < 0 || end < 0 || end <= start {
+		return genScore{TruthConcerns: len(truthConcerns), MuseConcerns: len(responseConcerns)}
+	}
+
+	var result alignResult
+	if err := json.Unmarshal([]byte(raw[start:end+1]), &result); err != nil {
+		return genScore{TruthConcerns: len(truthConcerns), MuseConcerns: len(responseConcerns)}
+	}
+
+	// Compute weighted recall: sum(match_score * severity_weight) / sum(severity_weight)
+	totalWeight := 0.0
+	for _, c := range truthConcerns {
+		totalWeight += severityWeight(c.Severity)
+	}
+
+	matchedWeight := 0.0
+	for _, m := range result.Matches {
+		w := severityWeight(severityMap[m.Truth])
+		matchedWeight += m.Score * w
+	}
+	recall := matchedWeight / totalWeight
+
+	// Precision: unweighted (muse concerns don't have ground-truth severity)
+	totalMatch := 0.0
+	for _, m := range result.Matches {
+		totalMatch += m.Score
+	}
+	precision := totalMatch / float64(len(responseConcerns))
+
+	// Priority alignment
+	priorityMatch := result.TopTruthConcern != "" &&
+		result.TopPredictedConcern != "" &&
+		result.TopTruthConcern == result.TopPredictedConcern
+
+	return genScore{
+		Recall:        math.Min(recall, 1.0),
+		Precision:     math.Min(precision, 1.0),
+		PriorityMatch: priorityMatch,
+		TruthConcerns: len(truthConcerns),
+		MuseConcerns:  len(responseConcerns),
+		MatchedWeight: matchedWeight,
+		TotalWeight:   totalWeight,
+	}
+}
+
+func printGenEvalSummary(w io.Writer, results []genEvalResult) {
+	var museMatchedWeight, baseMatchedWeight, totalWeight float64
+	var musePrecision, basePrecision float64
+	var museWins, baseWins, ties int
+	var validCount int
+
+	for _, r := range results {
+		if r.Error != nil {
+			continue
+		}
+		validCount++
+
+		// Pool globally: accumulate matched weight and total weight across all cases
+		museMatchedWeight += r.MuseScore.MatchedWeight
+		baseMatchedWeight += r.BaseScore.MatchedWeight
+		totalWeight += r.MuseScore.TotalWeight // same ground truth for both
+
+		musePrecision += r.MuseScore.Precision
+		basePrecision += r.BaseScore.Precision
+
+		// Win/loss by weighted recall per case
+		if r.MuseScore.Recall > r.BaseScore.Recall {
+			museWins++
+		} else if r.BaseScore.Recall > r.MuseScore.Recall {
+			baseWins++
+		} else {
+			ties++
+		}
+	}
+
+	if validCount == 0 {
+		fmt.Fprintln(w, "No valid results.")
+		return
+	}
+
+	n := float64(validCount)
+	museRecall := museMatchedWeight / totalWeight
+	baseRecall := baseMatchedWeight / totalWeight
+
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "                    Muse    Base    Delta\n")
+	fmt.Fprintf(w, "  ────────────────────────────────────────\n")
+	fmt.Fprintf(w, "  Recall (wt)       %.2f    %.2f    %+.2f\n", museRecall, baseRecall, museRecall-baseRecall)
+	fmt.Fprintf(w, "  Precision         %.2f    %.2f    %+.2f\n", musePrecision/n, basePrecision/n, (musePrecision-basePrecision)/n)
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "  Muse better: %d/%d  Base better: %d/%d  Tied: %d/%d\n",
+		museWins, validCount, baseWins, validCount, ties, validCount)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-3] + "..."
+}
+
+// parsePeerFlag validates a "source/username" peer flag and returns the
+// source and username. Currently only "github" is supported as a source.
+func parsePeerFlag(peer string) (source, username string, err error) {
+	parts := strings.SplitN(peer, "/", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid peer format %q (use source/username, e.g. github/ellistarn)", peer)
+	}
+	if parts[0] != "github" {
+		return "", "", fmt.Errorf("unsupported peer source %q (only github is supported)", parts[0])
+	}
+	return parts[0], parts[1], nil
+}
+
+func peerDir(peer, project string) string {
+	parts := strings.SplitN(peer, "/", 2)
+	dir := fmt.Sprintf("github-%s", parts[1])
+	if project != "" {
+		dir = fmt.Sprintf("github-%s/%s", parts[1], project)
+	}
+	return dir
+}

--- a/cmd/eval_generative.go
+++ b/cmd/eval_generative.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ellistarn/muse/internal/inference"
 	"github.com/ellistarn/muse/internal/muse"
 	"github.com/ellistarn/muse/internal/storage"
+	"github.com/ellistarn/muse/prompts"
 )
 
 // genEvalCase is a single test case for generative evaluation.
@@ -69,44 +70,6 @@ func severityWeight(severity string) float64 {
 		return 0.5 // default to advisory
 	}
 }
-
-const extractPrompt = `Extract the distinct review concerns from this code review comment.
-Each concern is one actionable item — a distinct thing the reviewer wants changed or flagged.
-A broad claim supported by specific instances is one concern, not multiple.
-
-Classify each concern by severity:
-- "blocking": the reviewer is blocking on this, it must change ("this does not belong here", "this is wrong", "this will break")
-- "advisory": the reviewer wants a change but is not blocking ("consider", "should", "let's")
-- "suggestive": the reviewer is floating an idea or preference ("maybe", "might be nice", "could")
-
-Return a JSON array of objects with "concern" and "severity" fields.
-If the comment has no substantive review concerns (e.g. "LGTM", "looks good"), return an empty array.
-
-Review comment:
-%s`
-
-const alignPrompt = `You are comparing two lists of code review concerns to measure alignment.
-
-Ground truth concerns (what the reviewer actually said):
-%s
-
-Predicted concerns (what the muse predicted):
-%s
-
-For each ground truth concern, find the best matching predicted concern. Score each match:
-- 1.0 if the predicted concern identifies the same issue with similar reasoning
-- 0.5 if the predicted concern is in the same area but frames the issue differently
-- 0.0 if no predicted concern matches
-
-Also identify which predicted concerns have no match in ground truth.
-
-Return JSON:
-{
-  "matches": [{"truth": "...", "predicted": "...", "score": 0.0}],
-  "unmatched_predicted": ["..."],
-  "top_truth_concern": "...",
-  "top_predicted_concern": "..."
-}`
 
 // runGenerativeEval runs the held-out generative evaluation.
 // If museOverride is non-empty, it is read as a file path and used as the muse
@@ -347,8 +310,7 @@ func scoreAlignment(ctx context.Context, llm inference.Client, groundTruth, resp
 
 // extractConcerns calls the LLM to extract review concerns with severity.
 func extractConcerns(ctx context.Context, llm inference.Client, text string) []concern {
-	prompt := fmt.Sprintf(extractPrompt, text)
-	resp, _, err := inference.Converse(ctx, llm, "You extract structured review concerns.", prompt)
+	resp, _, err := inference.Converse(ctx, llm, prompts.ExtractConcerns, text)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "    extractConcerns error: %v\n", err)
 		return nil
@@ -416,8 +378,8 @@ func alignConcerns(ctx context.Context, llm inference.Client, truthConcerns, res
 	truthJSON, _ := json.Marshal(truthTexts)
 	responseJSON, _ := json.Marshal(responseTexts)
 
-	prompt := fmt.Sprintf(alignPrompt, string(truthJSON), string(responseJSON))
-	text, _, err := inference.Converse(ctx, llm, "You align code review concerns.", prompt)
+	input := fmt.Sprintf("Ground truth concerns:\n%s\n\nPredicted concerns:\n%s", string(truthJSON), string(responseJSON))
+	text, _, err := inference.Converse(ctx, llm, prompts.AlignConcerns, input)
 	if err != nil {
 		return genScore{TruthConcerns: len(truthConcerns), MuseConcerns: len(responseConcerns)}
 	}

--- a/cmd/eval_validate.go
+++ b/cmd/eval_validate.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/ellistarn/muse/internal/compose"
+	"github.com/ellistarn/muse/internal/inference"
+	"github.com/ellistarn/muse/internal/storage"
+)
+
+// weightedObservation is an observation with its validated weight.
+type weightedObservation struct {
+	Reviewer string
+	Text     string
+	Quote    string
+	Weight   float64
+}
+
+const reinforcePrompt = `You are reviewing an observation about how you think and work.
+Be ruthlessly selective. Most observations are generic things any good reviewer does.
+Only reinforce observations that capture something DISTINCTIVE about your specific
+review style — patterns that distinguish you from other competent reviewers.
+
+Observation: "%s"
+
+Respond with ONLY one of:
++1  if this captures a distinctive pattern specific to how YOU review (not generic good practice)
+ 0  if this is accurate but generic — any experienced reviewer would do this
+-1  if this is wrong, misleading, or describes something you actively avoid`
+
+// validateObservations loads a peer's observations and asks their muse to
+// reinforce, ignore, or reject each one. Returns weighted observations.
+func validateObservations(ctx context.Context, peer, project string) ([]weightedObservation, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	pd := peerDir(fmt.Sprintf("github/%s", peer), project)
+	peerRoot := filepath.Join(home, ".muse", "peers", pd)
+	store := storage.NewLocalStoreWithRoot(peerRoot)
+
+	// Load observations
+	observations, err := loadAllObservations(ctx, store)
+	if err != nil {
+		return nil, fmt.Errorf("load observations: %w", err)
+	}
+	if len(observations) == 0 {
+		return nil, fmt.Errorf("no observations found for %s", peer)
+	}
+
+	// Load muse
+	document, err := store.GetMuse(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("no muse found for %s", peer)
+	}
+
+	llm, err := newLLMClient(ctx, TierStrong)
+	if err != nil {
+		return nil, err
+	}
+
+	museHash := compose.Fingerprint(document)[:12]
+	fmt.Fprintf(os.Stderr, "validate  %d observations  peer=github/%s\n", len(observations), peer)
+
+	// Ask the muse to reinforce each observation, with caching
+	weights := make([]float64, len(observations))
+	var mu sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(8)
+
+	for i, obs := range observations {
+		g.Go(func() error {
+			// Cache key: observation text + muse hash
+			fp := compose.Fingerprint(obs.Text, museHash)
+			cacheKey := fmt.Sprintf("eval/validate/%s.json", fp[:16])
+
+			// Check cache
+			if cached, err := loadCachedResponse(gctx, store, cacheKey, fp); err == nil {
+				w := parseWeight(cached)
+				mu.Lock()
+				weights[i] = w
+				mu.Unlock()
+				return nil
+			}
+
+			// Ask the muse
+			prompt := fmt.Sprintf(reinforcePrompt, obs.Text)
+			resp, _, err := inference.Converse(gctx, llm, document, prompt)
+			if err != nil {
+				return nil
+			}
+
+			w := parseWeight(resp)
+			mu.Lock()
+			weights[i] = w
+			mu.Unlock()
+
+			// Cache the raw response
+			saveCachedResponse(gctx, store, cacheKey, fp, resp)
+			return nil
+		})
+	}
+	g.Wait()
+
+	// Build weighted observations
+	var result []weightedObservation
+	var pos, neg, zero int
+	for i, obs := range observations {
+		if weights[i] > 0 {
+			pos++
+		} else if weights[i] < 0 {
+			neg++
+		} else {
+			zero++
+		}
+		result = append(result, weightedObservation{
+			Reviewer: peer,
+			Text:     obs.Text,
+			Quote:    obs.Quote,
+			Weight:   weights[i],
+		})
+	}
+	fmt.Fprintf(os.Stderr, "  +1: %d   0: %d  -1: %d\n", pos, zero, neg)
+
+	return result, nil
+}
+
+// parseWeight extracts +1, 0, or -1 from a response string.
+func parseWeight(s string) float64 {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "+1") {
+		return 1
+	}
+	if strings.HasPrefix(s, "-1") {
+		return -1
+	}
+	// Check for just "1" (without +)
+	if strings.HasPrefix(s, "1") {
+		return 1
+	}
+	return 0
+}
+
+// loadAllObservations loads all observations for a peer from storage.
+func loadAllObservations(ctx context.Context, store storage.Store) ([]compose.Observation, error) {
+	keys, err := store.ListData(ctx, "observations/")
+	if err != nil {
+		return nil, err
+	}
+
+	var all []compose.Observation
+	for _, key := range keys {
+		data, err := store.GetData(ctx, key)
+		if err != nil {
+			continue
+		}
+		var obs compose.Observations
+		if err := json.Unmarshal(data, &obs); err != nil {
+			continue
+		}
+		all = append(all, obs.Items...)
+	}
+	return all, nil
+}

--- a/cmd/eval_validate.go
+++ b/cmd/eval_validate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ellistarn/muse/internal/compose"
 	"github.com/ellistarn/muse/internal/inference"
 	"github.com/ellistarn/muse/internal/storage"
+	"github.com/ellistarn/muse/prompts"
 )
 
 // weightedObservation is an observation with its validated weight.
@@ -23,18 +24,6 @@ type weightedObservation struct {
 	Quote    string
 	Weight   float64
 }
-
-const reinforcePrompt = `You are reviewing an observation about how you think and work.
-Be ruthlessly selective. Most observations are generic things any good reviewer does.
-Only reinforce observations that capture something DISTINCTIVE about your specific
-review style — patterns that distinguish you from other competent reviewers.
-
-Observation: "%s"
-
-Respond with ONLY one of:
-+1  if this captures a distinctive pattern specific to how YOU review (not generic good practice)
- 0  if this is accurate but generic — any experienced reviewer would do this
--1  if this is wrong, misleading, or describes something you actively avoid`
 
 // validateObservations loads a peer's observations and asks their muse to
 // reinforce, ignore, or reject each one. Returns weighted observations.
@@ -92,9 +81,11 @@ func validateObservations(ctx context.Context, peer, project string) ([]weighted
 				return nil
 			}
 
-			// Ask the muse
-			prompt := fmt.Sprintf(reinforcePrompt, obs.Text)
-			resp, _, err := inference.Converse(gctx, llm, document, prompt)
+			// Muse-contextual prompt: the muse is the system context and
+			// task instructions (prompts.Reinforce) go in the user message.
+			// This pattern recurs anywhere the muse guides a task (observation,
+			// judging, etc). See designs/011-generative-evals.md.
+			resp, _, err := inference.Converse(gctx, llm, document, fmt.Sprintf("%s\n\nObservation: \"%s\"", prompts.Reinforce, obs.Text))
 			if err != nil {
 				return nil
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,7 @@ Run "muse listen --help" for MCP server configuration.`,
 	cmd.AddCommand(newEvalCmd())
 	cmd.AddCommand(newAddCmd())
 	cmd.AddCommand(newRemoveCmd())
+	cmd.AddCommand(newComposeTeamCmd())
 	return cmd
 }
 

--- a/designs/009-observations.md
+++ b/designs/009-observations.md
@@ -1,0 +1,84 @@
+# Observations
+
+An observation is a set of discrete items extracted from a single conversation, each capturing
+something the owner said that reveals how they think. Observations are stored as JSON per
+conversation, keyed by source and conversation ID, and fingerprinted so unchanged conversations
+are not re-observed.
+
+## Pipeline
+
+```
+sources --> upload channel --> upload --> observe channel --> observe --> label
+```
+
+Three stages run concurrently, connected by two channels:
+
+- **Sources** discover conversations and push them to the upload channel.
+- **Upload** determines which conversations are new or changed and which need observation.
+- **Observe** runs the LLM call and stores the resulting observations.
+
+A conversation can be observed as soon as it is uploaded, without waiting for all sources to
+finish discovering. Label waits for all observations to complete.
+
+## Fingerprinting
+
+Each observation is fingerprinted by the conversation's last-modified timestamp and the current
+prompt chain. A conversation whose fingerprint matches its stored observation is skipped. Changed
+conversations and new conversations flow through to observe.
+
+`--reobserve` clears all stored observations, forcing every conversation through observe.
+
+## Limit
+
+`--limit N` selects the N most recent conversations for observation. Conversations are ranked
+by last-modified timestamp across all sources. When a source is slow, the pipeline can finalize
+the top N and cancel remaining sources without waiting for them to finish.
+
+Without `--limit`, all conversations that need observation are processed.
+
+## Timestamps
+
+The priority queue orders by last-modified timestamp: file modification time for local sources,
+`updated_at` for GitHub and Slack. Wrong timestamps cause the wrong N to be selected. The
+failure is soft: the next run picks up what was missed.
+
+Sources that produce conversations newest-first enable early termination under `--limit`.
+Local sources sort by modification time. API sources with incremental sync fetch newest-first.
+
+## Errors
+
+A conversation-level error (bad JSON, missing field) is logged and skipped. A source-level
+error (missing directory, auth failure) closes that source. Other sources continue. An observe
+error stops the pipeline.
+
+## Decisions
+
+### Why stream across sources but not within a source?
+
+`Conversations()` returns a batch. Streaming within a source (observe page 1 while page 2
+fetches) would require changing every provider. Cross-source streaming captures most of the
+benefit because the bottleneck is the slowest source.
+
+### Why a priority queue for limit?
+
+First-come-first-served is unfair to slow API sources (local sources consume the budget).
+Even distribution introduces recency bias. The priority queue guarantees the N newest regardless
+of discovery order.
+
+### Why track completion at the upload level?
+
+A source pushes conversations to the upload channel and returns, but those conversations sit in
+the buffer until processed. Marking the source done at push time can finalize the priority queue
+before its conversations are inserted. Completion is tracked per conversation processed.
+
+## Deferred
+
+### Intra-source streaming
+
+Stream within a single source (observe while still fetching). Requires a channel-based provider
+interface. **Revisit when:** a single source's fetch time dominates the pipeline.
+
+### Dispatch order
+
+The pipeline processes conversations in discovery order. The previous sequential path sorted
+largest-first. **Revisit when:** observe wall-clock time increases measurably.

--- a/designs/009-observations.md
+++ b/designs/009-observations.md
@@ -43,13 +43,13 @@ The priority queue orders by last-modified timestamp: file modification time for
 failure is soft: the next run picks up what was missed.
 
 Sources that produce conversations newest-first enable early termination under `--limit`.
-Local sources sort by modification time. API sources with incremental sync fetch newest-first.
+Local sources sort by modification time; API sources with incremental sync fetch newest-first.
 
 ## Errors
 
-A conversation-level error (bad JSON, missing field) is logged and skipped. A source-level
-error (missing directory, auth failure) closes that source. Other sources continue. An observe
-error stops the pipeline.
+Errors are scoped to minimize blast radius. A conversation-level error (bad JSON, missing
+field) is logged and skipped. A source-level error (missing directory, auth failure) closes
+that source but others continue. An observe error stops the pipeline.
 
 ## Decisions
 
@@ -61,9 +61,9 @@ benefit because the bottleneck is the slowest source.
 
 ### Why a priority queue for limit?
 
-First-come-first-served is unfair to slow API sources (local sources consume the budget).
-Even distribution introduces recency bias. The priority queue guarantees the N newest regardless
-of discovery order.
+First-come-first-served lets fast local sources consume the entire budget before slow API
+sources finish. Distributing the budget evenly across sources sacrifices recency. The priority
+queue guarantees the N newest regardless of discovery order.
 
 ### Why track completion at the upload level?
 

--- a/designs/010-editorial-composition.md
+++ b/designs/010-editorial-composition.md
@@ -1,0 +1,170 @@
+# Editorial Composition
+
+## Problem
+
+A muse captures how the owner thinks. But the owner doesn't work in isolation. PRs go through
+reviewers who care about specific things. The owner benefits from anticipating these perspectives
+before engaging, to stop wasting the other person's time on things the owner could have caught
+themselves.
+
+Today muse builds one profile: the owner's. What's missing is the editorial board — the handful
+of people whose reactions the owner wants to anticipate.
+
+## Solution
+
+### Peer muses
+
+```bash
+muse compose github/ellistarn --project karpenter
+muse ask --peer github/ellistarn --project karpenter "Review this design"
+```
+
+`muse compose github/ellistarn` builds a muse for `ellistarn` from their public GitHub activity.
+The GitHub source searches for conversations involving `ellistarn`, assigns `role=user` to their
+messages, and runs the standard observe/label/compose pipeline. The result is a muse.md that
+captures what `ellistarn` consistently cares about in code reviews.
+
+`--project` narrows the scope to specific repositories. Unqualified names (e.g. `karpenter`) are
+resolved by searching GitHub for repos matching that name where the target user has activity — all
+matching repos are included. Names with a slash (e.g. `aws/karpenter-provider-aws`) are used as
+exact repo matches. The resolved repos are logged so the operator sees what was selected.
+
+Peer muses are stored separately from the owner's muse:
+
+```
+~/.muse/
+├── muse.md                                    # owner's muse
+├── peers/
+│   ├── github-ellistarn/
+│   │   └── karpenter/
+│   │       ├── conversations/
+│   │       ├── observations/
+│   │       └── versions/{timestamp}/muse.md
+│   └── github-jmdeal/
+│       └── karpenter/
+│           └── ...
+```
+
+### Identity pivot
+
+The GitHub source resolves the authenticated user's username and uses it for search
+(`involves:{username}`), role assignment (owner messages get `role=user`), and minimum participation
+filtering (conversations with fewer than 2 owner messages are discarded).
+
+For peer muses, the target username replaces the authenticated user in all three roles. The
+authenticated user's token provides API access — the target doesn't need credentials since the
+data is public.
+
+Non-target participants (including the owner) get `role=assistant` with a `[GitHub comment by
+@username]` attribution prefix, same as non-owner participants in the owner's muse. The observe
+prompt treats `role=user` messages as the subject's thinking and `role=assistant` messages as
+context the subject is responding to.
+
+The minimum participation filter is lowered to 1 message for peer muses (vs 2 for the owner). At
+threshold 2, Ellis has 38 karpenter conversations. At threshold 1, he has 1310. The quality concern
+is real — single-message conversations include "LGTM" and "nit: spacing" alongside substantive
+objections — but this is a compose-time problem. The observation pipeline discards low-signal
+conversations during the refine step. Whether the refine step actually handles a 34x expansion
+without diluting the muse is testable — the first validation should compare muse quality at
+threshold 1 vs 2.
+
+### Observe prompt
+
+Peer muses are built entirely from GitHub conversations, which are human-to-human. The human
+observe prompt extracts reasoning, awareness, and voice — voice extraction is exclusive to human
+conversations (#145). This is a natural fit: peer muses get the full observation pipeline without
+any prompt changes.
+
+### Using peer muses
+
+```bash
+muse ask --peer github/ellistarn --project karpenter "Review this design"
+```
+
+`muse ask --peer` loads the peer's muse.md instead of the owner's. `--project` selects the
+project-scoped muse. Sessions persist per peer, so follow-up questions work:
+
+```bash
+muse ask --peer github/ellistarn --project karpenter "Tell me more about point 3"
+```
+
+## Decisions
+
+### Why public data only?
+
+Peer muses are built from conversations the authenticated user can already see. The muse automates
+the reading, not the access. No credentials from the target person are needed.
+
+### Why separate storage?
+
+The owner's muse is built from conversations where the owner's messages are the signal. A peer's
+muse is built from conversations where the peer's messages are the signal. Mixing them produces a
+muse that represents neither person.
+
+### Why project scoping?
+
+A person reviews differently depending on context. A muse built from all of someone's GitHub
+activity averages across contexts, diluting the signal. Project scoping captures how the person
+thinks about a specific codebase. It also bounds data volume — a prolific reviewer with thousands
+of conversations produces a noisy muse without scoping.
+
+### Why reuse the human observe prompt?
+
+The reviewer signal — pushback, positions defended, patterns flagged — is what the human observe
+prompt already extracts. A reviewer-specific prompt would extract the same things plus code-specific
+patterns. Worth trying as a refinement after the base case works.
+
+## Deferred
+
+### Slack peer muses
+
+The Slack source exists and the identity pivot generalizes. The operator would provide the target's
+email, resolve to a user ID via `users.lookupByEmail`, and pivot identity the same way as GitHub.
+Channel-level project scoping needs design work — substring matching on channel names is too coarse.
+**Revisit when:** GitHub peer muses are validated.
+
+### Project muse
+
+Individual peer muses can be composed into a project muse that captures the project's review
+culture. Observation-level merge (concatenating all reviewers' observations into one pipeline)
+fails — multiple reviewers produce a fragmented label vocabulary that the theme stage can't
+consolidate. Muse-level composition works: feed the individual muses to the compose LLM and
+synthesize by topic, noting consensus and divergence.
+
+None of this is a substitute for reading the code or talking to the reviewers. The individual
+muses and the project muse are cheaply generated approximations. But for a developer with
+software industry experience and not much Karpenter experience, they surface interesting things
+— shared values the team enforces implicitly, divergences between reviewers that aren't
+documented anywhere, and patterns that would take months of PR review to absorb on your own.
+
+```bash
+muse ask --peer github/karpenter-team --project karpenter "What would the team flag?"
+```
+
+### Multi-peer review
+
+Multiple `--peer` flags to assemble perspectives from several reviewers in one command. Each peer's
+muse would weigh in independently. **Revisit when:** single-peer ask is validated.
+
+### Compose prompt for peer muses
+
+The compose prompt says "capture how they think." A peer-specific prompt would say "capture what
+this person consistently flags, what triggers their engagement, and what they let pass without
+comment. Organize around review patterns and triggers, not general reasoning." These are different
+extraction targets — the owner is the protagonist of their conversations, a peer is a reactor. The
+current prompt produces usable peer muses because the observation pipeline extracts the right raw
+signal. **Revisit when:** peer muses are compared against actual reviews and the structural gap
+(reasoning-organized vs trigger-organized) is measured.
+
+### Validation
+
+How does the owner know a peer muse is good? For their own muse, they read it and it resonates or
+doesn't. For a peer muse, the owner's model of the peer is exactly what's insufficient — that's
+why they're building the muse. A calibration mechanism: run the peer muse against the last N PRs
+the peer actually reviewed and compare the muse's predictions to what the peer said. **Revisit
+when:** peer muses are in regular use and quality feedback is needed.
+
+### Cross-muse discussion
+
+Two peer muses discussing a design with each other. The owner asks a question, each peer responds,
+and the owner sees where they agree and disagree. **Revisit when:** multi-peer mode exists.

--- a/designs/010-editorial-composition.md
+++ b/designs/010-editorial-composition.md
@@ -72,8 +72,7 @@ threshold 1 vs 2.
 
 Peer muses are built entirely from GitHub conversations, which are human-to-human. The human
 observe prompt extracts reasoning, awareness, and voice — voice extraction is exclusive to human
-conversations (#145). This is a natural fit: peer muses get the full observation pipeline without
-any prompt changes.
+conversations (#145). Peer muses get the full observation pipeline without prompt changes.
 
 ### Using peer muses
 
@@ -110,9 +109,9 @@ of conversations produces a noisy muse without scoping.
 
 ### Why reuse the human observe prompt?
 
-The reviewer signal — pushback, positions defended, patterns flagged — is what the human observe
-prompt already extracts. A reviewer-specific prompt would extract the same things plus code-specific
-patterns. Worth trying as a refinement after the base case works.
+The reviewer signal (pushback, positions defended, patterns flagged) is what the human observe
+prompt already extracts. A reviewer-specific prompt would add code-level patterns on top.
+Worth trying as a refinement after the base case works.
 
 ## Deferred
 

--- a/designs/011-generative-evals.md
+++ b/designs/011-generative-evals.md
@@ -24,7 +24,7 @@ to a point) and ask it to respond as the person would. Compare the muse's genera
 what the person actually said. Score the alignment.
 
 ```bash
-muse eval --generative --peer ellistarn --project karpenter --cases 10
+muse eval --generative --peer github/ellistarn --project karpenter --cases 10
 ```
 
 The command:

--- a/designs/011-generative-evals.md
+++ b/designs/011-generative-evals.md
@@ -1,0 +1,191 @@
+# Generative Evals
+
+## Problem
+
+We build muses but don't measure whether they're good. The owner reads their own muse and decides
+it "feels right," which is subjective and doesn't scale to peer muses where the owner's model of
+the peer is exactly what's insufficient.
+
+`muse eval` exists but measures something different: it compares responses with and without the
+muse on fixed questions, using an LLM judge. That tests whether the muse changes responses in a
+positive direction. It doesn't test whether the muse captures the right patterns from the source
+data.
+
+Generative evals test the pipeline end-to-end: does the muse, built from a person's past
+conversations, predict what that person would say in a new conversation?
+
+## Solution
+
+### Held-out evaluation
+
+Split the person's conversations into train and test sets. Build the muse from the train set. For
+each test conversation, show the muse the conversation context (the PR diff, or the discussion up
+to a point) and ask it to respond as the person would. Compare the muse's generated response to
+what the person actually said. Score the alignment.
+
+```bash
+muse eval --generative --peer ellistarn --project karpenter --cases 10
+```
+
+The command:
+
+1. Lists all conversations for the peer.
+2. Holds out recent conversations as the test set (20%, min 5, max 30).
+3. Uses the existing muse (not rebuilt — the eval measures the muse as-is).
+4. For each test conversation, extracts context and ground truth. Context is everything before
+   the target's first substantive comment. Ground truth is that comment.
+5. Asks the muse and a baseline (same model, no personality) to review the context.
+6. The LLM judge pipeline (extract, align, score) measures alignment for both.
+
+Many conversations are unusable: the target speaks first (no context), or their comment is too
+short (under 10 words). The eval scans up to 5x the test set size to find enough usable cases.
+In practice, about 1 in 3 conversations is usable for evaluation.
+
+### Scoring
+
+The judge is a three-step pipeline, not a single call:
+
+1. **Extract concerns** from the ground truth review. Each concern is one actionable item — a
+   distinct thing the reviewer wants changed or flagged. A broad claim ("error handling is
+   fragile") supported by specific instances is one concern, not N. The extraction prompt is
+   versioned — a change to it is a breaking change to the metric.
+2. **Extract concerns** from the muse's review, using the same extraction prompt.
+3. **Align and score**. One-to-one matching via the LLM judge. Each pair gets a score from 0
+   to 1. Then:
+
+- **Recall**: what fraction of the reviewer's stated concerns did the muse identify?
+- **Precision**: what fraction of the muse's concerns match something the reviewer raised?
+
+### What the first results show
+
+Initial results on ellistarn's karpenter reviews (8 usable cases out of 10 scanned):
+
+```
+                    Muse    Base    Delta
+  ────────────────────────────────────────
+  Recall            0.67    0.61    +0.06
+  Precision         0.18    0.12    +0.06
+
+  Muse better: 1/8  Base better: 0/8  Tied: 7/8
+```
+
+Three observations from running the eval:
+
+**Precision is structurally low for both muse and baseline.** LLMs are thorough reviewers —
+they raise 8-12 concerns per PR. Human reviewers are selective — they state 2-4 concerns and
+skip the rest. The precision metric penalizes thoroughness. This isn't a muse problem; it's a
+measurement artifact. A reviewer who thinks "the error handling is fragile, the naming is
+inconsistent, and the test coverage is thin" might only write about the error handling. The muse
+raises all three. Precision says 0.33; the muse's actual coverage is higher.
+
+This means precision is useful for comparing muse vs baseline (is the muse raising *more
+relevant* concerns?) but the absolute number is not interpretable as muse quality. Recall is the
+better single metric for muse quality, with the caveat that it has its own structural ceiling.
+
+**Recall has a structural ceiling below 1.0.** Reviewers don't state everything they notice.
+A recall of 0.6 may be excellent if reviewers typically state 60% of what they see.
+
+**Most cases are tied between muse and baseline.** 7 of 8 cases show identical recall. The
+base model is a strong reviewer on its own — it catches most of the same concerns. The muse's
+value shows up on the cases where the reviewer's concern is specific to the codebase or reflects
+a personal judgment call (issue #501: recall 1.0 vs 0.5). Issue #501 is an API design question
+about whether a field should be an implementation detail — the muse caught the architectural
+concern because Ellis's patterns include "what belongs at which layer." The base model missed it.
+
+**The muse's value is on architecture and judgment, not code correctness.** The base model
+catches bugs, naming issues, and missing error handling. The muse adds the reviewer's specific
+architectural preferences and design instincts. This means the eval is most diagnostic on
+conversations where the reviewer made a judgment call rather than pointed out an obvious defect.
+The parameter tuning loop should weight these cases more heavily.
+
+### Baseline
+
+Each test case runs without the muse: the same base model reviews with no personality. The
+baseline is pinned (same model and config across runs) so the delta is a stable measure of muse
+value. The muse's contribution is the delta, not the absolute score.
+
+### Applying to the owner's muse
+
+The held-out approach generalizes to the owner's muse, but context extraction is harder. The
+owner's conversations include AI interactions where the "ground truth" is a correction or
+steering signal, not a structured review. Start with peer muse evals where the ground truth is
+structured code review.
+
+### Parameter tuning
+
+Generative evals make tuning measurable. The immediate parameters to tune:
+
+- **MinContentWords**: 10, 20, 50 — which produces the best eval score?
+- **Observation count / limit**: 100, 200, 500 — diminishing returns?
+- **Owner compose prompt vs peer-specific prompt**: measure the gap
+
+Grid search over a small space. Build muse with each setting, run eval, pick the best.
+
+### Prompt optimization (DSPy-style)
+
+The eval score is an objective function over the full pipeline. The tunable surface includes
+observe prompts, compose prompts, and refine prompts. Before attempting prompt optimization,
+verify that eval scores are stable across runs. If the judge gives ±15% variance on the same
+muse, it can't detect a 5% improvement from a prompt change.
+
+## Decisions
+
+### Why held-out evaluation instead of cross-validation?
+
+Cross-validation (k-fold) gives more robust estimates but requires building k muses per eval
+run. Each muse build costs $1-3 in LLM calls. Held-out evaluation is cheaper and sufficient
+for directional signal.
+
+### Why an LLM judge instead of embedding similarity?
+
+Embedding similarity measures surface-level text overlap. Two reviews can flag the same concern
+using completely different words. An LLM judge understands semantic alignment.
+
+### Why most-recent for the test set?
+
+Recent conversations test whether the muse generalizes forward. A muse that predicts old reviews
+but not new ones has overfit to historical patterns.
+
+### Why not rebuild the muse for each eval?
+
+The eval measures the muse as-is. Rebuilding with a train-only split would give cleaner
+held-out semantics but costs $1-3 per build and changes the muse being tested. The current
+approach — use the existing muse, test against recent conversations the muse hasn't seen — is
+cheaper and tests the artifact the operator actually uses.
+
+## Deferred
+
+### Automated prompt optimization
+
+Use eval scores to search the prompt space. **Revisit when:** manual prompt tuning plateaus
+and eval scores are stable enough to distinguish between variants.
+
+### Regression testing
+
+Run generative evals on every pipeline change. **Revisit when:** the eval is fast enough for CI.
+
+### Multi-turn context
+
+Predict the reviewer's follow-up after the author responds. **Revisit when:** single-turn eval
+is validated.
+
+### Cross-muse evaluation
+
+Run each reviewer's muse against every other reviewer's test data to measure transferability.
+Initial results (5 cases per cell, high variance):
+
+- Some muses transfer well (Ellis→Jason +0.20, Todd→Jason +0.25)
+- Some don't (Todd→Ellis -0.25 in one run, +0.00 in another)
+- Most cross-evals are +0.00 — the personality signal is individual-specific
+
+At 5 cases per cell the matrix is too noisy for strong conclusions. 20-30 cases per cell would
+give stable results but costs ~1440 LLM calls across 12 cells. **Revisit when:** the eval is
+cheap enough to run large matrices, or when team-muse composition needs to know which reviewers
+overlap.
+
+### Precision-adjusted scoring
+
+The low precision numbers suggest the eval should distinguish "muse raised a valid concern the
+reviewer didn't mention" from "muse raised an irrelevant concern." A second judge call could
+score unmatched muse concerns as "valid but unstated" vs "wrong." **Revisit when:** precision
+is the metric being used to make tuning decisions.

--- a/designs/011-generative-evals.md
+++ b/designs/011-generative-evals.md
@@ -153,6 +153,16 @@ held-out semantics but costs $1-3 per build and changes the muse being tested. T
 approach — use the existing muse, test against recent conversations the muse hasn't seen — is
 cheaper and tests the artifact the operator actually uses.
 
+## Prompt architecture
+
+Two patterns for wiring prompts to `inference.Converse`:
+
+1. **Task prompts.** The prompt is the system message, user data is the user message. Every top-level command uses this: `Converse(ctx, llm, prompts.Observe, transcript)`.
+
+2. **Muse-contextual prompts.** The muse document is the system message, task instructions are concatenated into the user message: `Converse(ctx, llm, museDocument, prompts.Reinforce + observation)`. Used when the muse needs to guide the task, not just the response.
+
+Reinforce (012) uses pattern 2 today. Muse-guided observation, muse-guided judging, and any future "think like this person while doing X" task will use the same pattern. Worth discussing whether `inference.Converse` should support this natively (e.g. multiple system inputs, or an explicit muse context parameter) rather than having each call site concatenate.
+
 ## Deferred
 
 ### Automated prompt optimization

--- a/designs/011-generative-evals.md
+++ b/designs/011-generative-evals.md
@@ -78,9 +78,9 @@ measurement artifact. A reviewer who thinks "the error handling is fragile, the 
 inconsistent, and the test coverage is thin" might only write about the error handling. The muse
 raises all three. Precision says 0.33; the muse's actual coverage is higher.
 
-This means precision is useful for comparing muse vs baseline (is the muse raising *more
-relevant* concerns?) but the absolute number is not interpretable as muse quality. Recall is the
-better single metric for muse quality, with the caveat that it has its own structural ceiling.
+Precision is useful for comparing muse vs baseline (is the muse raising *more relevant*
+concerns?) but the absolute number is not interpretable as quality. Recall is the better
+single metric, with the caveat that it has its own structural ceiling.
 
 **Recall has a structural ceiling below 1.0.** Reviewers don't state everything they notice.
 A recall of 0.6 may be excellent if reviewers typically state 60% of what they see.
@@ -93,10 +93,9 @@ about whether a field should be an implementation detail — the muse caught the
 concern because Ellis's patterns include "what belongs at which layer." The base model missed it.
 
 **The muse's value is on architecture and judgment, not code correctness.** The base model
-catches bugs, naming issues, and missing error handling. The muse adds the reviewer's specific
-architectural preferences and design instincts. This means the eval is most diagnostic on
-conversations where the reviewer made a judgment call rather than pointed out an obvious defect.
-The parameter tuning loop should weight these cases more heavily.
+catches bugs, naming issues, and missing error handling. The muse adds the reviewer's architectural preferences and design instincts. The eval is
+most diagnostic on conversations where the reviewer made a judgment call rather than pointed
+out an obvious defect, and the parameter tuning loop should weight those cases accordingly.
 
 ### Baseline
 
@@ -157,11 +156,19 @@ cheaper and tests the artifact the operator actually uses.
 
 Two patterns for wiring prompts to `inference.Converse`:
 
-1. **Task prompts.** The prompt is the system message, user data is the user message. Every top-level command uses this: `Converse(ctx, llm, prompts.Observe, transcript)`.
+1. **Task prompts.** The prompt is the system message, user data is the user message.
+   Every top-level command uses this: `Converse(ctx, llm, prompts.Observe, transcript)`.
 
-2. **Muse-contextual prompts.** The muse document is the system message, task instructions are concatenated into the user message: `Converse(ctx, llm, museDocument, prompts.Reinforce + observation)`. Used when the muse needs to guide the task, not just the response.
+2. **Muse-contextual prompts.** The muse document is the system message, task instructions
+   are concatenated into the user message:
+   `Converse(ctx, llm, museDocument, prompts.Reinforce + observation)`.
+   Used when the muse needs to guide the task, not just shape the response.
 
-Reinforce (012) uses pattern 2 today. Muse-guided observation, muse-guided judging, and any future "think like this person while doing X" task will use the same pattern. Worth discussing whether `inference.Converse` should support this natively (e.g. multiple system inputs, or an explicit muse context parameter) rather than having each call site concatenate.
+Reinforce (012) uses pattern 2 today. Muse-guided observation, muse-guided judging, and
+any "think like this person while doing X" task will follow the same pattern. Worth
+discussing whether `inference.Converse` should support this natively (multiple system
+inputs, or an explicit muse context parameter) rather than having each call site
+concatenate.
 
 ## Deferred
 

--- a/designs/012-weighted-team-composition.md
+++ b/designs/012-weighted-team-composition.md
@@ -131,7 +131,7 @@ Severity-weighted recall delta over baseline, 30 cases per reviewer:
 | Todd | -0.10 | — | **+0.07** | -0.04 |
 | Derek | -0.08 | +0.01 | **+0.11** | +0.25 |
 
-v3 is positive for all four reviewers. No regressions. The biggest improvements:
+v3 is positive for all four reviewers with no regressions. The biggest improvements:
 
 - **Todd**: -0.10 → +0.07. His muse rejected 103 of 194 observations as generic. Removing
   that noise let the distinctive patterns through.
@@ -155,9 +155,9 @@ different mechanisms.
 
 ### Why not skip individual muses entirely?
 
-Individual muses remain useful standalone. `muse ask --peer github/DerekFrank` still works.
-The team muse no longer depends on them for composition — it goes from observations to team
-muse directly — but uses individual muses as the judge in the validation step.
+Individual muses remain useful standalone. The team muse no longer depends on them for
+composition (it goes from observations to team muse directly) but uses individual muses
+as the judge in the validation step.
 
 ### Why validate against observations instead of the muse level?
 

--- a/designs/012-weighted-team-composition.md
+++ b/designs/012-weighted-team-composition.md
@@ -1,0 +1,218 @@
+# Weighted Team Composition
+
+## Problem
+
+The team muse (a synthesis of multiple peer muses) dilutes distinctive reviewer patterns.
+Derek's individual muse scores +0.25 over baseline. The team muse scores -0.08. The information
+is present in the team document — Derek's "is there a reason you can't use X?" gatekeeping move
+appears in the text — but it competes with 13 other sections for attention weight in the LLM's
+context window.
+
+The root cause is two lossy compression steps: observations → individual muse → team muse. The
+composition prompt can be tuned to reduce dilution (changing from "synthesize by topic" to
+"preserve distinctive patterns" moved Derek from -0.08 to +0.01), but the architecture is
+working against us. A 200-line document with four reviewers will always give Derek's patterns
+less weight than a 60-line document entirely about Derek.
+
+## Solution
+
+### Observation-validated team composition
+
+Replace the two-step pipeline with a single composition step from validated observations to
+team muse.
+
+```
+Current:  observations → individual muse → team muse
+Proposed: observations → validate → team muse
+```
+
+The validation step asks each reviewer's muse to reinforce or reject its own observations. The
+team composition consumes weighted observations directly.
+
+### Step 1: Observe (existing)
+
+Extract observations from each reviewer's conversations.
+
+```
+~/.muse/peers/github-DerekFrank/karpenter/observations/
+~/.muse/peers/github-ellistarn/karpenter/observations/
+~/.muse/peers/github-jmdeal/karpenter/observations/
+~/.muse/peers/github-tzneal/karpenter/observations/
+```
+
+### Step 2: Compose individual muses (existing)
+
+Build per-reviewer muses from observations. Individual muses remain useful on their own. The
+team muse no longer consumes them.
+
+### Step 3: Validate observations
+
+Show each observation to the reviewer's own muse and ask: is this distinctive to how you
+review, or generic? The muse is the judge.
+
+The validation prompt:
+
+> You are reviewing an observation about how you think and work.
+> Be ruthlessly selective. Most observations are generic things any good reviewer does.
+> Only reinforce observations that capture something DISTINCTIVE about your specific
+> review style.
+>
+> Observation: "{observation_text}"
+>
+> +1 if this captures a distinctive pattern specific to how YOU review
+>  0 if this is accurate but generic — any experienced reviewer would do this
+> -1 if this is wrong, misleading, or describes something you actively avoid
+
+Each validation call is cached by observation hash + muse hash.
+
+Results from the four Karpenter reviewers (815 observations total):
+
+| Reviewer | Observations | +1 | 0 | -1 |
+|---|---|---|---|---|
+| Derek | 219 | 129 | 85 | 5 |
+| Ellis | 115 | 95 | 20 | 0 |
+| Jason | 287 | 192 | 93 | 2 |
+| Todd | 194 | 91 | 103 | 0 |
+
+Todd's muse rejected more than half its observations as generic. Derek's rejected 39%. This
+discrimination is the signal — the observations that survive are what distinguish each reviewer
+from a competent base model.
+
+### Step 4: Compose team muse
+
+Feed the full pool of observations from all reviewers to the composition prompt, annotated
+with their validated weights.
+
+```
+muse compose-team --project karpenter \
+  github/ellistarn github/jmdeal github/tzneal github/DerekFrank
+```
+
+The compose prompt receives observations grouped by reviewer, each tagged with its weight:
+
+```
+## Derek Frank
+
+[+1] When someone proposes a new feature, challenges whether existing primitives
+     (disruption budgets, taints, tag-based selection) already compose into what
+     they need. "Is there a reason you can't use X?" is a prerequisite.
+
+[+1] Evaluates every change against 100k-node cluster sizes. Sorts are unsafe
+     unless input is provably bounded.
+
+[ 0] Prefers short variable names in tight loops.
+
+[-1] Flags all uses of interface{} as a design smell.
+```
+
+The composition prompt instructions:
+
+- **+1 observations**: distinctive signals. Preserve at full strength, especially if unique
+  to one reviewer. Give them dedicated sections, not bullets in shared lists.
+- **0 observations**: generic. Compress aggressively or cut.
+- **-1 observations**: wrong or misleading. Cut.
+
+Observations scored +1 for one reviewer but 0 for others are *distinctive*. Observations
+scored +1 across all reviewers are *shared* — the base model catches most of these.
+
+### Step 5: Eval
+
+Run the team muse against all reviewers' conversations using `muse eval --generative`. The
+scoring function is severity-weighted recall pooled across all cases.
+
+## Results
+
+Severity-weighted recall delta over baseline, 30 cases per reviewer:
+
+| Reviewer | v1 (topic synthesis) | v2 (distinctive prompt) | v3 (validated observations) | Individual muse |
+|---|---|---|---|---|
+| Ellis | +0.04 | — | **+0.03** | -0.01 |
+| Jason | +0.18 | — | **+0.10** | +0.11 |
+| Todd | -0.10 | — | **+0.07** | -0.04 |
+| Derek | -0.08 | +0.01 | **+0.11** | +0.25 |
+
+v3 is positive for all four reviewers. No regressions. The biggest improvements:
+
+- **Todd**: -0.10 → +0.07. His muse rejected 103 of 194 observations as generic. Removing
+  that noise let the distinctive patterns through.
+- **Derek**: -0.08 → +0.11. His gatekeeping move ("is there a reason you can't use X?")
+  survived validation and got prominent treatment in the team muse.
+
+## Decisions
+
+### Why muse self-validation instead of eval-based attribution?
+
+The first implementation tried to attribute eval matches back to observations through a
+multi-step pipeline: run generative eval → extract concerns → align → attribute each match to
+an observation. This was expensive (many LLM calls per case), noisy (three layers of
+indirection), and slow.
+
+Muse self-validation is one LLM call per observation: show it to the muse, ask if it's
+distinctive. The muse already captures how the reviewer thinks — it's the right judge for
+whether an observation is generic or distinctive. The eval measures the final team muse quality;
+the validation step measures observation quality. These are different questions answered by
+different mechanisms.
+
+### Why not skip individual muses entirely?
+
+Individual muses remain useful standalone. `muse ask --peer github/DerekFrank` still works.
+The team muse no longer depends on them for composition — it goes from observations to team
+muse directly — but uses individual muses as the judge in the validation step.
+
+### Why validate against observations instead of the muse level?
+
+The individual muses are compressed. Two observations might both appear in Derek's muse, but
+only one is distinctive. Muse-level eval can't distinguish them; observation-level validation
+can.
+
+### Why validate against all data instead of a held-out split?
+
+The observations are generalized patterns, not memorized content. Testing whether a pattern is
+distinctive is well-posed even on training data. The overfitting risk (discrete labels on
+patterns) is lower than the cost of noisier signals from reduced data.
+
+## Validation
+
+```bash
+cd "$MUSE_DIR"
+
+# 1. compose-team command exists and accepts the right flags
+go build ./... || exit 1
+go run . compose-team --help | grep -q "\-\-project" || exit 1
+
+# 2. validate subcommand produces weighted observations with +1/0/-1 distribution
+# (not all +1 — the prompt must discriminate)
+go run . compose-team --project karpenter github/DerekFrank github/ellistarn 2>&1 | tee /tmp/validate-check.txt
+grep -q "+1:" /tmp/validate-check.txt || exit 1
+# Check that at least 10% of observations are scored 0 (generic)
+# This ensures the validation prompt is discriminating
+
+# 3. The composed team muse is saved
+test -f ~/.muse/peers/github-karpenter-team/karpenter/muse.md || exit 1
+
+# 4. generative eval works with --muse-override
+go run . eval --generative --peer github/DerekFrank --project karpenter --cases 5 \
+  --muse-override ~/.muse/peers/github-karpenter-team/karpenter/muse.md 2>&1 | \
+  grep -q "Recall" || exit 1
+
+echo "PASS"
+```
+
+## Deferred
+
+### Automated parameter search
+
+The composition prompt determines how scores map to inclusion/weight in the team muse. This
+mapping is tunable. **Revisit when:** the team muse eval is stable enough to distinguish between
+composition prompt variants.
+
+### Cross-reviewer transfer scores
+
+An observation from Derek's muse that gets +1 when validated by Jason's muse transfers across
+reviewers. The composition could weight transferable observations differently. **Revisit when:**
+single-reviewer validation is working and cross-reviewer validation is cheap enough.
+
+### Iterative refinement
+
+Run validate → compose → eval in a loop, using eval results to update the validation prompt.
+**Revisit when:** a single pass produces measurable improvement over the current team muse.

--- a/prompts/align-concerns.md
+++ b/prompts/align-concerns.md
@@ -1,0 +1,18 @@
+You are comparing two lists of code review concerns to measure alignment.
+
+You will receive ground truth concerns (what the reviewer actually said) and predicted concerns (what the muse predicted).
+
+For each ground truth concern, find the best matching predicted concern. Score each match:
+- 1.0 if the predicted concern identifies the same issue with similar reasoning
+- 0.5 if the predicted concern is in the same area but frames the issue differently
+- 0.0 if no predicted concern matches
+
+Also identify which predicted concerns have no match in ground truth.
+
+Return JSON:
+{
+  "matches": [{"truth": "...", "predicted": "...", "score": 0.0}],
+  "unmatched_predicted": ["..."],
+  "top_truth_concern": "...",
+  "top_predicted_concern": "..."
+}

--- a/prompts/extract-concerns.md
+++ b/prompts/extract-concerns.md
@@ -1,0 +1,11 @@
+Extract the distinct review concerns from this code review comment.
+Each concern is one actionable item — a distinct thing the reviewer wants changed or flagged.
+A broad claim supported by specific instances is one concern, not multiple.
+
+Classify each concern by severity:
+- "blocking": the reviewer is blocking on this, it must change ("this does not belong here", "this is wrong", "this will break")
+- "advisory": the reviewer wants a change but is not blocking ("consider", "should", "let's")
+- "suggestive": the reviewer is floating an idea or preference ("maybe", "might be nice", "could")
+
+Return a JSON array of objects with "concern" and "severity" fields.
+If the comment has no substantive review concerns (e.g. "LGTM", "looks good"), return an empty array.

--- a/prompts/prompts.go
+++ b/prompts/prompts.go
@@ -49,3 +49,12 @@ var GenerateEval string
 
 //go:embed thesis.md
 var Thesis string
+
+//go:embed reinforce.md
+var Reinforce string
+
+//go:embed extract-concerns.md
+var ExtractConcerns string
+
+//go:embed align-concerns.md
+var AlignConcerns string

--- a/prompts/reinforce.md
+++ b/prompts/reinforce.md
@@ -1,0 +1,9 @@
+You are reviewing an observation about how you think and work.
+Be ruthlessly selective. Most observations are generic things any good reviewer does.
+Only reinforce observations that capture something DISTINCTIVE about your specific
+review style — patterns that distinguish you from other competent reviewers.
+
+You will receive an observation. Respond with ONLY one of:
++1  if this captures a distinctive pattern specific to how YOU review (not generic good practice)
+ 0  if this is accurate but generic — any experienced reviewer would do this
+-1  if this is wrong, misleading, or describes something you actively avoid


### PR DESCRIPTION
Three design docs for features I'm prototyping on a fork, plus README updates.

**009: Observations.** Streaming discover/observe pipeline. Two channels replace the sequential barriers between discover, upload, and observe. Per-source watermarks enable early termination under --limit N.

**010: Editorial composition.** Build peer muses from a reviewer's public GitHub activity. `muse compose github/ellistarn --project karpenter` builds a muse that captures what ellistarn consistently cares about in karpenter reviews. `muse ask --peer github/ellistarn` queries it.

**011: Generative evals.** Held-out evaluation that measures whether a peer muse predicts what a reviewer actually said. Three-step LLM judge pipeline extracts concerns, aligns them, and scores recall/precision.

**README:** Added Peer Muses section. Normalized `--peer` to `github/username` format everywhere.

Implementation is on jamesmt-aws/muse branch `editorial-composition`. Working prototype tested with peer muses for four karpenter reviewers.