### PR TITLE
Persist MCP sessions to disk and prevent comingling with CLI sessions

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -36,13 +35,11 @@ to start a fresh session.`,
 				return err
 			}
 
-			// Session persistence lives under ~/.muse/sessions/.
-			home, err := os.UserHomeDir()
+			dir, err := sessionsDir()
 			if err != nil {
 				return err
 			}
-			sessionsDir := filepath.Join(home, ".muse", "sessions")
-			m := muse.New(llm, document, muse.WithSessionsDir(sessionsDir))
+			m := muse.New(llm, document, muse.WithSessionsDir(dir))
 
 			question := strings.Join(args, " ")
 			result, err := m.Ask(ctx, muse.AskInput{
@@ -54,6 +51,9 @@ to start a fresh session.`,
 			})
 			if result != nil && result.Response != "" {
 				fmt.Fprintln(os.Stdout) // trailing newline after stream completes
+			}
+			if result != nil {
+				m.SetLatest(result.SessionID)
 			}
 			return err
 		},

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -37,7 +37,11 @@ Add this to your agent's MCP config:
 			if err != nil {
 				return err
 			}
-			m := muse.New(llm, document)
+			dir, err := sessionsDir()
+			if err != nil {
+				return err
+			}
+			m := muse.New(llm, document, muse.WithSessionsDir(dir))
 			srv := mcpserver.NewServer(m)
 			return server.ServeStdio(srv)
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -75,6 +76,15 @@ func newStore(ctx context.Context) (storage.Store, error) {
 		return nil, err
 	}
 	return store, nil
+}
+
+// sessionsDir returns the path to ~/.muse/sessions/ for session persistence.
+func sessionsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".muse", "sessions"), nil
 }
 
 // loadDocument loads the muse.md content from storage. Returns empty string on first run.

--- a/designs/sessions.md
+++ b/designs/sessions.md
@@ -17,19 +17,20 @@ A session holds a message history: alternating user and assistant turns. It has 
 on first save) and a system prompt (stored as metadata for debugging). Two sessions never share
 state. A session grows until the user starts a new one.
 
-There are two session lifetimes, determined by the caller:
+Both MCP and CLI sessions are persisted to disk so there is a record of what was discussed. The
+difference is in how sessions are resumed:
 
-- **Process-scoped** (MCP): sessions live in memory and die with the process. Each MCP client
-  connection gets an independent session. This is the right model for MCP because the client
-  lifecycle *is* the session lifecycle — when the client disconnects, the conversation is over.
+- **MCP**: each client connection starts a fresh session. The MCP server never reads the `latest`
+  pointer and never writes it. When the client disconnects, the session remains on disk but is not
+  automatically resumed by any future connection.
 
-- **Persisted** (CLI): sessions survive process exits. `muse ask` resumes the latest session by
-  default, because the CLI invocation boundary is artificial — the user is in the same conversation,
-  they just pressed Enter in their shell. `--new` starts a fresh session when the user's intent has
-  actually changed.
+- **CLI**: `muse ask` resumes the latest session by default, because the CLI invocation boundary is
+  artificial — the user is in the same conversation, they just pressed Enter in their shell. `--new`
+  starts a fresh session when the user's intent has actually changed.
 
-Both operate on the same session model. The persistence boundary is a construction-time decision, not
-a model distinction.
+The `latest` pointer is a CLI UX concern — it is updated by `muse ask` after each turn, never by the
+MCP path. MCP sessions persist to the same directory but never interact with the `latest` pointer in
+either direction.
 
 ## Storage
 

--- a/e2e/mcp_test.go
+++ b/e2e/mcp_test.go
@@ -2,6 +2,9 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -19,10 +22,16 @@ import (
 // newMCPClient creates an in-process MCP client backed by a Muse with canned responses.
 func newMCPClient(t *testing.T, document string, responses ...bedrockruntime.ConverseOutput) *client.Client {
 	t.Helper()
+	return newMCPClientWithOpts(t, document, nil, responses...)
+}
+
+// newMCPClientWithOpts creates an in-process MCP client, passing opts through to Muse.
+func newMCPClientWithOpts(t *testing.T, document string, opts []museinternal.Option, responses ...bedrockruntime.ConverseOutput) *client.Client {
+	t.Helper()
 	runtime := &mockRuntime{responses: responses}
 	ctx := context.Background()
 	bedrockClient := bedrock.NewClientWithRuntime(ctx, runtime)
-	m := museinternal.New(bedrockClient, document)
+	m := museinternal.New(bedrockClient, document, opts...)
 	srv := musemcp.NewServer(m)
 
 	c, err := client.NewInProcessClient(srv)
@@ -175,4 +184,142 @@ type errorRuntime struct {
 
 func (e *errorRuntime) Converse(_ context.Context, _ *bedrockruntime.ConverseInput, _ ...func(*bedrockruntime.Options)) (*bedrockruntime.ConverseOutput, error) {
 	return nil, e.err
+}
+
+func TestMCP_SessionPersistedToDisk(t *testing.T) {
+	dir := t.TempDir()
+	c := newMCPClientWithOpts(t, "Be concise.",
+		[]museinternal.Option{museinternal.WithSessionsDir(dir)},
+		textResponse("Persisted answer."),
+	)
+
+	result := callAsk(t, c, "hello")
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+
+	// Verify a session file was written to disk.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read sessions dir: %v", err)
+	}
+	var jsonFiles []string
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".json" {
+			jsonFiles = append(jsonFiles, e.Name())
+		}
+	}
+	if len(jsonFiles) != 1 {
+		t.Fatalf("expected 1 session file, got %d: %v", len(jsonFiles), jsonFiles)
+	}
+
+	// Verify the session contains the conversation.
+	data, err := os.ReadFile(filepath.Join(dir, jsonFiles[0]))
+	if err != nil {
+		t.Fatalf("failed to read session file: %v", err)
+	}
+	var session struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(data, &session); err != nil {
+		t.Fatalf("failed to parse session: %v", err)
+	}
+	if len(session.Messages) != 2 {
+		t.Fatalf("expected 2 messages (user + assistant), got %d", len(session.Messages))
+	}
+	if session.Messages[0].Role != "user" || session.Messages[0].Content != "hello" {
+		t.Errorf("first message = %+v, want user/hello", session.Messages[0])
+	}
+	if session.Messages[1].Role != "assistant" || session.Messages[1].Content != "Persisted answer." {
+		t.Errorf("second message = %+v, want assistant/Persisted answer.", session.Messages[1])
+	}
+
+	// MCP sessions should NOT create a "latest" pointer (that's a CLI concern).
+	if _, err := os.Stat(filepath.Join(dir, "latest")); !os.IsNotExist(err) {
+		t.Error("MCP session should not create a 'latest' pointer file")
+	}
+}
+
+func TestMCP_DoesNotResumeAskSession(t *testing.T) {
+	// Simulate a prior "muse ask" session by writing a session file and latest pointer.
+	dir := t.TempDir()
+	askSession := struct {
+		ID       string `json:"id"`
+		System   string `json:"system"`
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}{
+		ID:     "ask-session-id",
+		System: "old system prompt",
+		Messages: []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		}{
+			{Role: "user", Content: "prior ask question"},
+			{Role: "assistant", Content: "prior ask answer"},
+		},
+	}
+	data, err := json.Marshal(askSession)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ask-session-id.json"), data, 0o644); err != nil {
+		t.Fatalf("failed to write session: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "latest"), []byte("ask-session-id"), 0o644); err != nil {
+		t.Fatalf("failed to write latest: %v", err)
+	}
+
+	// Create an MCP client with the same sessions dir. The MCP server should
+	// start a fresh session, NOT resume the ask session.
+	runtime := &mockRuntime{responses: []bedrockruntime.ConverseOutput{
+		textResponse("Fresh MCP answer."),
+	}}
+	ctx := context.Background()
+	bedrockClient := bedrock.NewClientWithRuntime(ctx, runtime)
+	m := museinternal.New(bedrockClient, "test doc", museinternal.WithSessionsDir(dir))
+	srv := musemcp.NewServer(m)
+
+	c, err := client.NewInProcessClient(srv)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{Name: "test", Version: "0.1"}
+	if _, err := c.Initialize(ctx, initReq); err != nil {
+		t.Fatalf("failed to initialize: %v", err)
+	}
+
+	result := callAsk(t, c, "new MCP question")
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+
+	// The MCP call should have sent only 1 message (the new question),
+	// NOT 3 (prior ask history + new question).
+	if len(runtime.calls) != 1 {
+		t.Fatalf("expected 1 Bedrock call, got %d", len(runtime.calls))
+	}
+	if runtime.calls[0].messages != 1 {
+		t.Errorf("Bedrock received %d messages, want 1 (fresh session); got ask session history leak", runtime.calls[0].messages)
+	}
+
+	// The "latest" pointer should still point to the ask session, not the MCP session.
+	latestData, err := os.ReadFile(filepath.Join(dir, "latest"))
+	if err != nil {
+		t.Fatalf("failed to read latest: %v", err)
+	}
+	if string(latestData) != "ask-session-id" {
+		t.Errorf("latest = %q, want %q; MCP session overwrote the CLI latest pointer", string(latestData), "ask-session-id")
+	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -46,6 +46,7 @@ func NewServer(m *muse.Muse) *server.MCPServer {
 			result, err := m.Ask(ctx, muse.AskInput{
 				Question:  question,
 				SessionID: museSessionID,
+				New:       museSessionID == "", // First call for this client; don't resume latest from "muse ask".
 			})
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("failed to ask: %v", err)), nil

--- a/internal/muse/muse.go
+++ b/internal/muse/muse.go
@@ -147,6 +147,13 @@ func (m *Muse) Document() string {
 	return m.document
 }
 
+// SetLatest updates the "latest" session pointer on disk so a subsequent
+// `muse ask` (without --new) resumes this session. Only the CLI path should
+// call this — MCP sessions persist but don't compete for the latest pointer.
+func (m *Muse) SetLatest(sessionID string) {
+	m.sessions.setLatest(sessionID)
+}
+
 // SyncProgressFunc receives sync progress from source providers during Upload.
 // The source parameter identifies which provider sent the update.
 type SyncProgressFunc func(source string, p conversation.SyncProgress)

--- a/internal/muse/session.go
+++ b/internal/muse/session.go
@@ -79,7 +79,21 @@ func (s *sessionStore) latestID() string {
 	return string(data)
 }
 
-// persistSession writes a session to disk and updates the latest pointer.
+// setLatest updates the latest pointer on disk so the CLI can resume.
+// Only callers that own the "resume last session" UX should call this.
+// Fire-and-forget: the latest pointer is a convenience shortcut, not
+// a correctness requirement — a failure here means the next `muse ask`
+// starts a new session instead of resuming, which is acceptable.
+func (s *sessionStore) setLatest(id string) {
+	if s.dir == "" {
+		return
+	}
+	if err := os.WriteFile(filepath.Join(s.dir, "latest"), []byte(id), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to update latest pointer: %v\n", err)
+	}
+}
+
+// persistSession writes a session to disk.
 func persistSession(dir string, session *Session) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
@@ -88,10 +102,7 @@ func persistSession(dir string, session *Session) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(dir, session.ID+".json"), data, 0o644); err != nil {
-		return err
-	}
-	return os.WriteFile(filepath.Join(dir, "latest"), []byte(session.ID), 0o644)
+	return os.WriteFile(filepath.Join(dir, session.ID+".json"), data, 0o644)
 }
 
 // loadSession reads a session from disk.


### PR DESCRIPTION
## Summary

- `muse listen` now persists sessions to `~/.muse/sessions/`, fixing the bug where MCP conversations were lost on process restart and never appeared on disk
- MCP server forces a fresh session on first call, preventing it from accidentally resuming a stale `muse ask` session via the `latest` pointer
- Split the `latest` pointer update out of `persistSession` into a separate `setLatest` method, exposed as `Muse.SetLatest()` — only called by `cmd/ask.go`, never by the MCP path
- Updated `designs/sessions.md` to reflect that both paths persist but only the CLI owns the `latest` pointer
- Two new e2e tests: session persistence to disk, and latest pointer isolation between MCP and CLI

## Test plan

- `go test ./e2e/ -run TestMCP` — all 7 pass (5 existing + 2 new)
- CLI smoke test: sent MCP request to `muse listen`, verified session file appeared in `~/.muse/sessions/` and `latest` pointer was unchanged