### PR TITLE
Triage + owner-only observe for large conversations

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -25,7 +25,7 @@ func newComposeCmd() *cobra.Command {
 	var learn bool
 	var limit int
 	var method string
-	var preserveContext bool
+	var context string
 	cmd := &cobra.Command{
 		Use:   "compose",
 		Short: "Compose a muse from conversations",
@@ -88,7 +88,7 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 
 			switch method {
 			case "clustering":
-				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, preserveContext, limit, uploaded, uploadBytes)
+				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, compose.ContextStrategy(context), limit, uploaded, uploadBytes)
 			case "map-reduce":
 				return runMapReduceCompose(ctx, cmd.OutOrStdout(), store, reobserve, learn, limit)
 			default:
@@ -101,11 +101,11 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 	cmd.Flags().BoolVar(&learn, "learn", false, "skip observe, recompose muse from existing observations (map-reduce only)")
 	cmd.Flags().IntVar(&limit, "limit", 0, "max conversations to observe per run (0 = no limit)")
 	cmd.Flags().StringVar(&method, "method", "clustering", "composition method: clustering or map-reduce")
-	cmd.Flags().BoolVar(&preserveContext, "preserve-context", false, "keep more assistant context before owner corrections during observation")
+	cmd.Flags().StringVar(&context, "context", "", "compression context strategy: '' (default 500 chars) or 'adaptive' (scale by owner message length)")
 	return cmd
 }
 
-func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel, preserveContext bool, limit, uploaded, uploadBytes int) error {
+func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel bool, ctxStrategy compose.ContextStrategy, limit, uploaded, uploadBytes int) error {
 	observeLLM, err := newLLMClient(ctx, TierFast)
 	if err != nil {
 		return err
@@ -122,10 +122,10 @@ func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.St
 		composeLLM, // compose
 		compose.ClusteredOptions{
 			BaseOptions: compose.BaseOptions{
-				Reobserve:       reobserve,
-				Limit:           limit,
-				Verbose:         verbose,
-				PreserveContext: preserveContext,
+				Reobserve: reobserve,
+				Limit:     limit,
+				Verbose:   verbose,
+				Context:   ctxStrategy,
 			},
 			Relabel:     relabel,
 			Uploaded:    uploaded,

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -25,6 +25,7 @@ func newComposeCmd() *cobra.Command {
 	var learn bool
 	var limit int
 	var method string
+	var preserveContext bool
 	cmd := &cobra.Command{
 		Use:   "compose",
 		Short: "Compose a muse from conversations",
@@ -87,7 +88,7 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 
 			switch method {
 			case "clustering":
-				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, limit, uploaded, uploadBytes)
+				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, preserveContext, limit, uploaded, uploadBytes)
 			case "map-reduce":
 				return runMapReduceCompose(ctx, cmd.OutOrStdout(), store, reobserve, learn, limit)
 			default:
@@ -100,10 +101,11 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 	cmd.Flags().BoolVar(&learn, "learn", false, "skip observe, recompose muse from existing observations (map-reduce only)")
 	cmd.Flags().IntVar(&limit, "limit", 0, "max conversations to observe per run (0 = no limit)")
 	cmd.Flags().StringVar(&method, "method", "clustering", "composition method: clustering or map-reduce")
+	cmd.Flags().BoolVar(&preserveContext, "preserve-context", false, "keep more assistant context before owner corrections during observation")
 	return cmd
 }
 
-func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel bool, limit, uploaded, uploadBytes int) error {
+func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel, preserveContext bool, limit, uploaded, uploadBytes int) error {
 	observeLLM, err := newLLMClient(ctx, TierFast)
 	if err != nil {
 		return err
@@ -120,9 +122,10 @@ func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.St
 		composeLLM, // compose
 		compose.ClusteredOptions{
 			BaseOptions: compose.BaseOptions{
-				Reobserve: reobserve,
-				Limit:     limit,
-				Verbose:   verbose,
+				Reobserve:       reobserve,
+				Limit:           limit,
+				Verbose:         verbose,
+				PreserveContext: preserveContext,
 			},
 			Relabel:     relabel,
 			Uploaded:    uploaded,

--- a/cmd/eval_context.go
+++ b/cmd/eval_context.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ellistarn/muse/internal/compose"
+	"github.com/ellistarn/muse/internal/conversation"
+	"github.com/ellistarn/muse/prompts"
+	"github.com/spf13/cobra"
+)
+
+func newEvalContextCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "eval-context [conversation-id]",
+		Short: "Compare observation strategies on a single conversation",
+		Long: `Loads a conversation snapshot, runs the observe pipeline under each
+context strategy (default, adaptive), and prints observations side by side.
+Uses a snapshot to ensure repeatable comparisons.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runEvalContext(cmd.Context(), args[0])
+		},
+	}
+	return cmd
+}
+
+func runEvalContext(ctx context.Context, convID string) error {
+	// Find the conversation file
+	convPath, err := findConversation(convID)
+	if err != nil {
+		return err
+	}
+
+	// Load and snapshot the conversation
+	data, err := os.ReadFile(convPath)
+	if err != nil {
+		return fmt.Errorf("read conversation: %w", err)
+	}
+	var conv conversation.Conversation
+	if err := json.Unmarshal(data, &conv); err != nil {
+		return fmt.Errorf("parse conversation: %w", err)
+	}
+	if conv.Source == "" {
+		conv.Source = sourceFromPath(convPath)
+	}
+
+	fmt.Fprintf(os.Stderr, "conversation: %s\n", convPath)
+	fmt.Fprintf(os.Stderr, "messages:     %d\n", len(conv.Messages))
+	fmt.Fprintf(os.Stderr, "source:       %s\n\n", conv.Source)
+
+	llm, err := newLLMClient(ctx, TierFast)
+	if err != nil {
+		return err
+	}
+
+	strategies := []struct {
+		name    string
+		ctx     compose.ContextStrategy
+	}{
+		{"default (500 chars)", compose.ContextDefault},
+		{"adaptive (500-2000)", compose.ContextAdaptive},
+	}
+
+	results := make([][]compose.Observation, len(strategies))
+
+	for i, s := range strategies {
+		fmt.Fprintf(os.Stderr, "--- strategy: %s ---\n", s.name)
+
+		raw, obs, usage, err := compose.ObserveForTestVerbose(ctx, llm, &conv, s.ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  error: %v\n", err)
+			continue
+		}
+		results[i] = obs
+		fmt.Fprintf(os.Stderr, "  observations: %d  tokens: %dk in / %dk out  cost: $%.4f\n",
+			len(obs), usage.InputTokens/1000, usage.OutputTokens/1000, usage.Cost())
+		fmt.Fprintf(os.Stderr, "  raw output (%d chars): %s\n", len(raw), raw[:min(len(raw), 500)])
+		fmt.Fprintln(os.Stderr)
+	}
+
+	// Print side-by-side comparison
+	fmt.Println()
+	for i, s := range strategies {
+		fmt.Printf("=== %s: %d observations ===\n\n", s.name, len(results[i]))
+		for j, obs := range results[i] {
+			if obs.Quote != "" {
+				fmt.Printf("  [%d] Quote: %s\n", j+1, truncateStr(obs.Quote, 120))
+			}
+			fmt.Printf("  [%d] %s\n\n", j+1, truncateStr(obs.Text, 300))
+		}
+	}
+
+	// Print prompt used (first 200 chars for identification)
+	observePrompt := prompts.Observe
+	if isHumanSource(conv.Source) {
+		observePrompt = prompts.ObserveHuman
+	}
+	fmt.Printf("--- prompt (first 200 chars) ---\n%s\n", truncateStr(observePrompt, 200))
+
+	return nil
+}
+
+func findConversation(id string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	// Search across all sources
+	sources := []string{"claude-code", "kiro-cli", "kiro", "opencode", "codex",
+		"github-issues", "github-prs", "slack"}
+	for _, src := range sources {
+		pattern := filepath.Join(home, ".muse", "conversations", src, id+"*")
+		matches, _ := filepath.Glob(pattern)
+		if len(matches) > 0 {
+			return matches[0], nil
+		}
+	}
+	// Try as a direct path
+	if _, err := os.Stat(id); err == nil {
+		return id, nil
+	}
+	return "", fmt.Errorf("conversation %q not found", id)
+}
+
+func sourceFromPath(path string) string {
+	parts := strings.Split(path, "/conversations/")
+	if len(parts) < 2 {
+		return "unknown"
+	}
+	return strings.Split(parts[1], "/")[0]
+}
+
+func truncateStr(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-3] + "..."
+}
+
+func isHumanSource(source string) bool {
+	switch source {
+	case "slack", "github-issues", "github-prs":
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,7 @@ Run "muse listen --help" for MCP server configuration.`,
 	cmd.AddCommand(newEvalCmd())
 	cmd.AddCommand(newAddCmd())
 	cmd.AddCommand(newRemoveCmd())
+	cmd.AddCommand(newEvalContextCmd())
 	return cmd
 }
 

--- a/designs/009-observations.md
+++ b/designs/009-observations.md
@@ -38,13 +38,68 @@ When the owner says "on line 12, be more specific," compression preserves the di
 strips line 12. The observation captures a general preference instead of a specific
 transformation.
 
-The fix is to make compression context-aware. When the owner's next message is a short
-correction (under ~50 words), the preceding assistant content is likely what prompted it.
-Preserving more of that content (assistant text, code blocks, or tool results depending on
-where the context lives) gives the observe prompt what it needs to produce specific
-observations.
+### Approaches attempted and abandoned
 
-`--preserve-context` enables this. Default off to preserve current token costs.
+**A: Adaptive compression.** Scale the assistant text limit by owner message length
+(500-2000 chars). More context diluted signal: 17k chars produced 0 observations while
+13k produced 5. The extra context made the conversation look more routine.
+
+**B: Prompt-driven extraction.** Ask the observe prompt for transformations, not just
+principles. Made the LLM more cautious, producing fewer observations.
+
+**C: Context-aware prompting.** Ask the LLM to reason about what context each response
+requires. Same regression as B.
+
+**D: Mechanical turn filtering.** Remove confirmations and short directives before
+observe. Insufficient: many low-signal turns survive word-count and pattern filters.
+
+**E: LLM triage + full conversation.** Cheap LLM call classifies turns as reasoning vs
+housekeeping, then pass triaged turns through the standard compression pipeline. Triage
+works well, but observe still returns NONE on the compressed triaged conversation.
+
+### What we found
+
+The observe prompt produces strong observations from concentrated owner input: 6 curated
+owner messages produce 5-6 observations with specific quotes and reasoning. The same
+messages embedded in a full compressed conversation (with assistant text, tool markers,
+and mechanical turns) produce NONE consistently.
+
+The problem is not context preservation, compression limits, or prompt wording. It is
+volume. The observe prompt gives up when there are too many messages to evaluate,
+regardless of their quality. Assistant context makes this worse by making every
+conversation look like routine agent direction.
+
+### Solution: triage + owner-only observe
+
+For conversations with more than 10 turns:
+
+1. **Mechanical filter.** Remove confirmations, mechanical directives, interrupted
+   requests. Pattern matching on known low-signal phrases.
+2. **LLM triage.** Cheap classification pass identifies which remaining turns contain
+   reasoning, decisions, corrections, or design thinking.
+3. **Owner-only observe.** Feed only the owner's messages from triaged turns to the
+   observe prompt. No assistant context, no compression, no refine step.
+
+For small conversations (10 turns or fewer), the original pipeline works: compress
+the full conversation and run observe + refine.
+
+Results on two test conversations:
+
+| Conversation | Turns | Old pipeline | New pipeline |
+|---|---|---|---|
+| RFC design session (104 msgs, 27 turns) | 27 → 15 → 11 | 0 observations | 7 observations |
+| Orwell pass editing (211 msgs, 26 turns) | 26 → 19 → 16 | 0 observations | 9 observations |
+
+The observations are specific: "Uses formal analysis to constrain the design space,
+then derives a natural set ({1, 2, 3}) rather than making it configurable beyond what
+the math supports." "Monitors the AI's vocabulary for jargon that doesn't match how
+they actually speak, and flags it directly."
+
+### Prompt update: agent-directed work
+
+The observe prompt now recognizes that agent-directed work carries signal. When the
+owner corrects the agent's draft, makes design decisions through the agent, or rewrites
+the agent's output in their own voice, the prompt treats it as reasoning, not routine.
 
 ## Fingerprinting
 

--- a/designs/009-observations.md
+++ b/designs/009-observations.md
@@ -57,17 +57,24 @@ observe. Insufficient: many low-signal turns survive word-count and pattern filt
 housekeeping, then pass triaged turns through the standard compression pipeline. Triage
 works well, but observe still returns NONE on the compressed triaged conversation.
 
-### What we found
+### What we found: context rot
 
-The observe prompt produces strong observations from concentrated owner input: 6 curated
-owner messages produce 5-6 observations with specific quotes and reasoning. The same
-messages embedded in a full compressed conversation (with assistant text, tool markers,
-and mechanical turns) produce NONE consistently.
+Long conversations exhibit context rot. Early turns carry design decisions, corrections,
+and reasoning. Later turns accumulate mechanical work: git operations, CI checks,
+formatting fixes. The signal-to-noise ratio degrades as the conversation grows.
 
-The problem is not context preservation, compression limits, or prompt wording. It is
-volume. The observe prompt gives up when there are too many messages to evaluate,
-regardless of their quality. Assistant context makes this worse by making every
-conversation look like routine agent direction.
+The observe prompt reads through the compressed conversation sequentially. When reasoning
+turns from early in the conversation are followed by pages of mechanical turns, the LLM's
+attention drifts to the recent, mechanical content. Reasoning that is still in the context
+window gets washed out by surrounding noise. The result is NONE for the whole conversation.
+
+This is a local signal problem, not a global ratio problem. Turn 4 is a design decision
+regardless of what turns 15-27 contain. But observing the full conversation forces the
+LLM to evaluate turn 4 in the context of everything that came after it.
+
+The triage + owner-only approach works around this by stripping noise before observe sees
+it. A more fundamental fix would observe in local windows so that no turn is ever evaluated
+in the context of distant mechanical turns. See reboot.md for next steps.
 
 ### Solution: triage + owner-only observe
 

--- a/designs/009-observations.md
+++ b/designs/009-observations.md
@@ -38,24 +38,34 @@ When the owner says "on line 12, be more specific," compression preserves the di
 strips line 12. The observation captures a general preference instead of a specific
 transformation.
 
-### Approaches attempted and abandoned
+### Approaches attempted and abandoned after experiments
 
 **A: Adaptive compression.** Scale the assistant text limit by owner message length
-(500-2000 chars). More context diluted signal: 17k chars produced 0 observations while
-13k produced 5. The extra context made the conversation look more routine.
+(500-2000 chars). More context diluted signal in local experiments: 17k chars
+produced 0 observations while 13k produced 5. The extra context made the
+conversation look less interesting to muse.
 
 **B: Prompt-driven extraction.** Ask the observe prompt for transformations, not just
 principles. Made the LLM more cautious, producing fewer observations.
 
 **C: Context-aware prompting.** Ask the LLM to reason about what context each response
-requires. Same regression as B.
+requires. Same performance regression relative to mainline as B.
 
-**D: Mechanical turn filtering.** Remove confirmations and short directives before
-observe. Insufficient: many low-signal turns survive word-count and pattern filters.
+**D: Word-count and pattern filters.** Remove confirmations and short directives before
+observe by matching known low-signal phrases and applying a minimum word count. Insufficient:
+many low-signal turns survive the patterns, and the turns that are removed aren't the ones
+causing observe to fail.
 
-**E: LLM triage + full conversation.** Cheap LLM call classifies turns as reasoning vs
+**E: LLM triage + compressed conversation.** Cheap LLM call classifies turns as reasoning vs
 housekeeping, then pass triaged turns through the standard compression pipeline. Triage
-works well, but observe still returns NONE on the compressed triaged conversation.
+works as a classifier — it correctly identifies which turns contain reasoning. But observe
+still returns NONE on the compressed triaged conversation. The triaged output still includes
+compressed assistant text (~500 chars per turn), and that's enough to trigger the same
+failure. We don't have a proven mechanism for why assistant text in reasoning turns kills
+observe. Possible explanations: pure volume (11 triaged turns × 500 chars of assistant text),
+attention shifting to the assistant's framing instead of the owner's reasoning, or mixed-role
+presentation changing how the model processes the input. We tested the endpoint (owner-only
+works, mixed doesn't) but not the mechanism.
 
 ### What we found: context rot
 

--- a/designs/reboot.md
+++ b/designs/reboot.md
@@ -1,0 +1,83 @@
+# Context Preservation: Reboot
+
+## Where we are
+
+Branch `preserve-context` has a working implementation: mechanical filter → LLM triage →
+owner-only observe. It turns 0-observation conversations into 7-9 observation conversations.
+Not yet pushed or PR'd. The design doc (009-observations.md) documents five abandoned
+approaches and the working one.
+
+## What we learned
+
+The observation pipeline has a context rot problem. Conversations start with design
+decisions and end with execution. The observe prompt processes the full conversation
+and loses the early reasoning signal under later mechanical noise.
+
+Five approaches failed by treating this as a compression, prompt, or filtering problem:
+
+- **Adaptive compression** (scale assistant text by owner message length): more context
+  diluted signal. 17k chars produced 0 observations, 13k produced 5.
+- **Prompt-driven extraction** (ask for transformations not principles): made the LLM
+  more cautious, produced fewer observations.
+- **Context-aware prompting** (ask the LLM to reason about what context is needed):
+  same regression.
+- **Mechanical turn filtering** (remove confirmations by pattern matching): insufficient,
+  many low-signal turns survive patterns.
+- **LLM triage + compressed conversation**: triage correctly identifies reasoning turns,
+  but observe still returns NONE on the compressed triaged conversation.
+
+The breakthrough: stripping assistant text entirely and feeding observe only the owner's
+messages from triaged turns. 6 curated owner messages → 5 observations. 27 mixed messages
+→ 0. The problem is volume and attention, not missing context.
+
+## The real problem: local signal, global observation
+
+Context rot is a local signal problem. Turn 4 is a design decision regardless of what
+turns 15-27 contain. But the current pipeline evaluates the full conversation at once.
+The LLM reads sequentially, and mechanical turns wash out earlier reasoning turns.
+
+The triage + owner-only approach is a workaround. It strips noise so observe sees
+concentrated signal. But it's still observing the full conversation's worth of owner
+messages at once, and it requires an extra LLM call for triage.
+
+## Next step: windowed observation
+
+Observe in sliding windows of 5-10 turns. Each window is small enough that local signal
+survives. No turn is evaluated in the context of distant mechanical turns.
+
+The pipeline would be:
+1. Extract turns as today
+2. Walk through turns in overlapping windows (e.g. 8 turns, stride 4)
+3. Run observe on each window independently
+4. Collect all observations, deduplicate
+
+This treats context rot at the source (temporal locality) rather than the symptom
+(filtering). Each window captures reasoning in its local context. Mechanical windows
+produce NONE, reasoning windows produce observations, and that's correct.
+
+Questions to resolve:
+- Window size and stride. Too small loses multi-turn reasoning arcs. Too large
+  reintroduces context rot.
+- Deduplication. Adjacent windows overlap and may extract the same observation twice.
+- Cost. More observe calls per conversation. Offset by smaller inputs per call.
+- Whether windows need assistant context or owner-only. The current finding says
+  owner-only works, but that was tested on globally-triaged turns, not local windows.
+
+## Files changed on preserve-context branch
+
+- `cmd/compose.go` — ContextStrategy flag (can be removed if we drop adaptive)
+- `cmd/eval_context.go` — test harness for comparing strategies on single conversations
+- `cmd/root.go` — registered eval-context command
+- `designs/009-observations.md` — compression section with findings
+- `internal/compose/clustered.go` — observeAndRefine with triage + owner-only path
+- `internal/compose/compose.go` — ContextStrategy type, filterLowSignalTurns, triageTurns
+- `prompts/observe.md` — agent-directed work paragraph
+- `prompts/prompts.go` — triage embed
+- `prompts/triage.md` — triage prompt
+
+## Test harness
+
+`muse eval-context <conversation-id-or-path>` runs the observe pipeline under each
+strategy on a single conversation and prints observations side by side. Useful for
+iterating on the pipeline without running full compose. Snapshot conversations to /tmp
+for repeatable comparisons (conversations grow between runs).

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -431,7 +431,7 @@ func runObserve(
 				convBytes := conversationDataSize(conv)
 
 				start := time.Now()
-				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose)
+				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose, opts.PreserveContext)
 				n := counter.Add(1)
 				if err != nil {
 					return fmt.Errorf("observe %s: %w", entry.Key, err)
@@ -499,8 +499,8 @@ func conversationDataSize(conv *conversation.Conversation) int {
 // exceeds the context window, mechanical compression is applied as a fallback:
 // code blocks are stripped, tool output is collapsed to [tool: name] markers,
 // and long assistant messages are truncated.
-func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool) ([]Observation, inference.Usage, error) {
-	refined, usage, err := observeAndRefine(ctx, client, conv, verbose)
+func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose, preserveContext bool) ([]Observation, inference.Usage, error) {
+	refined, usage, err := observeAndRefine(ctx, client, conv, verbose, preserveContext)
 	if err != nil {
 		return nil, usage, err
 	}
@@ -539,13 +539,13 @@ func observeAndParse(ctx context.Context, client inference.Client, conv *convers
 // prompt in chunks, and refines the candidates into a single text.
 // Both the map-reduce path (which wants raw text) and the clustering path
 // (which further parses into discrete items) call this function.
-func observeAndRefine(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool) (string, inference.Usage, error) {
+func observeAndRefine(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose, preserveContext bool) (string, inference.Usage, error) {
 	turns := extractTurns(conv)
 	if len(turns) == 0 {
 		return "", inference.Usage{}, nil
 	}
 
-	chunks := compressConversation(turns, conv.Source)
+	chunks := compressConversation(turns, conv.Source, preserveContext)
 	if len(chunks) == 0 {
 		return "", inference.Usage{}, nil
 	}
@@ -602,6 +602,16 @@ func observeAndRefine(ctx context.Context, client inference.Client, conv *conver
 // full assistant text.
 const maxAssistantChars = 500
 
+// maxAssistantCharsPreserved is the limit when the owner's response looks like
+// a correction or edit directive. Short owner responses to long assistant turns
+// are likely reacting to specific content, so we preserve more context.
+const maxAssistantCharsPreserved = 2000
+
+// maxCorrectionWords is the word count threshold for detecting owner corrections.
+// Messages shorter than this that follow a long assistant turn are likely
+// reacting to specific content in that turn.
+const maxCorrectionWords = 50
+
 // isHumanSource returns true for sources where conversations are between
 // the owner and other people (not AI assistants).
 func isHumanSource(source string) bool {
@@ -616,7 +626,11 @@ func isHumanSource(source string) bool {
 // compressConversation mechanically compresses turns for observation: strips
 // code blocks, collapses tool output to [tool: name] markers, and truncates
 // long assistant/peer messages. Returns chunked text ready for the observe prompt.
-func compressConversation(turns []turn, source string) []string {
+//
+// When preserveContext is true, short owner messages (likely corrections or edit
+// directives) get more preceding assistant context preserved, so the observe
+// prompt can see what the owner was reacting to.
+func compressConversation(turns []turn, source string, preserveContext bool) []string {
 	var chunks []string
 	var b strings.Builder
 
@@ -629,7 +643,11 @@ func compressConversation(turns []turn, source string) []string {
 	for _, t := range turns {
 		var entry string
 		if t.assistantContent != "" {
-			compressed := compressAssistant(t.assistantContent)
+			limit := maxAssistantChars
+			if preserveContext && isLikelyCorrection(t.humanContent) {
+				limit = maxAssistantCharsPreserved
+			}
+			compressed := compressAssistantWithLimit(t.assistantContent, limit)
 			entry = fmt.Sprintf("%s: %s\n%s: %s\n\n", peerLabel, compressed, ownerLabel, t.humanContent)
 		} else {
 			entry = fmt.Sprintf("%s: %s\n\n", ownerLabel, t.humanContent)
@@ -647,15 +665,24 @@ func compressConversation(turns []turn, source string) []string {
 	return chunks
 }
 
+// isLikelyCorrection returns true when an owner message is short enough to be
+// a correction or edit directive rather than a substantive new contribution.
+func isLikelyCorrection(humanContent string) bool {
+	words := len(strings.Fields(humanContent))
+	return words > 0 && words <= maxCorrectionWords
+}
+
 // compressAssistant strips code blocks, collapses tool markers, and truncates.
 func compressAssistant(content string) string {
-	// Strip fenced code blocks (```...```)
-	result := stripCodeBlocks(content)
+	return compressAssistantWithLimit(content, maxAssistantChars)
+}
 
-	// Truncate if still too long
+// compressAssistantWithLimit strips code blocks and truncates to the given limit.
+func compressAssistantWithLimit(content string, limit int) string {
+	result := stripCodeBlocks(content)
 	result = strings.TrimSpace(result)
-	if len(result) > maxAssistantChars {
-		result = result[:maxAssistantChars] + "..."
+	if len(result) > limit {
+		result = result[:limit] + "..."
 	}
 	return result
 }

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -431,7 +431,7 @@ func runObserve(
 				convBytes := conversationDataSize(conv)
 
 				start := time.Now()
-				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose, opts.PreserveContext)
+				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose, opts.Context)
 				n := counter.Add(1)
 				if err != nil {
 					return fmt.Errorf("observe %s: %w", entry.Key, err)
@@ -492,6 +492,26 @@ func conversationDataSize(conv *conversation.Conversation) int {
 	return n
 }
 
+// ObserveForTestVerbose runs the full observe pipeline on a single conversation,
+// returning the raw observe output and parsed observations.
+func ObserveForTestVerbose(ctx context.Context, client inference.Client, conv *conversation.Conversation, ctxStrategy ContextStrategy) (string, []Observation, inference.Usage, error) {
+	raw, usage, err := observeAndRefine(ctx, client, conv, true, ctxStrategy)
+	if err != nil {
+		return "", nil, usage, err
+	}
+	if raw == "" {
+		return "", nil, usage, nil
+	}
+	items := parseObservationItems(raw)
+	var relevant []Observation
+	for _, item := range items {
+		if isRelevant(item.Text) {
+			relevant = append(relevant, item)
+		}
+	}
+	return raw, relevant, usage, nil
+}
+
 // observeAndParse runs the observe pipeline on a conversation and returns
 // discrete observations (not a markdown blob).
 //
@@ -499,8 +519,8 @@ func conversationDataSize(conv *conversation.Conversation) int {
 // exceeds the context window, mechanical compression is applied as a fallback:
 // code blocks are stripped, tool output is collapsed to [tool: name] markers,
 // and long assistant messages are truncated.
-func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose, preserveContext bool) ([]Observation, inference.Usage, error) {
-	refined, usage, err := observeAndRefine(ctx, client, conv, verbose, preserveContext)
+func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, ctxStrategy ContextStrategy) ([]Observation, inference.Usage, error) {
+	refined, usage, err := observeAndRefine(ctx, client, conv, verbose, ctxStrategy)
 	if err != nil {
 		return nil, usage, err
 	}
@@ -539,16 +559,13 @@ func observeAndParse(ctx context.Context, client inference.Client, conv *convers
 // prompt in chunks, and refines the candidates into a single text.
 // Both the map-reduce path (which wants raw text) and the clustering path
 // (which further parses into discrete items) call this function.
-func observeAndRefine(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose, preserveContext bool) (string, inference.Usage, error) {
+func observeAndRefine(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, ctxStrategy ContextStrategy) (string, inference.Usage, error) {
 	turns := extractTurns(conv)
 	if len(turns) == 0 {
 		return "", inference.Usage{}, nil
 	}
 
-	chunks := compressConversation(turns, conv.Source, preserveContext)
-	if len(chunks) == 0 {
-		return "", inference.Usage{}, nil
-	}
+	var totalUsage inference.Usage
 
 	// Select the appropriate observe prompt based on source type
 	observePrompt := prompts.Observe
@@ -556,61 +573,118 @@ func observeAndRefine(ctx context.Context, client inference.Client, conv *conver
 		observePrompt = prompts.ObserveHuman
 	}
 
-	var totalUsage inference.Usage
+	// For large conversations, concentrate signal: filter → triage → owner-only.
+	// The observe prompt works well on concentrated input but returns NONE when
+	// high-signal turns are diluted by mechanical agent interaction.
+	observeInput := ""
+	if len(turns) > 10 {
+		// Mechanical filter
+		filtered := filterLowSignalTurns(turns)
+		if verbose && len(filtered) < len(turns) {
+			fmt.Fprintf(os.Stderr, "    filter %d → %d turns (%d low-signal removed)\n",
+				len(turns), len(filtered), len(turns)-len(filtered))
+		}
+		if len(filtered) == 0 {
+			return "", totalUsage, nil
+		}
 
-	// Observe (Pass 1)
-	var allCandidates []string
-	for i, chunk := range chunks {
+		// LLM triage
+		triaged := filtered
+		if len(filtered) > 10 {
+			t, usage, err := triageTurns(ctx, client, filtered, conv.Source, verbose)
+			totalUsage = totalUsage.Add(usage)
+			if err != nil {
+				if verbose {
+					fmt.Fprintf(os.Stderr, "    triage error, falling back: %v\n", err)
+				}
+			} else if len(t) > 0 {
+				triaged = t
+			}
+		}
+		if len(triaged) == 0 {
+			return "", totalUsage, nil
+		}
+
+		// Owner-only: strip assistant context entirely
+		var b strings.Builder
+		for _, t := range triaged {
+			fmt.Fprintf(&b, "[owner]: %s\n\n", t.humanContent)
+		}
+		observeInput = b.String()
+		if verbose {
+			fmt.Fprintf(os.Stderr, "    owner-only %d turns, %d chars\n", len(triaged), len(observeInput))
+		}
+	}
+
+	// For small conversations, use the original compression pipeline
+	if observeInput == "" {
+		chunks := compressConversation(turns, conv.Source, ctxStrategy)
+		if len(chunks) == 0 {
+			return "", totalUsage, nil
+		}
+		// Small conversations: observe + refine as before
+		var allCandidates []string
+		for i, chunk := range chunks {
+			start := time.Now()
+			obs, usage, err := inference.Converse(ctx, client, observePrompt, chunk, inference.WithMaxTokens(4096))
+			totalUsage = totalUsage.Add(usage)
+			if verbose {
+				fmt.Fprintf(os.Stderr, "      observe[%d/%d] %d chars → %d chars (%s, $%.4f)\n",
+					i+1, len(chunks), len(chunk), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+			}
+			if err != nil && obs == "" {
+				return "", totalUsage, err
+			}
+			if obs != "" && !isEmpty(obs) {
+				allCandidates = append(allCandidates, obs)
+			}
+		}
+		if len(allCandidates) == 0 {
+			return "", totalUsage, nil
+		}
+		candidates := strings.Join(allCandidates, "\n\n")
 		start := time.Now()
-		obs, usage, err := inference.Converse(ctx, client, observePrompt, chunk, inference.WithMaxTokens(4096))
+		refined, usage, err := inference.Converse(ctx, client, prompts.Refine, candidates, inference.WithMaxTokens(4096))
 		totalUsage = totalUsage.Add(usage)
 		if verbose {
-			fmt.Fprintf(os.Stderr, "      observe[%d/%d] %d chars → %d chars (%s, $%.4f)\n",
-				i+1, len(chunks), len(chunk), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+			fmt.Fprintf(os.Stderr, "      refine %d chars → %d chars (%s, $%.4f)\n",
+				len(candidates), len(refined), time.Since(start).Round(time.Millisecond), usage.Cost())
 		}
-		if err != nil && obs == "" {
+		if err != nil && refined == "" {
 			return "", totalUsage, err
 		}
-		if obs != "" && !isEmpty(obs) {
-			allCandidates = append(allCandidates, obs)
+		if isEmpty(refined) {
+			return "", totalUsage, nil
 		}
-	}
-	if len(allCandidates) == 0 {
-		return "", totalUsage, nil
+		return refined, totalUsage, nil
 	}
 
-	// Refine (Pass 2)
-	candidates := strings.Join(allCandidates, "\n\n")
+	// Large conversations: single observe pass on owner-only text, no refine
 	start := time.Now()
-	refined, usage, err := inference.Converse(ctx, client, prompts.Refine, candidates, inference.WithMaxTokens(4096))
+	obs, usage, err := inference.Converse(ctx, client, observePrompt, observeInput, inference.WithMaxTokens(4096))
 	totalUsage = totalUsage.Add(usage)
 	if verbose {
-		fmt.Fprintf(os.Stderr, "      refine %d chars → %d chars (%s, $%.4f)\n",
-			len(candidates), len(refined), time.Since(start).Round(time.Millisecond), usage.Cost())
+		fmt.Fprintf(os.Stderr, "      observe %d chars → %d chars (%s, $%.4f)\n",
+			len(observeInput), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
 	}
-	if err != nil && refined == "" {
+	if err != nil && obs == "" {
 		return "", totalUsage, err
 	}
-	if isEmpty(refined) {
+	if isEmpty(obs) {
 		return "", totalUsage, nil
 	}
-	return refined, totalUsage, nil
+	return obs, totalUsage, nil
 }
 
-// maxAssistantChars caps truncated assistant messages. Long assistant output is
-// mostly code or tool results — the human's reaction is what matters, not the
-// full assistant text.
-const maxAssistantChars = 500
-
-// maxAssistantCharsPreserved is the limit when the owner's response looks like
-// a correction or edit directive. Short owner responses to long assistant turns
-// are likely reacting to specific content, so we preserve more context.
-const maxAssistantCharsPreserved = 2000
-
-// maxCorrectionWords is the word count threshold for detecting owner corrections.
-// Messages shorter than this that follow a long assistant turn are likely
-// reacting to specific content in that turn.
-const maxCorrectionWords = 50
+// Assistant text limits for adaptive compression. Short owner messages are
+// likely corrections reacting to specific content, so we preserve more of the
+// preceding assistant turn. Long owner messages carry their own context.
+const (
+	minAssistantChars = 500  // limit for long owner messages (>= maxOwnerWords)
+	maxAssistantChars = 2000 // limit for very short owner messages (<= minOwnerWords)
+	minOwnerWords     = 5    // at or below this, full context preserved
+	maxOwnerWords     = 100  // at or above this, minimal context preserved
+)
 
 // isHumanSource returns true for sources where conversations are between
 // the owner and other people (not AI assistants).
@@ -626,11 +700,7 @@ func isHumanSource(source string) bool {
 // compressConversation mechanically compresses turns for observation: strips
 // code blocks, collapses tool output to [tool: name] markers, and truncates
 // long assistant/peer messages. Returns chunked text ready for the observe prompt.
-//
-// When preserveContext is true, short owner messages (likely corrections or edit
-// directives) get more preceding assistant context preserved, so the observe
-// prompt can see what the owner was reacting to.
-func compressConversation(turns []turn, source string, preserveContext bool) []string {
+func compressConversation(turns []turn, source string, ctx ContextStrategy) []string {
 	var chunks []string
 	var b strings.Builder
 
@@ -643,9 +713,9 @@ func compressConversation(turns []turn, source string, preserveContext bool) []s
 	for _, t := range turns {
 		var entry string
 		if t.assistantContent != "" {
-			limit := maxAssistantChars
-			if preserveContext && isLikelyCorrection(t.humanContent) {
-				limit = maxAssistantCharsPreserved
+			limit := minAssistantChars
+			if ctx == ContextAdaptive {
+				limit = assistantCharLimit(t.humanContent)
 			}
 			compressed := compressAssistantWithLimit(t.assistantContent, limit)
 			entry = fmt.Sprintf("%s: %s\n%s: %s\n\n", peerLabel, compressed, ownerLabel, t.humanContent)
@@ -665,11 +735,20 @@ func compressConversation(turns []turn, source string, preserveContext bool) []s
 	return chunks
 }
 
-// isLikelyCorrection returns true when an owner message is short enough to be
-// a correction or edit directive rather than a substantive new contribution.
-func isLikelyCorrection(humanContent string) bool {
+// assistantCharLimit returns the truncation limit for an assistant message
+// based on the length of the owner's response. Interpolates linearly between
+// maxAssistantChars (short owner messages) and minAssistantChars (long ones).
+func assistantCharLimit(humanContent string) int {
 	words := len(strings.Fields(humanContent))
-	return words > 0 && words <= maxCorrectionWords
+	if words <= minOwnerWords {
+		return maxAssistantChars
+	}
+	if words >= maxOwnerWords {
+		return minAssistantChars
+	}
+	// Linear interpolation
+	frac := float64(words-minOwnerWords) / float64(maxOwnerWords-minOwnerWords)
+	return maxAssistantChars - int(frac*float64(maxAssistantChars-minAssistantChars))
 }
 
 // compressAssistant strips code blocks, collapses tool markers, and truncates.

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -59,6 +59,9 @@ type BaseOptions struct {
 	Limit int
 	// Verbose enables per-item progress logging.
 	Verbose bool
+	// PreserveContext keeps more assistant context before owner corrections,
+	// so the observe prompt can see what the owner was reacting to.
+	PreserveContext bool
 }
 
 // Options configures a map-reduce compose run.
@@ -287,7 +290,7 @@ type turn struct {
 }
 
 func observeConversation(ctx context.Context, client inference.Client, conv *conversation.Conversation) (string, inference.Usage, error) {
-	refined, usage, err := observeAndRefine(ctx, client, conv, false)
+	refined, usage, err := observeAndRefine(ctx, client, conv, false, false)
 	if err != nil {
 		return "", usage, err
 	}

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -2,6 +2,7 @@ package compose
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -51,6 +52,17 @@ type HitMiss struct {
 	Miss int
 }
 
+// ContextStrategy controls how much assistant context is preserved during
+// compression before the observe prompt sees the conversation.
+type ContextStrategy string
+
+const (
+	// ContextDefault uses the original fixed 500-char limit for all turns.
+	ContextDefault ContextStrategy = ""
+	// ContextAdaptive interpolates the limit by owner message length (500-2000 chars).
+	ContextAdaptive ContextStrategy = "adaptive"
+)
+
 // BaseOptions contains fields shared across all compose strategies.
 type BaseOptions struct {
 	// Reobserve ignores persisted observations and re-observes all conversations.
@@ -59,9 +71,8 @@ type BaseOptions struct {
 	Limit int
 	// Verbose enables per-item progress logging.
 	Verbose bool
-	// PreserveContext keeps more assistant context before owner corrections,
-	// so the observe prompt can see what the owner was reacting to.
-	PreserveContext bool
+	// Context controls the compression strategy for assistant text.
+	Context ContextStrategy
 }
 
 // Options configures a map-reduce compose run.
@@ -290,7 +301,7 @@ type turn struct {
 }
 
 func observeConversation(ctx context.Context, client inference.Client, conv *conversation.Conversation) (string, inference.Usage, error) {
-	refined, usage, err := observeAndRefine(ctx, client, conv, false, false)
+	refined, usage, err := observeAndRefine(ctx, client, conv, false, ContextDefault)
 	if err != nil {
 		return "", usage, err
 	}
@@ -425,4 +436,197 @@ func extractTurns(conv *conversation.Conversation) []turn {
 		}
 	}
 	return turns
+}
+
+// lowSignalPatterns matches owner messages that carry no distinctive reasoning:
+// confirmations, mechanical directives, and single-word responses.
+var lowSignalPatterns = []string{
+	"yes",
+	"yeah",
+	"yep",
+	"sure",
+	"ok",
+	"okay",
+	"do it",
+	"go ahead",
+	"looks good",
+	"lgtm",
+	"sounds good",
+	"thanks",
+	"thank you",
+	"no",
+	"nope",
+	"never mind",
+	"nevermind",
+}
+
+// mechanicalPrefixes matches owner messages that are agent directives without
+// reasoning: git operations, file management, and execution commands.
+var mechanicalPrefixes = []string{
+	"commit",
+	"push",
+	"squash",
+	"rebase",
+	"merge",
+	"deploy",
+	"run ",
+	"install",
+	"delete ",
+	"remove ",
+	"create ",
+}
+
+// filterLowSignalTurns removes turns where the owner's message is a
+// confirmation, mechanical directive, or otherwise carries no distinctive
+// reasoning. Keeps turns where the owner makes decisions, corrects something,
+// or explains why.
+func filterLowSignalTurns(turns []turn) []turn {
+	var kept []turn
+	for _, t := range turns {
+		if isLowSignal(t.humanContent) {
+			continue
+		}
+		kept = append(kept, t)
+	}
+	return kept
+}
+
+// minSignalWords is the minimum word count for a turn to be considered
+// potentially high-signal. Shorter messages are kept only if they contain
+// a question or quotation, which suggest reasoning or correction.
+const minSignalWords = 15
+
+func isLowSignal(content string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(content))
+	words := strings.Fields(normalized)
+
+	// Interrupted requests are always noise
+	if strings.Contains(normalized, "[request interrupted") {
+		return true
+	}
+
+	// Exact-match confirmations at any length
+	clean := strings.TrimRight(normalized, ".!?,")
+	for _, p := range lowSignalPatterns {
+		if clean == p {
+			return true
+		}
+	}
+
+	// Short messages that are mechanical directives
+	if len(words) <= 8 {
+		for _, prefix := range mechanicalPrefixes {
+			if strings.HasPrefix(normalized, prefix) {
+				return true
+			}
+		}
+	}
+
+	// Below the word threshold, keep only if the message asks a question
+	// or contains a quotation (both suggest reasoning or correction)
+	if len(words) < minSignalWords {
+		hasQuestion := strings.Contains(content, "?")
+		hasQuote := strings.Contains(content, "\"")
+		if !hasQuestion && !hasQuote {
+			return true
+		}
+	}
+
+	return false
+}
+
+// triageTurns uses a cheap LLM call to classify turns as reasoning vs
+// housekeeping. Returns only the turns classified as reasoning.
+func triageTurns(ctx context.Context, client inference.Client, turns []turn, source string, verbose bool) ([]turn, inference.Usage, error) {
+	// Build numbered turn text for the triage prompt
+	var b strings.Builder
+	ownerLabel := "[owner]"
+	peerLabel := "[assistant]"
+	if isHumanSource(source) {
+		peerLabel = "[peer]"
+	}
+	for i, t := range turns {
+		if t.assistantContent != "" {
+			// Compress assistant to minimal context for triage (cheap pass)
+			compressed := strings.TrimSpace(t.assistantContent)
+			if len(compressed) > 200 {
+				compressed = compressed[:200] + "..."
+			}
+			fmt.Fprintf(&b, "Turn %d:\n%s: %s\n%s: %s\n\n", i+1, peerLabel, compressed, ownerLabel, t.humanContent)
+		} else {
+			fmt.Fprintf(&b, "Turn %d:\n%s: %s\n\n", i+1, ownerLabel, t.humanContent)
+		}
+	}
+
+	triageInput := b.String()
+	if verbose {
+		fmt.Fprintf(os.Stderr, "    triage input (%d chars):\n", len(triageInput))
+		lines := strings.Split(triageInput, "\n")
+		for _, line := range lines {
+			if strings.HasPrefix(line, "Turn ") || strings.HasPrefix(line, "[owner]") {
+				if len(line) > 100 {
+					line = line[:100] + "..."
+				}
+				fmt.Fprintf(os.Stderr, "      %s\n", line)
+			}
+		}
+	}
+
+	start := time.Now()
+	resp, usage, err := inference.Converse(ctx, client, prompts.Triage, triageInput, inference.WithMaxTokens(1024))
+	if err != nil {
+		return nil, usage, err
+	}
+
+	// Parse the JSON array of turn numbers
+	indices := parseTriageResponse(resp, len(turns))
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "    triage %d → %d turns (%s, $%.4f) raw: %s\n",
+			len(turns), len(indices), time.Since(start).Round(time.Millisecond), usage.Cost(), strings.TrimSpace(resp))
+	}
+
+	var kept []turn
+	indexSet := make(map[int]bool)
+	for _, idx := range indices {
+		indexSet[idx] = true
+	}
+	for i, t := range turns {
+		if indexSet[i+1] { // turns are 1-indexed in the prompt
+			kept = append(kept, t)
+		}
+	}
+	return kept, usage, nil
+}
+
+// parseTriageResponse extracts turn numbers from the triage LLM response.
+// The response may contain multiple JSON arrays if the model self-corrects.
+// We take the last valid array, which is the model's final answer.
+func parseTriageResponse(resp string, maxTurns int) []int {
+	// Find all JSON arrays in the response, take the last one
+	var lastValid []int
+	for i := 0; i < len(resp); i++ {
+		if resp[i] != '[' {
+			continue
+		}
+		// Find matching ]
+		end := strings.Index(resp[i:], "]")
+		if end < 0 {
+			continue
+		}
+		candidate := resp[i : i+end+1]
+		var numbers []int
+		if err := json.Unmarshal([]byte(candidate), &numbers); err == nil {
+			lastValid = numbers
+		}
+		i = i + end
+	}
+
+	var valid []int
+	for _, n := range lastValid {
+		if n >= 1 && n <= maxTurns {
+			valid = append(valid, n)
+		}
+	}
+	return valid
 }

--- a/prompts/observe.md
+++ b/prompts/observe.md
@@ -1,6 +1,6 @@
 Extract observations about how this person thinks and what they're aware of from their conversation with an AI assistant. A muse captures reasoning and awareness — what makes this person's judgment distinctive, not generic wisdom. Voice is derived separately from human-to-human conversations.
 
-Most conversations are routine. The expected output is NONE.
+Some conversations are routine and produce no observations.
 
 Input: a compressed conversation transcript. [assistant] messages are mechanically compressed (code blocks stripped, tool calls collapsed, long messages truncated). [owner] messages are preserved in full. Focus on the owner's messages.
 
@@ -10,7 +10,9 @@ Reasoning — the owner originates an idea, corrects course, explains why, pushe
 
 Awareness — the owner models their own thinking, calibrates for an audience, or acknowledges limits. Self-awareness and audience-awareness are rare and high-value. Weak: "Is self-aware about their biases." Strong: "Recognizes they over-index on compression and actively checks whether terseness is hurting legibility."
 
-Every observation must describe the owner's own thinking or behavior, not the assistant's. When the owner discusses external content, the signal is their reaction — judgment, disagreement, how they apply it — not the content itself. Ignore routine interactions and tool outputs.
+Every observation must describe the owner's own thinking or behavior, not the assistant's. When the owner discusses external content, the signal is their reaction — judgment, disagreement, how they apply it — not the content itself.
+
+The owner often works through an agent: drafting documents, writing code, composing messages. This looks routine but carries signal when the owner corrects the agent's output, makes design decisions, or rewrites the agent's draft in their own voice. "This is too long" followed by a rewrite reveals editing judgment. "Say disruption cost, not baseline" reveals how the owner thinks about naming. Treat agent-directed work as a window into the owner's thinking, not as routine tool use.
 
 When the owner corrects the AI, distinguish genuine preferences from frustration with model defaults. "Wants less verbose output" might be a reaction to the model being wordy, not a real trait of the person. The observation should capture what the person actually values, traceable to their behavior independent of the model's failings.
 

--- a/prompts/prompts.go
+++ b/prompts/prompts.go
@@ -49,3 +49,6 @@ var GenerateEval string
 
 //go:embed thesis.md
 var Thesis string
+
+//go:embed triage.md
+var Triage string

--- a/prompts/triage.md
+++ b/prompts/triage.md
@@ -1,0 +1,9 @@
+Classify each numbered turn in this conversation as REASONING or SKIP. Evaluate every turn independently.
+
+REASONING: the owner makes a decision, corrects something, explains why, pushes back, reframes a problem, proposes a design, or reveals how they think. Editing the assistant's draft counts as reasoning. Choosing between alternatives counts as reasoning.
+
+SKIP: the owner confirms ("yes", "sure"), gives a mechanical directive ("commit and push", "squash these"), asks a status question ("how are we on the PR?"), or runs a command.
+
+You MUST return a JSON array of turn numbers classified as REASONING. Evaluate ALL turns, not just the last one. Return [] only if truly no turns contain reasoning.
+
+Example: [1, 3, 4, 7]


### PR DESCRIPTION
## Summary

- Implements triage + owner-only observation path for conversations over 10 turns
- Mechanical filter removes confirmations and short directives by pattern matching
- LLM triage classifies remaining turns as reasoning vs housekeeping
- Owner-only observe strips assistant text entirely, feeding only owner messages
- Conversations that produced 0 observations now produce 7-9
- Clarifies abandoned approaches in 009: renames D to "word-count and pattern filters", documents that triage works as a classifier but we don't have a proven mechanism for why assistant text in reasoning turns still kills observe
- Adds eval-context command for testing strategies on single conversations
- Adds reboot.md documenting context rot findings and next steps

## Test plan

- [ ] `go test ./...` passes
- [ ] `muse eval-context <conversation-snapshot>` compares strategies side by side
- [ ] Run `muse compose --reobserve` on a corpus and verify observation counts increase

🤖 Generated with [Claude Code](https://claude.com/claude-code)