### PR TITLE
Multi-zoom observation: windowed + triage at two zoom levels

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -25,7 +25,7 @@ func newComposeCmd() *cobra.Command {
 	var learn bool
 	var limit int
 	var method string
-	var preserveContext bool
+	var context string
 	cmd := &cobra.Command{
 		Use:   "compose",
 		Short: "Compose a muse from conversations",
@@ -88,7 +88,7 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 
 			switch method {
 			case "clustering":
-				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, preserveContext, limit, uploaded, uploadBytes)
+				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, compose.ContextStrategy(context), limit, uploaded, uploadBytes)
 			case "map-reduce":
 				return runMapReduceCompose(ctx, cmd.OutOrStdout(), store, reobserve, learn, limit)
 			default:
@@ -101,11 +101,11 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 	cmd.Flags().BoolVar(&learn, "learn", false, "skip observe, recompose muse from existing observations (map-reduce only)")
 	cmd.Flags().IntVar(&limit, "limit", 0, "max conversations to observe per run (0 = no limit)")
 	cmd.Flags().StringVar(&method, "method", "clustering", "composition method: clustering or map-reduce")
-	cmd.Flags().BoolVar(&preserveContext, "preserve-context", false, "keep more assistant context before owner corrections during observation")
+	cmd.Flags().StringVar(&context, "context", "", "compression context strategy: '' (default 500 chars) or 'adaptive' (scale by owner message length)")
 	return cmd
 }
 
-func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel, preserveContext bool, limit, uploaded, uploadBytes int) error {
+func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel bool, ctxStrategy compose.ContextStrategy, limit, uploaded, uploadBytes int) error {
 	observeLLM, err := newLLMClient(ctx, TierFast)
 	if err != nil {
 		return err
@@ -122,10 +122,10 @@ func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.St
 		composeLLM, // compose
 		compose.ClusteredOptions{
 			BaseOptions: compose.BaseOptions{
-				Reobserve:       reobserve,
-				Limit:           limit,
-				Verbose:         verbose,
-				PreserveContext: preserveContext,
+				Reobserve: reobserve,
+				Limit:     limit,
+				Verbose:   verbose,
+				Context:   ctxStrategy,
 			},
 			Relabel:     relabel,
 			Uploaded:    uploaded,

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -25,6 +25,7 @@ func newComposeCmd() *cobra.Command {
 	var learn bool
 	var limit int
 	var method string
+	var preserveContext bool
 	cmd := &cobra.Command{
 		Use:   "compose",
 		Short: "Compose a muse from conversations",
@@ -87,7 +88,7 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 
 			switch method {
 			case "clustering":
-				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, limit, uploaded, uploadBytes)
+				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, preserveContext, limit, uploaded, uploadBytes)
 			case "map-reduce":
 				return runMapReduceCompose(ctx, cmd.OutOrStdout(), store, reobserve, learn, limit)
 			default:
@@ -100,10 +101,11 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 	cmd.Flags().BoolVar(&learn, "learn", false, "skip observe, recompose muse from existing observations (map-reduce only)")
 	cmd.Flags().IntVar(&limit, "limit", 0, "max conversations to observe per run (0 = no limit)")
 	cmd.Flags().StringVar(&method, "method", "clustering", "composition method: clustering or map-reduce")
+	cmd.Flags().BoolVar(&preserveContext, "preserve-context", false, "keep more assistant context before owner corrections during observation")
 	return cmd
 }
 
-func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel bool, limit, uploaded, uploadBytes int) error {
+func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel, preserveContext bool, limit, uploaded, uploadBytes int) error {
 	observeLLM, err := newLLMClient(ctx, TierFast)
 	if err != nil {
 		return err
@@ -120,9 +122,10 @@ func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.St
 		composeLLM, // compose
 		compose.ClusteredOptions{
 			BaseOptions: compose.BaseOptions{
-				Reobserve: reobserve,
-				Limit:     limit,
-				Verbose:   verbose,
+				Reobserve:       reobserve,
+				Limit:           limit,
+				Verbose:         verbose,
+				PreserveContext: preserveContext,
 			},
 			Relabel:     relabel,
 			Uploaded:    uploaded,

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -26,6 +26,7 @@ func newComposeCmd() *cobra.Command {
 	var limit int
 	var method string
 	var context string
+	var observeMode string
 	cmd := &cobra.Command{
 		Use:   "compose",
 		Short: "Compose a muse from conversations",
@@ -86,9 +87,11 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 				uploadBytes = result.Bytes
 			}
 
+			mode := compose.ObserveMode(observeMode)
+
 			switch method {
 			case "clustering":
-				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, compose.ContextStrategy(context), limit, uploaded, uploadBytes)
+				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, compose.ContextStrategy(context), mode, limit, uploaded, uploadBytes)
 			case "map-reduce":
 				return runMapReduceCompose(ctx, cmd.OutOrStdout(), store, reobserve, learn, limit)
 			default:
@@ -102,10 +105,11 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 	cmd.Flags().IntVar(&limit, "limit", 0, "max conversations to observe per run (0 = no limit)")
 	cmd.Flags().StringVar(&method, "method", "clustering", "composition method: clustering or map-reduce")
 	cmd.Flags().StringVar(&context, "context", "", "compression context strategy: '' (default 500 chars) or 'adaptive' (scale by owner message length)")
+	cmd.Flags().StringVar(&observeMode, "observe-mode", "", "observation strategy for large conversations: '' (multi-zoom, default), 'windowed', 'triage-owner-only', 'full-conversation'")
 	return cmd
 }
 
-func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel bool, ctxStrategy compose.ContextStrategy, limit, uploaded, uploadBytes int) error {
+func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel bool, ctxStrategy compose.ContextStrategy, mode compose.ObserveMode, limit, uploaded, uploadBytes int) error {
 	observeLLM, err := newLLMClient(ctx, TierFast)
 	if err != nil {
 		return err
@@ -126,6 +130,7 @@ func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.St
 				Limit:     limit,
 				Verbose:   verbose,
 				Context:   ctxStrategy,
+				Observe:   mode,
 			},
 			Relabel:     relabel,
 			Uploaded:    uploaded,

--- a/cmd/eval_context.go
+++ b/cmd/eval_context.go
@@ -59,11 +59,13 @@ func runEvalContext(ctx context.Context, convID string) error {
 	}
 
 	strategies := []struct {
-		name    string
-		ctx     compose.ContextStrategy
+		name string
+		ctx  compose.ContextStrategy
+		mode compose.ObserveMode
 	}{
-		{"default (500 chars)", compose.ContextDefault},
-		{"adaptive (500-2000)", compose.ContextAdaptive},
+		{"windowed", compose.ContextDefault, compose.ObserveWindowed},
+		{"triage-owner-only", compose.ContextDefault, compose.ObserveTriageOwnerOnly},
+		{"full-conversation (baseline)", compose.ContextDefault, compose.ObserveFullConversation},
 	}
 
 	results := make([][]compose.Observation, len(strategies))
@@ -71,7 +73,7 @@ func runEvalContext(ctx context.Context, convID string) error {
 	for i, s := range strategies {
 		fmt.Fprintf(os.Stderr, "--- strategy: %s ---\n", s.name)
 
-		raw, obs, usage, err := compose.ObserveForTestVerbose(ctx, llm, &conv, s.ctx)
+		raw, obs, usage, err := compose.ObserveForTestVerbose(ctx, llm, &conv, s.ctx, s.mode)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  error: %v\n", err)
 			continue
@@ -79,7 +81,9 @@ func runEvalContext(ctx context.Context, convID string) error {
 		results[i] = obs
 		fmt.Fprintf(os.Stderr, "  observations: %d  tokens: %dk in / %dk out  cost: $%.4f\n",
 			len(obs), usage.InputTokens/1000, usage.OutputTokens/1000, usage.Cost())
-		fmt.Fprintf(os.Stderr, "  raw output (%d chars): %s\n", len(raw), raw[:min(len(raw), 500)])
+		if len(raw) > 0 {
+			fmt.Fprintf(os.Stderr, "  raw output (%d chars): %s\n", len(raw), raw[:min(len(raw), 500)])
+		}
 		fmt.Fprintln(os.Stderr)
 	}
 

--- a/cmd/eval_context.go
+++ b/cmd/eval_context.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ellistarn/muse/internal/compose"
+	"github.com/ellistarn/muse/internal/conversation"
+	"github.com/ellistarn/muse/prompts"
+	"github.com/spf13/cobra"
+)
+
+func newEvalContextCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "eval-context [conversation-id]",
+		Short: "Compare observation strategies on a single conversation",
+		Long: `Loads a conversation snapshot, runs the observe pipeline under each
+context strategy (default, adaptive), and prints observations side by side.
+Uses a snapshot to ensure repeatable comparisons.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runEvalContext(cmd.Context(), args[0])
+		},
+	}
+	return cmd
+}
+
+func runEvalContext(ctx context.Context, convID string) error {
+	// Find the conversation file
+	convPath, err := findConversation(convID)
+	if err != nil {
+		return err
+	}
+
+	// Load and snapshot the conversation
+	data, err := os.ReadFile(convPath)
+	if err != nil {
+		return fmt.Errorf("read conversation: %w", err)
+	}
+	var conv conversation.Conversation
+	if err := json.Unmarshal(data, &conv); err != nil {
+		return fmt.Errorf("parse conversation: %w", err)
+	}
+	if conv.Source == "" {
+		conv.Source = sourceFromPath(convPath)
+	}
+
+	fmt.Fprintf(os.Stderr, "conversation: %s\n", convPath)
+	fmt.Fprintf(os.Stderr, "messages:     %d\n", len(conv.Messages))
+	fmt.Fprintf(os.Stderr, "source:       %s\n\n", conv.Source)
+
+	llm, err := newLLMClient(ctx, TierFast)
+	if err != nil {
+		return err
+	}
+
+	strategies := []struct {
+		name    string
+		ctx     compose.ContextStrategy
+	}{
+		{"default (500 chars)", compose.ContextDefault},
+		{"adaptive (500-2000)", compose.ContextAdaptive},
+	}
+
+	results := make([][]compose.Observation, len(strategies))
+
+	for i, s := range strategies {
+		fmt.Fprintf(os.Stderr, "--- strategy: %s ---\n", s.name)
+
+		raw, obs, usage, err := compose.ObserveForTestVerbose(ctx, llm, &conv, s.ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  error: %v\n", err)
+			continue
+		}
+		results[i] = obs
+		fmt.Fprintf(os.Stderr, "  observations: %d  tokens: %dk in / %dk out  cost: $%.4f\n",
+			len(obs), usage.InputTokens/1000, usage.OutputTokens/1000, usage.Cost())
+		fmt.Fprintf(os.Stderr, "  raw output (%d chars): %s\n", len(raw), raw[:min(len(raw), 500)])
+		fmt.Fprintln(os.Stderr)
+	}
+
+	// Print side-by-side comparison
+	fmt.Println()
+	for i, s := range strategies {
+		fmt.Printf("=== %s: %d observations ===\n\n", s.name, len(results[i]))
+		for j, obs := range results[i] {
+			if obs.Quote != "" {
+				fmt.Printf("  [%d] Quote: %s\n", j+1, truncateStr(obs.Quote, 120))
+			}
+			fmt.Printf("  [%d] %s\n\n", j+1, truncateStr(obs.Text, 300))
+		}
+	}
+
+	// Print prompt used (first 200 chars for identification)
+	observePrompt := prompts.Observe
+	if isHumanSource(conv.Source) {
+		observePrompt = prompts.ObserveHuman
+	}
+	fmt.Printf("--- prompt (first 200 chars) ---\n%s\n", truncateStr(observePrompt, 200))
+
+	return nil
+}
+
+func findConversation(id string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	// Search across all sources
+	sources := []string{"claude-code", "kiro-cli", "kiro", "opencode", "codex",
+		"github-issues", "github-prs", "slack"}
+	for _, src := range sources {
+		pattern := filepath.Join(home, ".muse", "conversations", src, id+"*")
+		matches, _ := filepath.Glob(pattern)
+		if len(matches) > 0 {
+			return matches[0], nil
+		}
+	}
+	// Try as a direct path
+	if _, err := os.Stat(id); err == nil {
+		return id, nil
+	}
+	return "", fmt.Errorf("conversation %q not found", id)
+}
+
+func sourceFromPath(path string) string {
+	parts := strings.Split(path, "/conversations/")
+	if len(parts) < 2 {
+		return "unknown"
+	}
+	return strings.Split(parts[1], "/")[0]
+}
+
+func truncateStr(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-3] + "..."
+}
+
+func isHumanSource(source string) bool {
+	switch source {
+	case "slack", "github-issues", "github-prs":
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/eval_context.go
+++ b/cmd/eval_context.go
@@ -63,6 +63,7 @@ func runEvalContext(ctx context.Context, convID string) error {
 		ctx  compose.ContextStrategy
 		mode compose.ObserveMode
 	}{
+		{"multi-zoom (default)", compose.ContextDefault, compose.ObserveMultiZoom},
 		{"windowed", compose.ContextDefault, compose.ObserveWindowed},
 		{"triage-owner-only", compose.ContextDefault, compose.ObserveTriageOwnerOnly},
 		{"full-conversation (baseline)", compose.ContextDefault, compose.ObserveFullConversation},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,7 @@ Run "muse listen --help" for MCP server configuration.`,
 	cmd.AddCommand(newEvalCmd())
 	cmd.AddCommand(newAddCmd())
 	cmd.AddCommand(newRemoveCmd())
+	cmd.AddCommand(newEvalContextCmd())
 	return cmd
 }
 

--- a/designs/009-observations.md
+++ b/designs/009-observations.md
@@ -38,13 +38,68 @@ When the owner says "on line 12, be more specific," compression preserves the di
 strips line 12. The observation captures a general preference instead of a specific
 transformation.
 
-The fix is to make compression context-aware. When the owner's next message is a short
-correction (under ~50 words), the preceding assistant content is likely what prompted it.
-Preserving more of that content (assistant text, code blocks, or tool results depending on
-where the context lives) gives the observe prompt what it needs to produce specific
-observations.
+### Approaches attempted and abandoned
 
-`--preserve-context` enables this. Default off to preserve current token costs.
+**A: Adaptive compression.** Scale the assistant text limit by owner message length
+(500-2000 chars). More context diluted signal: 17k chars produced 0 observations while
+13k produced 5. The extra context made the conversation look more routine.
+
+**B: Prompt-driven extraction.** Ask the observe prompt for transformations, not just
+principles. Made the LLM more cautious, producing fewer observations.
+
+**C: Context-aware prompting.** Ask the LLM to reason about what context each response
+requires. Same regression as B.
+
+**D: Mechanical turn filtering.** Remove confirmations and short directives before
+observe. Insufficient: many low-signal turns survive word-count and pattern filters.
+
+**E: LLM triage + full conversation.** Cheap LLM call classifies turns as reasoning vs
+housekeeping, then pass triaged turns through the standard compression pipeline. Triage
+works well, but observe still returns NONE on the compressed triaged conversation.
+
+### What we found
+
+The observe prompt produces strong observations from concentrated owner input: 6 curated
+owner messages produce 5-6 observations with specific quotes and reasoning. The same
+messages embedded in a full compressed conversation (with assistant text, tool markers,
+and mechanical turns) produce NONE consistently.
+
+The problem is not context preservation, compression limits, or prompt wording. It is
+volume. The observe prompt gives up when there are too many messages to evaluate,
+regardless of their quality. Assistant context makes this worse by making every
+conversation look like routine agent direction.
+
+### Solution: triage + owner-only observe
+
+For conversations with more than 10 turns:
+
+1. **Mechanical filter.** Remove confirmations, mechanical directives, interrupted
+   requests. Pattern matching on known low-signal phrases.
+2. **LLM triage.** Cheap classification pass identifies which remaining turns contain
+   reasoning, decisions, corrections, or design thinking.
+3. **Owner-only observe.** Feed only the owner's messages from triaged turns to the
+   observe prompt. No assistant context, no compression, no refine step.
+
+For small conversations (10 turns or fewer), the original pipeline works: compress
+the full conversation and run observe + refine.
+
+Results on two test conversations:
+
+| Conversation | Turns | Old pipeline | New pipeline |
+|---|---|---|---|
+| RFC design session (104 msgs, 27 turns) | 27 → 15 → 11 | 0 observations | 7 observations |
+| Orwell pass editing (211 msgs, 26 turns) | 26 → 19 → 16 | 0 observations | 9 observations |
+
+The observations are specific: "Uses formal analysis to constrain the design space,
+then derives a natural set ({1, 2, 3}) rather than making it configurable beyond what
+the math supports." "Monitors the AI's vocabulary for jargon that doesn't match how
+they actually speak, and flags it directly."
+
+### Prompt update: agent-directed work
+
+The observe prompt now recognizes that agent-directed work carries signal. When the
+owner corrects the agent's draft, makes design decisions through the agent, or rewrites
+the agent's output in their own voice, the prompt treats it as reasoning, not routine.
 
 ## Fingerprinting
 

--- a/designs/009-observations.md
+++ b/designs/009-observations.md
@@ -57,17 +57,24 @@ observe. Insufficient: many low-signal turns survive word-count and pattern filt
 housekeeping, then pass triaged turns through the standard compression pipeline. Triage
 works well, but observe still returns NONE on the compressed triaged conversation.
 
-### What we found
+### What we found: context rot
 
-The observe prompt produces strong observations from concentrated owner input: 6 curated
-owner messages produce 5-6 observations with specific quotes and reasoning. The same
-messages embedded in a full compressed conversation (with assistant text, tool markers,
-and mechanical turns) produce NONE consistently.
+Long conversations exhibit context rot. Early turns carry design decisions, corrections,
+and reasoning. Later turns accumulate mechanical work: git operations, CI checks,
+formatting fixes. The signal-to-noise ratio degrades as the conversation grows.
 
-The problem is not context preservation, compression limits, or prompt wording. It is
-volume. The observe prompt gives up when there are too many messages to evaluate,
-regardless of their quality. Assistant context makes this worse by making every
-conversation look like routine agent direction.
+The observe prompt reads through the compressed conversation sequentially. When reasoning
+turns from early in the conversation are followed by pages of mechanical turns, the LLM's
+attention drifts to the recent, mechanical content. Reasoning that is still in the context
+window gets washed out by surrounding noise. The result is NONE for the whole conversation.
+
+This is a local signal problem, not a global ratio problem. Turn 4 is a design decision
+regardless of what turns 15-27 contain. But observing the full conversation forces the
+LLM to evaluate turn 4 in the context of everything that came after it.
+
+The triage + owner-only approach works around this by stripping noise before observe sees
+it. A more fundamental fix would observe in local windows so that no turn is ever evaluated
+in the context of distant mechanical turns. See reboot.md for next steps.
 
 ### Solution: triage + owner-only observe
 

--- a/designs/009-observations.md
+++ b/designs/009-observations.md
@@ -38,24 +38,34 @@ When the owner says "on line 12, be more specific," compression preserves the di
 strips line 12. The observation captures a general preference instead of a specific
 transformation.
 
-### Approaches attempted and abandoned
+### Approaches attempted and abandoned after experiments
 
 **A: Adaptive compression.** Scale the assistant text limit by owner message length
-(500-2000 chars). More context diluted signal: 17k chars produced 0 observations while
-13k produced 5. The extra context made the conversation look more routine.
+(500-2000 chars). More context diluted signal in local experiments: 17k chars
+produced 0 observations while 13k produced 5. The extra context made the
+conversation look less interesting to muse.
 
 **B: Prompt-driven extraction.** Ask the observe prompt for transformations, not just
 principles. Made the LLM more cautious, producing fewer observations.
 
 **C: Context-aware prompting.** Ask the LLM to reason about what context each response
-requires. Same regression as B.
+requires. Same performance regression relative to mainline as B.
 
-**D: Mechanical turn filtering.** Remove confirmations and short directives before
-observe. Insufficient: many low-signal turns survive word-count and pattern filters.
+**D: Word-count and pattern filters.** Remove confirmations and short directives before
+observe by matching known low-signal phrases and applying a minimum word count. Insufficient:
+many low-signal turns survive the patterns, and the turns that are removed aren't the ones
+causing observe to fail.
 
-**E: LLM triage + full conversation.** Cheap LLM call classifies turns as reasoning vs
+**E: LLM triage + compressed conversation.** Cheap LLM call classifies turns as reasoning vs
 housekeeping, then pass triaged turns through the standard compression pipeline. Triage
-works well, but observe still returns NONE on the compressed triaged conversation.
+works as a classifier — it correctly identifies which turns contain reasoning. But observe
+still returns NONE on the compressed triaged conversation. The triaged output still includes
+compressed assistant text (~500 chars per turn), and that's enough to trigger the same
+failure. We don't have a proven mechanism for why assistant text in reasoning turns kills
+observe. Possible explanations: pure volume (11 triaged turns × 500 chars of assistant text),
+attention shifting to the assistant's framing instead of the owner's reasoning, or mixed-role
+presentation changing how the model processes the input. We tested the endpoint (owner-only
+works, mixed doesn't) but not the mechanism.
 
 ### What we found: context rot
 

--- a/designs/010-observe-strategies.md
+++ b/designs/010-observe-strategies.md
@@ -1,58 +1,64 @@
 # Observe Strategy Comparison
 
-## Experiment: 2026-04-07
+## Corpus experiment: 2026-04-07
 
-Ran full compose (observe through muse.md) on 417-427 conversations using three
+Ran full compose (observe through muse.md) on 417-430 conversations using four
 observation strategies. Same prompts, same downstream pipeline (label, theme, cluster,
 summarize, thesis, compose). Only the observe stage differs.
 
 The `--observe-mode` flag on `muse compose` selects the strategy. The flag threads
-through BaseOptions to observeAndRefine, which dispatches to one of three paths for
-conversations with more than 10 turns. Short conversations use the same compress +
-observe + refine path regardless of mode.
+through BaseOptions to observeAndRefine, which dispatches for conversations with more
+than 10 turns. Short conversations use the same compress + observe + refine path
+regardless of mode.
 
 ### Results
 
-| Strategy | Observations | Conversations w/ obs | Observe cost | Total cost | Time |
-|---|---|---|---|---|---|
-| Windowed (size 8, stride 4) | 462 | 69 | $12.15 | $13.46 | 862s |
-| Triage + owner-only | 243 | 42 | $5.62 | $6.52 | 364s |
-| Full conversation (baseline) | 151 | 42 | $5.65 | $6.40 | 329s |
+| Strategy | Observations | Conversations w/ obs | Clusters | Total cost |
+|---|---|---|---|---|
+| Multi-zoom (default) | 658 | 82 | 25 | $18.25 |
+| Windowed (size 8, stride 4) | 462 | 69 | 22 | $13.46 |
+| Triage + owner-only | 243 | 42 | 21 | $6.52 |
+| Full conversation (baseline) | 151 | 42 | 19 | $6.40 |
 
-All three produce ~100-line muse.md files. The difference is which 100 lines.
+All four produce ~100-line muse.md files. The difference is which 100 lines.
 
-### What each strategy finds
+### What each zoom level finds
 
-**Windowed** finds the most craft-level specifics: named editing passes with exit
+**Windowed** (local zoom) finds craft-level specifics: named editing passes with exit
 conditions, specific punctuation rules, voice authenticity tests ("I would never type
 those"), artifact staleness as a failure mode, document structure as epistemic signaling,
 ML jargon rejection. These are small-scale reasoning moments that live in specific turns.
 
-**Triage + owner-only** finds decision-making patterns: where decisions should land
-(operator vs app-dev), named reusable primitives (Ralph Wiggum loop, Orwell pass),
-agent loop architecture, scope cutting as active discipline. Stripping assistant text
-concentrates the owner's strategic reasoning.
+**Triage + owner-only** (global zoom) finds decision-making patterns: where decisions
+should land (operator vs app-dev), named reusable primitives (Ralph Wiggum loop, Orwell
+pass), agent loop architecture, scope cutting as active discipline. Stripping assistant
+text concentrates the owner's strategic reasoning.
 
 **Full conversation (baseline)** finds analytical/philosophical depth: separating the
 lens from the specimen, research methodology (substrate vs method failure),
 metacognitive self-correction, weaponized vagueness. Surprisingly not empty -- the
 0-observation problem only affects long conversations. Short conversations produce
-observations fine under all strategies, and there are enough short conversations to
-build a reasonable (if thinner) muse.
+observations fine under all strategies.
+
+**Multi-zoom** (windowed + triage, merged) combines both zoom levels. It produced
+sections that neither strategy found alone: "Who decides, not what's possible" (decision
+allocation, knowledge topology) and "The distribution, not the number" (metrics as
+hypotheses, signal stratification). It preserved most of the craft-level detail from
+windowed while adding the strategic reasoning from triage.
 
 ### The strategies are not converging
 
-The three muses are not three approximations of the same portrait. They emphasize
-genuinely different facets:
+The three single-strategy muses are not three approximations of the same portrait.
+They emphasize genuinely different facets:
 
 - Windowed catches editing craft and concrete specifics
 - Triage catches decision architecture and pattern naming
 - Baseline catches philosophical depth and metacognition
 
-This means the compose step is bottlenecked on observation diversity, not volume.
-More observations of the same type won't improve the muse. Different observations will.
+The compose step is bottlenecked on observation diversity, not volume. More observations
+of the same type won't improve the muse. Different observations will.
 
-### Diagnosis
+### Why different zoom levels find different signal
 
 Each strategy presents conversations differently to the observe prompt, which changes
 what the LLM attends to:
@@ -62,85 +68,76 @@ what the LLM attends to:
   naming decisions, editing moves.
 
 - **Triage + owner-only** shows 10-15 owner messages with no assistant context. The
-  LLM sees concentrated strategic reasoning. It catches macro-level patterns: where
-  decisions land, how patterns get named, what gets deferred.
+  LLM sees concentrated strategic reasoning spanning the full conversation. It catches
+  macro-level patterns: how a position evolved, what patterns recur, what got deferred.
 
-- **Baseline** shows the full compressed conversation. For short conversations this
-  works fine. For long ones it returns NONE, but the short-conversation observations
-  lean toward analytical depth because short conversations tend to be focused
-  discussions rather than execution sessions.
+- **Baseline** shows the full compressed conversation. Works for short conversations.
+  For long ones it returns NONE, but the short-conversation observations lean toward
+  analytical depth because short conversations tend to be focused discussions.
 
-The strategies aren't better or worse -- they're sensitive to different signal types.
+## Orwell experiment
 
-## Next: multi-altitude observation
+Separate experiment applying the three single strategies to Orwell's "Politics and the
+English Language" (~5,000 words). Results in orwellian-observation.md. The essay has
+known structure, making hand-verification possible.
 
-The three strategies form a granularity spectrum: windowed (8 turns with assistant
-context) is the most granular, triage (owner-only from reasoning turns) is mid-altitude,
-baseline (full conversation) is the widest view. Each altitude catches signal invisible
-to the others.
+| Strategy | Observations | Strongest section |
+|---|---|---|
+| Baseline (full essay) | ~54 + 5 cross-cutting | Even spread, generic on catalog/prescription |
+| Windowed (5 windows) | ~34 raw, 23 deduped | Catalog (structural insights from close reading) |
+| Triage (reasoning only) | ~42 + 4 cross-cutting | Diagnosis (19 obs vs baseline's 13) |
 
-### Could we cascade instead of union?
+Even on a 5,000-word essay -- shorter than where context rot typically appears -- the
+strategies found different signal:
 
-The naive union runs all three independently and merges observations. Cost is additive.
-A cascade would run one strategy, then use its output to inform the next.
+- **Windowed found structural patterns in the catalog** that baseline treated as a list:
+  metaphor lifecycle model, escalating severity across categories, substitution as proof
+  technique. Close reading of a contained section yields insights that sequential reading
+  of the full text glosses over.
 
-The natural cascade: window the conversation, triage the windows, construct a
-higher-altitude pass from the results. But two findings constrain this:
+- **Triage concentrated on the diagnosis section** and found the sharpest rhetorical
+  strategy observations: self-deception as a service ("partially concealing your meaning
+  even from yourself"), "designed" deployed as the strongest verb only after evidence
+  accumulates, clarity framed as loss of capability rather than gain of wisdom.
 
-1. **Triage within windows adds little.** Each window is 8 turns. Mechanical windows
-   already return NONE naturally. Triaging within a window to get 3-4 turns is
-   essentially just a smaller window -- we could achieve the same effect by reducing
-   window size. The triage step is redundant at window scale.
+- **All three converged** on: bidirectional causation, steelmanning before dismantling,
+  epistemic calibration, self-incrimination, concrete vs abstract as master distinction,
+  the pacification juxtaposition, Rule 6 as override.
 
-2. **Triage on triaged turns with assistant text still fails.** From 009 approach E:
-   triage correctly identifies reasoning turns, but observe on triaged turns with
-   compressed assistant text returns NONE. This was tested on full conversations, not
-   windows. On windows the problem might not apply (they're small enough). But we
-   haven't tested this, and the mechanism is still unexplained.
+The Orwell experiment confirms the corpus finding: zoom level determines what signal
+survives, even when context rot isn't the problem.
 
-What triage adds to windowed isn't finer filtering -- it's a different altitude.
-Windowed observes 8-turn interactions. Triage observes 10-15 owner messages spanning
-the whole conversation. The second pass sees cross-conversation arcs that no single
-window contains: how the owner's position evolved, what patterns recur across decisions,
-what got deferred and why.
+## Decision: multi-zoom as default
 
-### The right framing: multi-altitude, not multi-strategy
+Multi-zoom is the default observe mode. It runs both windowed (local) and triage +
+owner-only (global) passes on each large conversation, merges the observations, and
+stores the combined set. Small conversations (10 turns or fewer) get a single pass.
 
-If both altitudes find unique signal, the pipeline should run both as a single
-pipeline, not as two separate strategies the user chooses between. The user shouldn't
-need to know about observation strategies. They run `muse compose` and get the best
-muse we can build.
+The pipeline for large conversations:
+1. **Local pass:** sliding windows (size 8, stride 4) with assistant context, observe
+   each, deduplicate across overlapping windows, refine
+2. **Global pass:** mechanical filter, LLM triage, owner-only observe
+3. **Merge:** combine observations from both passes, deduplicate by text containment
+4. **Downstream:** label, theme, cluster, summarize, thesis, compose (unchanged)
 
-The pipeline would be:
-1. **Window pass:** sliding windows with assistant context, observe each, deduplicate
-2. **Altitude pass:** triage + owner-only on the full conversation
-3. **Merge:** combine observations from both passes, deduplicate
-4. **Downstream:** label, theme, cluster, summarize, thesis, compose as today
+### Cost
 
-Cost is ~$18 observe for the current corpus. That's 2.7x baseline. Whether this is
-acceptable depends on how often users run compose (daily? weekly?) and whether the
-quality improvement justifies it. The downstream stages ($1-2) are unchanged.
+Multi-zoom observe costs ~$17 for a 430-conversation corpus. That's 2.7x baseline.
+Downstream stages add ~$1.70 regardless of strategy. Total: ~$18.25.
 
-### Experiment to run
+The main cost lever is window size. Larger windows mean fewer observe calls but risk
+reintroducing context rot. The current 8/4 split is untested against alternatives.
 
-1. Run windowed and triage on the same corpus (reuse cached observations or run fresh)
-2. Merge observation artifacts, deduplicating by text similarity
-3. Compose from the merged set
-4. Compare the resulting muse against windowed-only and triage-only
-5. Judge using the same LLM-as-judge dimensions we use for generative evals
+### What multi-zoom doesn't do
 
-This is a single-variable test: same conversations, same downstream pipeline, only the
-observation set differs. If the merged muse is clearly better, build multi-altitude
-into the default pipeline. If it's roughly equivalent to windowed alone, the triage
-pass is waste and windowed is the answer.
+The two passes run independently. There is no cascade (triage informing windowed or
+vice versa). The Orwell experiment suggested triaging first, then windowing the
+reasoning passages. This is a potential optimization but adds complexity and the
+independent merge already captures both zoom levels' signal.
 
-### Cost note
+### Deferred: observe from documents
 
-Windowed is 2x the observe cost of triage ($12 vs $6) because it makes 5-68 observe
-calls per conversation (one per window) plus a refine call. The windows run sequentially
-within a conversation but conversations run in parallel. Observe dominates total cost
-(90% for windowed, 86% for triage).
-
-If windowed becomes the default, the main cost lever is window size. Larger windows
-mean fewer calls but risk reintroducing context rot. The current 8/4 split is untested
-against alternatives.
+The Orwell experiment was done outside the pipeline because the observe prompt expects
+conversations, not essays. A "generate observations from document" capability would
+let the pipeline learn from authored text (design docs, essays, blog posts) in addition
+to conversations. Out of scope for now.

--- a/designs/010-observe-strategies.md
+++ b/designs/010-observe-strategies.md
@@ -1,17 +1,38 @@
 # Observe Strategy Comparison
 
-## Corpus experiment: 2026-04-07
+Two separate findings led to multi-zoom observation. They're related but distinct.
 
-Ran full compose (observe through muse.md) on 417-430 conversations using four
-observation strategies. Same prompts, same downstream pipeline (label, theme, cluster,
-summarize, thesis, compose). Only the observe stage differs.
+## Finding 1: context rot (009)
 
-The `--observe-mode` flag on `muse compose` selects the strategy. The flag threads
-through BaseOptions to observeAndRefine, which dispatches for conversations with more
-than 10 turns. Short conversations use the same compress + observe + refine path
-regardless of mode.
+Long conversations produce 0 observations under the baseline pipeline. The same
+conversations produce 7-9 observations after triage + owner-only filtering. This is
+catastrophic signal loss with a clear fix.
 
-### Results
+The evidence is on the preserve-context branch. Two test conversations:
+
+| Conversation | Turns | Baseline | Triage + owner-only |
+|---|---|---|---|
+| RFC design session (104 msgs) | 27 | 0 observations | 7 observations |
+| Orwell pass editing (211 msgs) | 26 | 0 observations | 9 observations |
+
+The mechanism: early turns carry design decisions and corrections. Later turns
+accumulate mechanical work (git operations, CI, formatting). The observe prompt reads
+sequentially and later noise washes out earlier reasoning signal. This is context rot.
+
+Windowed observation treats context rot at the source: observe in sliding windows so
+no turn is ever evaluated in the context of distant mechanical turns. Mechanical
+windows return NONE, reasoning windows produce observations. This works.
+
+## Finding 2: attention allocation (this doc)
+
+Different observation strategies find different signal, even when context rot isn't the
+problem. How you present the input changes what the LLM attends to. This is not about
+losing signal -- it's about which signal gets attention.
+
+### Corpus experiment: 2026-04-07
+
+Ran full compose on 417-430 conversations using four strategies. Same downstream
+pipeline (label through compose). Only the observe stage differs.
 
 | Strategy | Observations | Conversations w/ obs | Clusters | Total cost |
 |---|---|---|---|---|
@@ -22,64 +43,34 @@ regardless of mode.
 
 All four produce ~100-line muse.md files. The difference is which 100 lines.
 
-### What each zoom level finds
-
 **Windowed** (local zoom) finds craft-level specifics: named editing passes with exit
-conditions, specific punctuation rules, voice authenticity tests ("I would never type
-those"), artifact staleness as a failure mode, document structure as epistemic signaling,
-ML jargon rejection. These are small-scale reasoning moments that live in specific turns.
+conditions, punctuation rules, voice authenticity tests ("I would never type those"),
+artifact staleness, document structure as epistemic signaling. Small-scale reasoning
+moments that live in specific turns.
 
 **Triage + owner-only** (global zoom) finds decision-making patterns: where decisions
-should land (operator vs app-dev), named reusable primitives (Ralph Wiggum loop, Orwell
-pass), agent loop architecture, scope cutting as active discipline. Stripping assistant
+should land (operator vs app-dev), named reusable primitives (Ralph Wiggum loop,
+Orwell pass), agent loop architecture, scope cutting as discipline. Stripping assistant
 text concentrates the owner's strategic reasoning.
 
-**Full conversation (baseline)** finds analytical/philosophical depth: separating the
-lens from the specimen, research methodology (substrate vs method failure),
-metacognitive self-correction, weaponized vagueness. Surprisingly not empty -- the
-0-observation problem only affects long conversations. Short conversations produce
-observations fine under all strategies.
+**Baseline** finds analytical/philosophical depth: separating the lens from the
+specimen, substrate vs method failure, metacognitive self-correction. The 0-observation
+problem only affects long conversations; short conversations work fine under all
+strategies.
 
 **Multi-zoom** (windowed + triage, merged) combines both zoom levels. It produced
-sections that neither strategy found alone: "Who decides, not what's possible" (decision
-allocation, knowledge topology) and "The distribution, not the number" (metrics as
-hypotheses, signal stratification). It preserved most of the craft-level detail from
-windowed while adding the strategic reasoning from triage.
-
-### The strategies are not converging
+sections that neither strategy found alone: "Who decides, not what's possible"
+(decision allocation, knowledge topology) and "The distribution, not the number"
+(metrics as hypotheses, signal stratification).
 
 The three single-strategy muses are not three approximations of the same portrait.
-They emphasize genuinely different facets:
+They emphasize genuinely different facets. The compose step is bottlenecked on
+observation diversity, not volume.
 
-- Windowed catches editing craft and concrete specifics
-- Triage catches decision architecture and pattern naming
-- Baseline catches philosophical depth and metacognition
+### Orwell experiment
 
-The compose step is bottlenecked on observation diversity, not volume. More observations
-of the same type won't improve the muse. Different observations will.
-
-### Why different zoom levels find different signal
-
-Each strategy presents conversations differently to the observe prompt, which changes
-what the LLM attends to:
-
-- **Windowed** shows 8 turns with full assistant context. The LLM sees a specific
-  interaction in detail. It catches micro-level reasoning: word choice corrections,
-  naming decisions, editing moves.
-
-- **Triage + owner-only** shows 10-15 owner messages with no assistant context. The
-  LLM sees concentrated strategic reasoning spanning the full conversation. It catches
-  macro-level patterns: how a position evolved, what patterns recur, what got deferred.
-
-- **Baseline** shows the full compressed conversation. Works for short conversations.
-  For long ones it returns NONE, but the short-conversation observations lean toward
-  analytical depth because short conversations tend to be focused discussions.
-
-## Orwell experiment
-
-Separate experiment applying the three single strategies to Orwell's "Politics and the
-English Language" (~5,000 words). Results in orwellian-observation.md. The essay has
-known structure, making hand-verification possible.
+Separate experiment applying three strategies to Orwell's "Politics and the English
+Language" (~5,000 words). Full results in orwellian-observation.md.
 
 | Strategy | Observations | Strongest section |
 |---|---|---|
@@ -87,57 +78,72 @@ known structure, making hand-verification possible.
 | Windowed (5 windows) | ~34 raw, 23 deduped | Catalog (structural insights from close reading) |
 | Triage (reasoning only) | ~42 + 4 cross-cutting | Diagnosis (19 obs vs baseline's 13) |
 
-Even on a 5,000-word essay -- shorter than where context rot typically appears -- the
-strategies found different signal:
+The essay is ~5,000 words -- below the threshold where context rot appears. No
+strategy returned NONE. Baseline produced 13 diagnosis observations; it didn't fail.
 
-- **Windowed found structural patterns in the catalog** that baseline treated as a list:
-  metaphor lifecycle model, escalating severity across categories, substitution as proof
-  technique. Close reading of a contained section yields insights that sequential reading
-  of the full text glosses over.
+What the Orwell experiment shows is attention allocation, not context rot:
 
-- **Triage concentrated on the diagnosis section** and found the sharpest rhetorical
-  strategy observations: self-deception as a service ("partially concealing your meaning
-  even from yourself"), "designed" deployed as the strongest verb only after evidence
-  accumulates, clarity framed as loss of capability rather than gain of wisdom.
+- **Windowed** found structural patterns in the catalog that baseline treated as a
+  list: metaphor lifecycle model, escalating severity across categories, substitution
+  as proof technique. Close reading of a contained section yields insights that
+  sequential reading glosses over.
+
+- **Triage** concentrated on the diagnosis section and found the sharpest observations:
+  self-deception as a service, "designed" deployed as the strongest verb only after
+  evidence accumulates, clarity framed as loss of capability rather than gain of wisdom.
 
 - **All three converged** on: bidirectional causation, steelmanning before dismantling,
-  epistemic calibration, self-incrimination, concrete vs abstract as master distinction,
-  the pacification juxtaposition, Rule 6 as override.
+  epistemic calibration, self-incrimination, concrete vs abstract, the pacification
+  juxtaposition, Rule 6 as override.
 
-The Orwell experiment confirms the corpus finding: zoom level determines what signal
-survives, even when context rot isn't the problem.
+### Why these are different findings
+
+Context rot is catastrophic: 0 observations from a conversation that should produce
+7-9. The fix is structural (windowed observation, triage + owner-only).
+
+Attention allocation is quantitative: 13 vs 19 observations in a section, or different
+observations from the same material. The fix is running multiple zoom levels.
+
+Multi-zoom addresses both: windowed fixes context rot in long conversations, and the
+combination of local + global zoom captures signal that either alone would miss.
 
 ## Decision: multi-zoom as default
 
-Multi-zoom is the default observe mode. It runs both windowed (local) and triage +
-owner-only (global) passes on each large conversation, merges the observations, and
-stores the combined set. Small conversations (10 turns or fewer) get a single pass.
+Multi-zoom is the default observe mode. For conversations over 10 turns:
 
-The pipeline for large conversations:
 1. **Local pass:** sliding windows (size 8, stride 4) with assistant context, observe
    each, deduplicate across overlapping windows, refine
 2. **Global pass:** mechanical filter, LLM triage, owner-only observe
 3. **Merge:** combine observations from both passes, deduplicate by text containment
 4. **Downstream:** label, theme, cluster, summarize, thesis, compose (unchanged)
 
+Small conversations (10 turns or fewer) get a single pass.
+
 ### Cost
 
-Multi-zoom observe costs ~$17 for a 430-conversation corpus. That's 2.7x baseline.
+Multi-zoom observe costs ~$17 for a 430-conversation corpus (2.7x baseline).
 Downstream stages add ~$1.70 regardless of strategy. Total: ~$18.25.
 
 The main cost lever is window size. Larger windows mean fewer observe calls but risk
 reintroducing context rot. The current 8/4 split is untested against alternatives.
 
+### Implementation
+
+The `--observe-mode` flag on `muse compose` selects the strategy. It threads through
+BaseOptions to observeAndParse, which dispatches to observeMultiZoom for the default
+mode. Multi-zoom calls observeWindowed and observeTriageOwnerOnly independently, then
+merges with deduplicateObservations. Global pass failure is non-fatal (falls back to
+local only).
+
 ### What multi-zoom doesn't do
 
-The two passes run independently. There is no cascade (triage informing windowed or
-vice versa). The Orwell experiment suggested triaging first, then windowing the
-reasoning passages. This is a potential optimization but adds complexity and the
-independent merge already captures both zoom levels' signal.
+The two passes run independently. There is no cascade. The Orwell experiment suggested
+triaging first, then windowing reasoning passages. This is a potential optimization
+but the independent merge already captures both zoom levels' signal.
 
 ### Deferred: observe from documents
 
 The Orwell experiment was done outside the pipeline because the observe prompt expects
 conversations, not essays. A "generate observations from document" capability would
-let the pipeline learn from authored text (design docs, essays, blog posts) in addition
-to conversations. Out of scope for now.
+let the pipeline learn from authored text (design docs, essays, blog posts). Out of
+scope for now.

--- a/designs/010-observe-strategies.md
+++ b/designs/010-observe-strategies.md
@@ -1,0 +1,146 @@
+# Observe Strategy Comparison
+
+## Experiment: 2026-04-07
+
+Ran full compose (observe through muse.md) on 417-427 conversations using three
+observation strategies. Same prompts, same downstream pipeline (label, theme, cluster,
+summarize, thesis, compose). Only the observe stage differs.
+
+The `--observe-mode` flag on `muse compose` selects the strategy. The flag threads
+through BaseOptions to observeAndRefine, which dispatches to one of three paths for
+conversations with more than 10 turns. Short conversations use the same compress +
+observe + refine path regardless of mode.
+
+### Results
+
+| Strategy | Observations | Conversations w/ obs | Observe cost | Total cost | Time |
+|---|---|---|---|---|---|
+| Windowed (size 8, stride 4) | 462 | 69 | $12.15 | $13.46 | 862s |
+| Triage + owner-only | 243 | 42 | $5.62 | $6.52 | 364s |
+| Full conversation (baseline) | 151 | 42 | $5.65 | $6.40 | 329s |
+
+All three produce ~100-line muse.md files. The difference is which 100 lines.
+
+### What each strategy finds
+
+**Windowed** finds the most craft-level specifics: named editing passes with exit
+conditions, specific punctuation rules, voice authenticity tests ("I would never type
+those"), artifact staleness as a failure mode, document structure as epistemic signaling,
+ML jargon rejection. These are small-scale reasoning moments that live in specific turns.
+
+**Triage + owner-only** finds decision-making patterns: where decisions should land
+(operator vs app-dev), named reusable primitives (Ralph Wiggum loop, Orwell pass),
+agent loop architecture, scope cutting as active discipline. Stripping assistant text
+concentrates the owner's strategic reasoning.
+
+**Full conversation (baseline)** finds analytical/philosophical depth: separating the
+lens from the specimen, research methodology (substrate vs method failure),
+metacognitive self-correction, weaponized vagueness. Surprisingly not empty -- the
+0-observation problem only affects long conversations. Short conversations produce
+observations fine under all strategies, and there are enough short conversations to
+build a reasonable (if thinner) muse.
+
+### The strategies are not converging
+
+The three muses are not three approximations of the same portrait. They emphasize
+genuinely different facets:
+
+- Windowed catches editing craft and concrete specifics
+- Triage catches decision architecture and pattern naming
+- Baseline catches philosophical depth and metacognition
+
+This means the compose step is bottlenecked on observation diversity, not volume.
+More observations of the same type won't improve the muse. Different observations will.
+
+### Diagnosis
+
+Each strategy presents conversations differently to the observe prompt, which changes
+what the LLM attends to:
+
+- **Windowed** shows 8 turns with full assistant context. The LLM sees a specific
+  interaction in detail. It catches micro-level reasoning: word choice corrections,
+  naming decisions, editing moves.
+
+- **Triage + owner-only** shows 10-15 owner messages with no assistant context. The
+  LLM sees concentrated strategic reasoning. It catches macro-level patterns: where
+  decisions land, how patterns get named, what gets deferred.
+
+- **Baseline** shows the full compressed conversation. For short conversations this
+  works fine. For long ones it returns NONE, but the short-conversation observations
+  lean toward analytical depth because short conversations tend to be focused
+  discussions rather than execution sessions.
+
+The strategies aren't better or worse -- they're sensitive to different signal types.
+
+## Next: multi-altitude observation
+
+The three strategies form a granularity spectrum: windowed (8 turns with assistant
+context) is the most granular, triage (owner-only from reasoning turns) is mid-altitude,
+baseline (full conversation) is the widest view. Each altitude catches signal invisible
+to the others.
+
+### Could we cascade instead of union?
+
+The naive union runs all three independently and merges observations. Cost is additive.
+A cascade would run one strategy, then use its output to inform the next.
+
+The natural cascade: window the conversation, triage the windows, construct a
+higher-altitude pass from the results. But two findings constrain this:
+
+1. **Triage within windows adds little.** Each window is 8 turns. Mechanical windows
+   already return NONE naturally. Triaging within a window to get 3-4 turns is
+   essentially just a smaller window -- we could achieve the same effect by reducing
+   window size. The triage step is redundant at window scale.
+
+2. **Triage on triaged turns with assistant text still fails.** From 009 approach E:
+   triage correctly identifies reasoning turns, but observe on triaged turns with
+   compressed assistant text returns NONE. This was tested on full conversations, not
+   windows. On windows the problem might not apply (they're small enough). But we
+   haven't tested this, and the mechanism is still unexplained.
+
+What triage adds to windowed isn't finer filtering -- it's a different altitude.
+Windowed observes 8-turn interactions. Triage observes 10-15 owner messages spanning
+the whole conversation. The second pass sees cross-conversation arcs that no single
+window contains: how the owner's position evolved, what patterns recur across decisions,
+what got deferred and why.
+
+### The right framing: multi-altitude, not multi-strategy
+
+If both altitudes find unique signal, the pipeline should run both as a single
+pipeline, not as two separate strategies the user chooses between. The user shouldn't
+need to know about observation strategies. They run `muse compose` and get the best
+muse we can build.
+
+The pipeline would be:
+1. **Window pass:** sliding windows with assistant context, observe each, deduplicate
+2. **Altitude pass:** triage + owner-only on the full conversation
+3. **Merge:** combine observations from both passes, deduplicate
+4. **Downstream:** label, theme, cluster, summarize, thesis, compose as today
+
+Cost is ~$18 observe for the current corpus. That's 2.7x baseline. Whether this is
+acceptable depends on how often users run compose (daily? weekly?) and whether the
+quality improvement justifies it. The downstream stages ($1-2) are unchanged.
+
+### Experiment to run
+
+1. Run windowed and triage on the same corpus (reuse cached observations or run fresh)
+2. Merge observation artifacts, deduplicating by text similarity
+3. Compose from the merged set
+4. Compare the resulting muse against windowed-only and triage-only
+5. Judge using the same LLM-as-judge dimensions we use for generative evals
+
+This is a single-variable test: same conversations, same downstream pipeline, only the
+observation set differs. If the merged muse is clearly better, build multi-altitude
+into the default pipeline. If it's roughly equivalent to windowed alone, the triage
+pass is waste and windowed is the answer.
+
+### Cost note
+
+Windowed is 2x the observe cost of triage ($12 vs $6) because it makes 5-68 observe
+calls per conversation (one per window) plus a refine call. The windows run sequentially
+within a conversation but conversations run in parallel. Observe dominates total cost
+(90% for windowed, 86% for triage).
+
+If windowed becomes the default, the main cost lever is window size. Larger windows
+mean fewer calls but risk reintroducing context rot. The current 8/4 split is untested
+against alternatives.

--- a/designs/reboot.md
+++ b/designs/reboot.md
@@ -1,0 +1,83 @@
+# Context Preservation: Reboot
+
+## Where we are
+
+Branch `preserve-context` has a working implementation: mechanical filter → LLM triage →
+owner-only observe. It turns 0-observation conversations into 7-9 observation conversations.
+Not yet pushed or PR'd. The design doc (009-observations.md) documents five abandoned
+approaches and the working one.
+
+## What we learned
+
+The observation pipeline has a context rot problem. Conversations start with design
+decisions and end with execution. The observe prompt processes the full conversation
+and loses the early reasoning signal under later mechanical noise.
+
+Five approaches failed by treating this as a compression, prompt, or filtering problem:
+
+- **Adaptive compression** (scale assistant text by owner message length): more context
+  diluted signal. 17k chars produced 0 observations, 13k produced 5.
+- **Prompt-driven extraction** (ask for transformations not principles): made the LLM
+  more cautious, produced fewer observations.
+- **Context-aware prompting** (ask the LLM to reason about what context is needed):
+  same regression.
+- **Mechanical turn filtering** (remove confirmations by pattern matching): insufficient,
+  many low-signal turns survive patterns.
+- **LLM triage + compressed conversation**: triage correctly identifies reasoning turns,
+  but observe still returns NONE on the compressed triaged conversation.
+
+The breakthrough: stripping assistant text entirely and feeding observe only the owner's
+messages from triaged turns. 6 curated owner messages → 5 observations. 27 mixed messages
+→ 0. The problem is volume and attention, not missing context.
+
+## The real problem: local signal, global observation
+
+Context rot is a local signal problem. Turn 4 is a design decision regardless of what
+turns 15-27 contain. But the current pipeline evaluates the full conversation at once.
+The LLM reads sequentially, and mechanical turns wash out earlier reasoning turns.
+
+The triage + owner-only approach is a workaround. It strips noise so observe sees
+concentrated signal. But it's still observing the full conversation's worth of owner
+messages at once, and it requires an extra LLM call for triage.
+
+## Next step: windowed observation
+
+Observe in sliding windows of 5-10 turns. Each window is small enough that local signal
+survives. No turn is evaluated in the context of distant mechanical turns.
+
+The pipeline would be:
+1. Extract turns as today
+2. Walk through turns in overlapping windows (e.g. 8 turns, stride 4)
+3. Run observe on each window independently
+4. Collect all observations, deduplicate
+
+This treats context rot at the source (temporal locality) rather than the symptom
+(filtering). Each window captures reasoning in its local context. Mechanical windows
+produce NONE, reasoning windows produce observations, and that's correct.
+
+Questions to resolve:
+- Window size and stride. Too small loses multi-turn reasoning arcs. Too large
+  reintroduces context rot.
+- Deduplication. Adjacent windows overlap and may extract the same observation twice.
+- Cost. More observe calls per conversation. Offset by smaller inputs per call.
+- Whether windows need assistant context or owner-only. The current finding says
+  owner-only works, but that was tested on globally-triaged turns, not local windows.
+
+## Files changed on preserve-context branch
+
+- `cmd/compose.go` — ContextStrategy flag (can be removed if we drop adaptive)
+- `cmd/eval_context.go` — test harness for comparing strategies on single conversations
+- `cmd/root.go` — registered eval-context command
+- `designs/009-observations.md` — compression section with findings
+- `internal/compose/clustered.go` — observeAndRefine with triage + owner-only path
+- `internal/compose/compose.go` — ContextStrategy type, filterLowSignalTurns, triageTurns
+- `prompts/observe.md` — agent-directed work paragraph
+- `prompts/prompts.go` — triage embed
+- `prompts/triage.md` — triage prompt
+
+## Test harness
+
+`muse eval-context <conversation-id-or-path>` runs the observe pipeline under each
+strategy on a single conversation and prints observations side by side. Useful for
+iterating on the pipeline without running full compose. Snapshot conversations to /tmp
+for repeatable comparisons (conversations grow between runs).

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -431,7 +431,7 @@ func runObserve(
 				convBytes := conversationDataSize(conv)
 
 				start := time.Now()
-				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose)
+				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose, opts.PreserveContext)
 				n := counter.Add(1)
 				if err != nil {
 					return fmt.Errorf("observe %s: %w", entry.Key, err)
@@ -499,8 +499,8 @@ func conversationDataSize(conv *conversation.Conversation) int {
 // exceeds the context window, mechanical compression is applied as a fallback:
 // code blocks are stripped, tool output is collapsed to [tool: name] markers,
 // and long assistant messages are truncated.
-func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool) ([]Observation, inference.Usage, error) {
-	refined, usage, err := observeAndRefine(ctx, client, conv, verbose)
+func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose, preserveContext bool) ([]Observation, inference.Usage, error) {
+	refined, usage, err := observeAndRefine(ctx, client, conv, verbose, preserveContext)
 	if err != nil {
 		return nil, usage, err
 	}
@@ -539,13 +539,13 @@ func observeAndParse(ctx context.Context, client inference.Client, conv *convers
 // prompt in chunks, and refines the candidates into a single text.
 // Both the map-reduce path (which wants raw text) and the clustering path
 // (which further parses into discrete items) call this function.
-func observeAndRefine(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool) (string, inference.Usage, error) {
+func observeAndRefine(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose, preserveContext bool) (string, inference.Usage, error) {
 	turns := extractTurns(conv)
 	if len(turns) == 0 {
 		return "", inference.Usage{}, nil
 	}
 
-	chunks := compressConversation(turns, conv.Source)
+	chunks := compressConversation(turns, conv.Source, preserveContext)
 	if len(chunks) == 0 {
 		return "", inference.Usage{}, nil
 	}
@@ -602,6 +602,16 @@ func observeAndRefine(ctx context.Context, client inference.Client, conv *conver
 // full assistant text.
 const maxAssistantChars = 500
 
+// maxAssistantCharsPreserved is the limit when the owner's response looks like
+// a correction or edit directive. Short owner responses to long assistant turns
+// are likely reacting to specific content, so we preserve more context.
+const maxAssistantCharsPreserved = 2000
+
+// maxCorrectionWords is the word count threshold for detecting owner corrections.
+// Messages shorter than this that follow a long assistant turn are likely
+// reacting to specific content in that turn.
+const maxCorrectionWords = 50
+
 // isHumanSource returns true for sources where conversations are between
 // the owner and other people (not AI assistants).
 func isHumanSource(source string) bool {
@@ -616,7 +626,11 @@ func isHumanSource(source string) bool {
 // compressConversation mechanically compresses turns for observation: strips
 // code blocks, collapses tool output to [tool: name] markers, and truncates
 // long assistant/peer messages. Returns chunked text ready for the observe prompt.
-func compressConversation(turns []turn, source string) []string {
+//
+// When preserveContext is true, short owner messages (likely corrections or edit
+// directives) get more preceding assistant context preserved, so the observe
+// prompt can see what the owner was reacting to.
+func compressConversation(turns []turn, source string, preserveContext bool) []string {
 	var chunks []string
 	var b strings.Builder
 
@@ -629,7 +643,11 @@ func compressConversation(turns []turn, source string) []string {
 	for _, t := range turns {
 		var entry string
 		if t.assistantContent != "" {
-			compressed := compressAssistant(t.assistantContent)
+			limit := maxAssistantChars
+			if preserveContext && isLikelyCorrection(t.humanContent) {
+				limit = maxAssistantCharsPreserved
+			}
+			compressed := compressAssistantWithLimit(t.assistantContent, limit)
 			entry = fmt.Sprintf("%s: %s\n%s: %s\n\n", peerLabel, compressed, ownerLabel, t.humanContent)
 		} else {
 			entry = fmt.Sprintf("%s: %s\n\n", ownerLabel, t.humanContent)
@@ -647,15 +665,24 @@ func compressConversation(turns []turn, source string) []string {
 	return chunks
 }
 
+// isLikelyCorrection returns true when an owner message is short enough to be
+// a correction or edit directive rather than a substantive new contribution.
+func isLikelyCorrection(humanContent string) bool {
+	words := len(strings.Fields(humanContent))
+	return words > 0 && words <= maxCorrectionWords
+}
+
 // compressAssistant strips code blocks, collapses tool markers, and truncates.
 func compressAssistant(content string) string {
-	// Strip fenced code blocks (```...```)
-	result := stripCodeBlocks(content)
+	return compressAssistantWithLimit(content, maxAssistantChars)
+}
 
-	// Truncate if still too long
+// compressAssistantWithLimit strips code blocks and truncates to the given limit.
+func compressAssistantWithLimit(content string, limit int) string {
+	result := stripCodeBlocks(content)
 	result = strings.TrimSpace(result)
-	if len(result) > maxAssistantChars {
-		result = result[:maxAssistantChars] + "..."
+	if len(result) > limit {
+		result = result[:limit] + "..."
 	}
 	return result
 }

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -431,7 +431,7 @@ func runObserve(
 				convBytes := conversationDataSize(conv)
 
 				start := time.Now()
-				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose, opts.PreserveContext)
+				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose, opts.Context)
 				n := counter.Add(1)
 				if err != nil {
 					return fmt.Errorf("observe %s: %w", entry.Key, err)
@@ -492,6 +492,26 @@ func conversationDataSize(conv *conversation.Conversation) int {
 	return n
 }
 
+// ObserveForTestVerbose runs the full observe pipeline on a single conversation,
+// returning the raw observe output and parsed observations.
+func ObserveForTestVerbose(ctx context.Context, client inference.Client, conv *conversation.Conversation, ctxStrategy ContextStrategy) (string, []Observation, inference.Usage, error) {
+	raw, usage, err := observeAndRefine(ctx, client, conv, true, ctxStrategy)
+	if err != nil {
+		return "", nil, usage, err
+	}
+	if raw == "" {
+		return "", nil, usage, nil
+	}
+	items := parseObservationItems(raw)
+	var relevant []Observation
+	for _, item := range items {
+		if isRelevant(item.Text) {
+			relevant = append(relevant, item)
+		}
+	}
+	return raw, relevant, usage, nil
+}
+
 // observeAndParse runs the observe pipeline on a conversation and returns
 // discrete observations (not a markdown blob).
 //
@@ -499,8 +519,8 @@ func conversationDataSize(conv *conversation.Conversation) int {
 // exceeds the context window, mechanical compression is applied as a fallback:
 // code blocks are stripped, tool output is collapsed to [tool: name] markers,
 // and long assistant messages are truncated.
-func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose, preserveContext bool) ([]Observation, inference.Usage, error) {
-	refined, usage, err := observeAndRefine(ctx, client, conv, verbose, preserveContext)
+func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, ctxStrategy ContextStrategy) ([]Observation, inference.Usage, error) {
+	refined, usage, err := observeAndRefine(ctx, client, conv, verbose, ctxStrategy)
 	if err != nil {
 		return nil, usage, err
 	}
@@ -539,16 +559,13 @@ func observeAndParse(ctx context.Context, client inference.Client, conv *convers
 // prompt in chunks, and refines the candidates into a single text.
 // Both the map-reduce path (which wants raw text) and the clustering path
 // (which further parses into discrete items) call this function.
-func observeAndRefine(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose, preserveContext bool) (string, inference.Usage, error) {
+func observeAndRefine(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, ctxStrategy ContextStrategy) (string, inference.Usage, error) {
 	turns := extractTurns(conv)
 	if len(turns) == 0 {
 		return "", inference.Usage{}, nil
 	}
 
-	chunks := compressConversation(turns, conv.Source, preserveContext)
-	if len(chunks) == 0 {
-		return "", inference.Usage{}, nil
-	}
+	var totalUsage inference.Usage
 
 	// Select the appropriate observe prompt based on source type
 	observePrompt := prompts.Observe
@@ -556,61 +573,118 @@ func observeAndRefine(ctx context.Context, client inference.Client, conv *conver
 		observePrompt = prompts.ObserveHuman
 	}
 
-	var totalUsage inference.Usage
+	// For large conversations, concentrate signal: filter → triage → owner-only.
+	// The observe prompt works well on concentrated input but returns NONE when
+	// high-signal turns are diluted by mechanical agent interaction.
+	observeInput := ""
+	if len(turns) > 10 {
+		// Mechanical filter
+		filtered := filterLowSignalTurns(turns)
+		if verbose && len(filtered) < len(turns) {
+			fmt.Fprintf(os.Stderr, "    filter %d → %d turns (%d low-signal removed)\n",
+				len(turns), len(filtered), len(turns)-len(filtered))
+		}
+		if len(filtered) == 0 {
+			return "", totalUsage, nil
+		}
 
-	// Observe (Pass 1)
-	var allCandidates []string
-	for i, chunk := range chunks {
+		// LLM triage
+		triaged := filtered
+		if len(filtered) > 10 {
+			t, usage, err := triageTurns(ctx, client, filtered, conv.Source, verbose)
+			totalUsage = totalUsage.Add(usage)
+			if err != nil {
+				if verbose {
+					fmt.Fprintf(os.Stderr, "    triage error, falling back: %v\n", err)
+				}
+			} else if len(t) > 0 {
+				triaged = t
+			}
+		}
+		if len(triaged) == 0 {
+			return "", totalUsage, nil
+		}
+
+		// Owner-only: strip assistant context entirely
+		var b strings.Builder
+		for _, t := range triaged {
+			fmt.Fprintf(&b, "[owner]: %s\n\n", t.humanContent)
+		}
+		observeInput = b.String()
+		if verbose {
+			fmt.Fprintf(os.Stderr, "    owner-only %d turns, %d chars\n", len(triaged), len(observeInput))
+		}
+	}
+
+	// For small conversations, use the original compression pipeline
+	if observeInput == "" {
+		chunks := compressConversation(turns, conv.Source, ctxStrategy)
+		if len(chunks) == 0 {
+			return "", totalUsage, nil
+		}
+		// Small conversations: observe + refine as before
+		var allCandidates []string
+		for i, chunk := range chunks {
+			start := time.Now()
+			obs, usage, err := inference.Converse(ctx, client, observePrompt, chunk, inference.WithMaxTokens(4096))
+			totalUsage = totalUsage.Add(usage)
+			if verbose {
+				fmt.Fprintf(os.Stderr, "      observe[%d/%d] %d chars → %d chars (%s, $%.4f)\n",
+					i+1, len(chunks), len(chunk), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+			}
+			if err != nil && obs == "" {
+				return "", totalUsage, err
+			}
+			if obs != "" && !isEmpty(obs) {
+				allCandidates = append(allCandidates, obs)
+			}
+		}
+		if len(allCandidates) == 0 {
+			return "", totalUsage, nil
+		}
+		candidates := strings.Join(allCandidates, "\n\n")
 		start := time.Now()
-		obs, usage, err := inference.Converse(ctx, client, observePrompt, chunk, inference.WithMaxTokens(4096))
+		refined, usage, err := inference.Converse(ctx, client, prompts.Refine, candidates, inference.WithMaxTokens(4096))
 		totalUsage = totalUsage.Add(usage)
 		if verbose {
-			fmt.Fprintf(os.Stderr, "      observe[%d/%d] %d chars → %d chars (%s, $%.4f)\n",
-				i+1, len(chunks), len(chunk), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+			fmt.Fprintf(os.Stderr, "      refine %d chars → %d chars (%s, $%.4f)\n",
+				len(candidates), len(refined), time.Since(start).Round(time.Millisecond), usage.Cost())
 		}
-		if err != nil && obs == "" {
+		if err != nil && refined == "" {
 			return "", totalUsage, err
 		}
-		if obs != "" && !isEmpty(obs) {
-			allCandidates = append(allCandidates, obs)
+		if isEmpty(refined) {
+			return "", totalUsage, nil
 		}
-	}
-	if len(allCandidates) == 0 {
-		return "", totalUsage, nil
+		return refined, totalUsage, nil
 	}
 
-	// Refine (Pass 2)
-	candidates := strings.Join(allCandidates, "\n\n")
+	// Large conversations: single observe pass on owner-only text, no refine
 	start := time.Now()
-	refined, usage, err := inference.Converse(ctx, client, prompts.Refine, candidates, inference.WithMaxTokens(4096))
+	obs, usage, err := inference.Converse(ctx, client, observePrompt, observeInput, inference.WithMaxTokens(4096))
 	totalUsage = totalUsage.Add(usage)
 	if verbose {
-		fmt.Fprintf(os.Stderr, "      refine %d chars → %d chars (%s, $%.4f)\n",
-			len(candidates), len(refined), time.Since(start).Round(time.Millisecond), usage.Cost())
+		fmt.Fprintf(os.Stderr, "      observe %d chars → %d chars (%s, $%.4f)\n",
+			len(observeInput), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
 	}
-	if err != nil && refined == "" {
+	if err != nil && obs == "" {
 		return "", totalUsage, err
 	}
-	if isEmpty(refined) {
+	if isEmpty(obs) {
 		return "", totalUsage, nil
 	}
-	return refined, totalUsage, nil
+	return obs, totalUsage, nil
 }
 
-// maxAssistantChars caps truncated assistant messages. Long assistant output is
-// mostly code or tool results — the human's reaction is what matters, not the
-// full assistant text.
-const maxAssistantChars = 500
-
-// maxAssistantCharsPreserved is the limit when the owner's response looks like
-// a correction or edit directive. Short owner responses to long assistant turns
-// are likely reacting to specific content, so we preserve more context.
-const maxAssistantCharsPreserved = 2000
-
-// maxCorrectionWords is the word count threshold for detecting owner corrections.
-// Messages shorter than this that follow a long assistant turn are likely
-// reacting to specific content in that turn.
-const maxCorrectionWords = 50
+// Assistant text limits for adaptive compression. Short owner messages are
+// likely corrections reacting to specific content, so we preserve more of the
+// preceding assistant turn. Long owner messages carry their own context.
+const (
+	minAssistantChars = 500  // limit for long owner messages (>= maxOwnerWords)
+	maxAssistantChars = 2000 // limit for very short owner messages (<= minOwnerWords)
+	minOwnerWords     = 5    // at or below this, full context preserved
+	maxOwnerWords     = 100  // at or above this, minimal context preserved
+)
 
 // isHumanSource returns true for sources where conversations are between
 // the owner and other people (not AI assistants).
@@ -626,11 +700,7 @@ func isHumanSource(source string) bool {
 // compressConversation mechanically compresses turns for observation: strips
 // code blocks, collapses tool output to [tool: name] markers, and truncates
 // long assistant/peer messages. Returns chunked text ready for the observe prompt.
-//
-// When preserveContext is true, short owner messages (likely corrections or edit
-// directives) get more preceding assistant context preserved, so the observe
-// prompt can see what the owner was reacting to.
-func compressConversation(turns []turn, source string, preserveContext bool) []string {
+func compressConversation(turns []turn, source string, ctx ContextStrategy) []string {
 	var chunks []string
 	var b strings.Builder
 
@@ -643,9 +713,9 @@ func compressConversation(turns []turn, source string, preserveContext bool) []s
 	for _, t := range turns {
 		var entry string
 		if t.assistantContent != "" {
-			limit := maxAssistantChars
-			if preserveContext && isLikelyCorrection(t.humanContent) {
-				limit = maxAssistantCharsPreserved
+			limit := minAssistantChars
+			if ctx == ContextAdaptive {
+				limit = assistantCharLimit(t.humanContent)
 			}
 			compressed := compressAssistantWithLimit(t.assistantContent, limit)
 			entry = fmt.Sprintf("%s: %s\n%s: %s\n\n", peerLabel, compressed, ownerLabel, t.humanContent)
@@ -665,11 +735,20 @@ func compressConversation(turns []turn, source string, preserveContext bool) []s
 	return chunks
 }
 
-// isLikelyCorrection returns true when an owner message is short enough to be
-// a correction or edit directive rather than a substantive new contribution.
-func isLikelyCorrection(humanContent string) bool {
+// assistantCharLimit returns the truncation limit for an assistant message
+// based on the length of the owner's response. Interpolates linearly between
+// maxAssistantChars (short owner messages) and minAssistantChars (long ones).
+func assistantCharLimit(humanContent string) int {
 	words := len(strings.Fields(humanContent))
-	return words > 0 && words <= maxCorrectionWords
+	if words <= minOwnerWords {
+		return maxAssistantChars
+	}
+	if words >= maxOwnerWords {
+		return minAssistantChars
+	}
+	// Linear interpolation
+	frac := float64(words-minOwnerWords) / float64(maxOwnerWords-minOwnerWords)
+	return maxAssistantChars - int(frac*float64(maxAssistantChars-minAssistantChars))
 }
 
 // compressAssistant strips code blocks, collapses tool markers, and truncates.

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -353,8 +353,10 @@ func runObserve(
 	sort.Strings(sources)
 	discovered := len(entries)
 
-	// Compute prompt chain hash for fingerprinting
-	promptHash := Fingerprint(prompts.Observe, prompts.ObserveHuman, prompts.Refine)
+	// Compute prompt chain hash for fingerprinting. Includes window parameters
+	// so changing the observation strategy invalidates cached observations.
+	promptHash := Fingerprint(prompts.Observe, prompts.ObserveHuman, prompts.Refine,
+		fmt.Sprintf("window:%d:%d", windowSize, windowStride))
 
 	// Determine which conversations need (re)observation
 	var pending []storage.ConversationEntry
@@ -494,8 +496,8 @@ func conversationDataSize(conv *conversation.Conversation) int {
 
 // ObserveForTestVerbose runs the full observe pipeline on a single conversation,
 // returning the raw observe output and parsed observations.
-func ObserveForTestVerbose(ctx context.Context, client inference.Client, conv *conversation.Conversation, ctxStrategy ContextStrategy) (string, []Observation, inference.Usage, error) {
-	raw, usage, err := observeAndRefine(ctx, client, conv, true, ctxStrategy)
+func ObserveForTestVerbose(ctx context.Context, client inference.Client, conv *conversation.Conversation, ctxStrategy ContextStrategy, mode ObserveMode) (string, []Observation, inference.Usage, error) {
+	raw, usage, err := observeAndRefine(ctx, client, conv, true, ctxStrategy, mode)
 	if err != nil {
 		return "", nil, usage, err
 	}
@@ -520,7 +522,7 @@ func ObserveForTestVerbose(ctx context.Context, client inference.Client, conv *c
 // code blocks are stripped, tool output is collapsed to [tool: name] markers,
 // and long assistant messages are truncated.
 func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, ctxStrategy ContextStrategy) ([]Observation, inference.Usage, error) {
-	refined, usage, err := observeAndRefine(ctx, client, conv, verbose, ctxStrategy)
+	refined, usage, err := observeAndRefine(ctx, client, conv, verbose, ctxStrategy, ObserveWindowed)
 	if err != nil {
 		return nil, usage, err
 	}
@@ -554,12 +556,21 @@ func observeAndParse(ctx context.Context, client inference.Client, conv *convers
 	return relevant, usage, nil
 }
 
+// Window parameters for sliding-window observation. Each window is small
+// enough that local signal survives without being washed out by distant
+// mechanical turns (context rot). Adjacent windows overlap so multi-turn
+// reasoning arcs aren't split across boundaries.
+const (
+	windowSize   = 8 // turns per window
+	windowStride = 4 // advance between windows
+)
+
 // observeAndRefine is the shared core of the observation pipeline. It extracts
 // turns from a conversation, mechanically compresses them, runs the observe
-// prompt in chunks, and refines the candidates into a single text.
+// prompt, and refines the candidates into a single text.
 // Both the map-reduce path (which wants raw text) and the clustering path
 // (which further parses into discrete items) call this function.
-func observeAndRefine(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, ctxStrategy ContextStrategy) (string, inference.Usage, error) {
+func observeAndRefine(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, ctxStrategy ContextStrategy, mode ObserveMode) (string, inference.Usage, error) {
 	turns := extractTurns(conv)
 	if len(turns) == 0 {
 		return "", inference.Usage{}, nil
@@ -573,107 +584,247 @@ func observeAndRefine(ctx context.Context, client inference.Client, conv *conver
 		observePrompt = prompts.ObserveHuman
 	}
 
-	// For large conversations, concentrate signal: filter → triage → owner-only.
-	// The observe prompt works well on concentrated input but returns NONE when
-	// high-signal turns are diluted by mechanical agent interaction.
-	observeInput := ""
-	if len(turns) > 10 {
-		// Mechanical filter
-		filtered := filterLowSignalTurns(turns)
-		if verbose && len(filtered) < len(turns) {
-			fmt.Fprintf(os.Stderr, "    filter %d → %d turns (%d low-signal removed)\n",
-				len(turns), len(filtered), len(turns)-len(filtered))
-		}
-		if len(filtered) == 0 {
-			return "", totalUsage, nil
-		}
-
-		// LLM triage
-		triaged := filtered
-		if len(filtered) > 10 {
-			t, usage, err := triageTurns(ctx, client, filtered, conv.Source, verbose)
-			totalUsage = totalUsage.Add(usage)
-			if err != nil {
-				if verbose {
-					fmt.Fprintf(os.Stderr, "    triage error, falling back: %v\n", err)
-				}
-			} else if len(t) > 0 {
-				triaged = t
-			}
-		}
-		if len(triaged) == 0 {
-			return "", totalUsage, nil
-		}
-
-		// Owner-only: strip assistant context entirely
-		var b strings.Builder
-		for _, t := range triaged {
-			fmt.Fprintf(&b, "[owner]: %s\n\n", t.humanContent)
-		}
-		observeInput = b.String()
-		if verbose {
-			fmt.Fprintf(os.Stderr, "    owner-only %d turns, %d chars\n", len(triaged), len(observeInput))
+	// For large conversations, dispatch on observe mode.
+	if len(turns) > 10 && mode != ObserveFullConversation {
+		switch mode {
+		case ObserveTriageOwnerOnly:
+			return observeTriageOwnerOnly(ctx, client, turns, conv.Source, observePrompt, verbose, &totalUsage)
+		default:
+			return observeWindowed(ctx, client, turns, conv.Source, observePrompt, ctxStrategy, verbose, &totalUsage)
 		}
 	}
 
-	// For small conversations, use the original compression pipeline
-	if observeInput == "" {
-		chunks := compressConversation(turns, conv.Source, ctxStrategy)
-		if len(chunks) == 0 {
-			return "", totalUsage, nil
-		}
-		// Small conversations: observe + refine as before
-		var allCandidates []string
-		for i, chunk := range chunks {
-			start := time.Now()
-			obs, usage, err := inference.Converse(ctx, client, observePrompt, chunk, inference.WithMaxTokens(4096))
-			totalUsage = totalUsage.Add(usage)
-			if verbose {
-				fmt.Fprintf(os.Stderr, "      observe[%d/%d] %d chars → %d chars (%s, $%.4f)\n",
-					i+1, len(chunks), len(chunk), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
-			}
-			if err != nil && obs == "" {
-				return "", totalUsage, err
-			}
-			if obs != "" && !isEmpty(obs) {
-				allCandidates = append(allCandidates, obs)
-			}
-		}
-		if len(allCandidates) == 0 {
-			return "", totalUsage, nil
-		}
-		candidates := strings.Join(allCandidates, "\n\n")
+	// Small conversations: compress, observe in chunks, refine
+	chunks := compressConversation(turns, conv.Source, ctxStrategy)
+	if len(chunks) == 0 {
+		return "", totalUsage, nil
+	}
+	var allCandidates []string
+	for i, chunk := range chunks {
 		start := time.Now()
-		refined, usage, err := inference.Converse(ctx, client, prompts.Refine, candidates, inference.WithMaxTokens(4096))
+		obs, usage, err := inference.Converse(ctx, client, observePrompt, chunk, inference.WithMaxTokens(4096))
 		totalUsage = totalUsage.Add(usage)
 		if verbose {
-			fmt.Fprintf(os.Stderr, "      refine %d chars → %d chars (%s, $%.4f)\n",
-				len(candidates), len(refined), time.Since(start).Round(time.Millisecond), usage.Cost())
+			fmt.Fprintf(os.Stderr, "      observe[%d/%d] %d chars → %d chars (%s, $%.4f)\n",
+				i+1, len(chunks), len(chunk), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
 		}
-		if err != nil && refined == "" {
+		if err != nil && obs == "" {
 			return "", totalUsage, err
 		}
-		if isEmpty(refined) {
-			return "", totalUsage, nil
+		if obs != "" && !isEmpty(obs) {
+			allCandidates = append(allCandidates, obs)
 		}
-		return refined, totalUsage, nil
+	}
+	if len(allCandidates) == 0 {
+		return "", totalUsage, nil
+	}
+	candidates := strings.Join(allCandidates, "\n\n")
+	start := time.Now()
+	refined, usage, err := inference.Converse(ctx, client, prompts.Refine, candidates, inference.WithMaxTokens(4096))
+	totalUsage = totalUsage.Add(usage)
+	if verbose {
+		fmt.Fprintf(os.Stderr, "      refine %d chars → %d chars (%s, $%.4f)\n",
+			len(candidates), len(refined), time.Since(start).Round(time.Millisecond), usage.Cost())
+	}
+	if err != nil && refined == "" {
+		return "", totalUsage, err
+	}
+	if isEmpty(refined) {
+		return "", totalUsage, nil
+	}
+	return refined, totalUsage, nil
+}
+
+// observeWindowed runs sliding-window observation on a large conversation.
+// Each window is small enough that local signal survives without being
+// diluted by distant mechanical turns.
+func observeWindowed(ctx context.Context, client inference.Client, turns []turn, source, observePrompt string, ctxStrategy ContextStrategy, verbose bool, totalUsage *inference.Usage) (string, inference.Usage, error) {
+	windows := buildWindows(turns, windowSize, windowStride)
+	if verbose {
+		fmt.Fprintf(os.Stderr, "    windowed: %d turns → %d windows (size %d, stride %d)\n",
+			len(turns), len(windows), windowSize, windowStride)
 	}
 
-	// Large conversations: single observe pass on owner-only text, no refine
+	var allCandidates []string
+	for i, w := range windows {
+		chunk := compressConversation(w, source, ctxStrategy)
+		input := strings.Join(chunk, "\n")
+		start := time.Now()
+		obs, usage, err := inference.Converse(ctx, client, observePrompt, input, inference.WithMaxTokens(4096))
+		*totalUsage = totalUsage.Add(usage)
+		if verbose {
+			fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, %d chars → %d chars (%s, $%.4f)\n",
+				i+1, len(windows), len(w), len(input), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+		}
+		if err != nil && obs == "" {
+			return "", *totalUsage, err
+		}
+		if obs != "" && !isEmpty(obs) {
+			allCandidates = append(allCandidates, obs)
+		}
+	}
+	if len(allCandidates) == 0 {
+		return "", *totalUsage, nil
+	}
+
+	// Deduplicate across overlapping windows, then refine
+	candidates := deduplicateObservationText(strings.Join(allCandidates, "\n\n"))
+	start := time.Now()
+	refined, usage, err := inference.Converse(ctx, client, prompts.Refine, candidates, inference.WithMaxTokens(4096))
+	*totalUsage = totalUsage.Add(usage)
+	if verbose {
+		fmt.Fprintf(os.Stderr, "      refine %d chars → %d chars (%s, $%.4f)\n",
+			len(candidates), len(refined), time.Since(start).Round(time.Millisecond), usage.Cost())
+	}
+	if err != nil && refined == "" {
+		return "", *totalUsage, err
+	}
+	if isEmpty(refined) {
+		return "", *totalUsage, nil
+	}
+	return refined, *totalUsage, nil
+}
+
+// observeTriageOwnerOnly runs the triage + owner-only observation path.
+// Mechanical filter → LLM triage → strip assistant text → single observe pass.
+func observeTriageOwnerOnly(ctx context.Context, client inference.Client, turns []turn, source, observePrompt string, verbose bool, totalUsage *inference.Usage) (string, inference.Usage, error) {
+	// Mechanical filter
+	filtered := filterLowSignalTurns(turns)
+	if verbose && len(filtered) < len(turns) {
+		fmt.Fprintf(os.Stderr, "    filter %d → %d turns (%d low-signal removed)\n",
+			len(turns), len(filtered), len(turns)-len(filtered))
+	}
+	if len(filtered) == 0 {
+		return "", *totalUsage, nil
+	}
+
+	// LLM triage
+	triaged := filtered
+	if len(filtered) > 10 {
+		t, usage, err := triageTurns(ctx, client, filtered, source, verbose)
+		*totalUsage = totalUsage.Add(usage)
+		if err != nil {
+			if verbose {
+				fmt.Fprintf(os.Stderr, "    triage error, falling back: %v\n", err)
+			}
+		} else if len(t) > 0 {
+			triaged = t
+		}
+	}
+	if len(triaged) == 0 {
+		return "", *totalUsage, nil
+	}
+
+	// Owner-only: strip assistant context entirely
+	var b strings.Builder
+	for _, t := range triaged {
+		fmt.Fprintf(&b, "[owner]: %s\n\n", t.humanContent)
+	}
+	observeInput := b.String()
+	if verbose {
+		fmt.Fprintf(os.Stderr, "    owner-only %d turns, %d chars\n", len(triaged), len(observeInput))
+	}
+
 	start := time.Now()
 	obs, usage, err := inference.Converse(ctx, client, observePrompt, observeInput, inference.WithMaxTokens(4096))
-	totalUsage = totalUsage.Add(usage)
+	*totalUsage = totalUsage.Add(usage)
 	if verbose {
 		fmt.Fprintf(os.Stderr, "      observe %d chars → %d chars (%s, $%.4f)\n",
 			len(observeInput), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
 	}
 	if err != nil && obs == "" {
-		return "", totalUsage, err
+		return "", *totalUsage, err
 	}
 	if isEmpty(obs) {
-		return "", totalUsage, nil
+		return "", *totalUsage, nil
 	}
-	return obs, totalUsage, nil
+	return obs, *totalUsage, nil
+}
+
+// buildWindows splits turns into overlapping windows of the given size and stride.
+// The last window is extended or padded to avoid a tiny tail.
+func buildWindows(turns []turn, size, stride int) [][]turn {
+	if len(turns) <= size {
+		return [][]turn{turns}
+	}
+	var windows [][]turn
+	for start := 0; start < len(turns); start += stride {
+		end := start + size
+		if end > len(turns) {
+			end = len(turns)
+		}
+		// If the remaining turns after this window would be smaller than
+		// stride, extend this window to the end to avoid a tiny tail.
+		if len(turns)-end < stride {
+			end = len(turns)
+		}
+		windows = append(windows, turns[start:end])
+		if end == len(turns) {
+			break
+		}
+	}
+	return windows
+}
+
+// deduplicateObservationText removes duplicate observations from raw LLM output
+// across overlapping windows. Two observations are duplicates if their text
+// (after normalization) is identical or one contains the other.
+func deduplicateObservationText(text string) string {
+	items := parseObservationItems(text)
+	if len(items) == 0 {
+		return text
+	}
+
+	type normalizedObs struct {
+		original Observation
+		norm     string
+	}
+	var normalized []normalizedObs
+	for _, item := range items {
+		n := strings.ToLower(strings.TrimSpace(item.Text))
+		normalized = append(normalized, normalizedObs{original: item, norm: n})
+	}
+
+	// Keep track of which observations survive dedup
+	keep := make([]bool, len(normalized))
+	for i := range keep {
+		keep[i] = true
+	}
+
+	for i := 0; i < len(normalized); i++ {
+		if !keep[i] {
+			continue
+		}
+		for j := i + 1; j < len(normalized); j++ {
+			if !keep[j] {
+				continue
+			}
+			// Exact match
+			if normalized[i].norm == normalized[j].norm {
+				keep[j] = false
+				continue
+			}
+			// Containment: if one contains the other, keep the longer one
+			if strings.Contains(normalized[i].norm, normalized[j].norm) {
+				keep[j] = false
+			} else if strings.Contains(normalized[j].norm, normalized[i].norm) {
+				keep[i] = false
+				break
+			}
+		}
+	}
+
+	var b strings.Builder
+	for i, n := range normalized {
+		if !keep[i] {
+			continue
+		}
+		if n.original.Quote != "" {
+			fmt.Fprintf(&b, "Quote: %s\n", n.original.Quote)
+		}
+		fmt.Fprintf(&b, "Observation: %s\n\n", n.original.Text)
+	}
+	return strings.TrimSpace(b.String())
 }
 
 // Assistant text limits for adaptive compression. Short owner messages are

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -356,7 +356,8 @@ func runObserve(
 	// Compute prompt chain hash for fingerprinting. Includes window parameters
 	// so changing the observation strategy invalidates cached observations.
 	promptHash := Fingerprint(prompts.Observe, prompts.ObserveHuman, prompts.Refine,
-		fmt.Sprintf("window:%d:%d", windowSize, windowStride))
+		fmt.Sprintf("window:%d:%d", windowSize, windowStride),
+		fmt.Sprintf("mode:%s", opts.Observe))
 
 	// Determine which conversations need (re)observation
 	var pending []storage.ConversationEntry
@@ -433,7 +434,7 @@ func runObserve(
 				convBytes := conversationDataSize(conv)
 
 				start := time.Now()
-				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose, opts.Context)
+				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose, opts.Context, opts.Observe)
 				n := counter.Add(1)
 				if err != nil {
 					return fmt.Errorf("observe %s: %w", entry.Key, err)
@@ -497,6 +498,23 @@ func conversationDataSize(conv *conversation.Conversation) int {
 // ObserveForTestVerbose runs the full observe pipeline on a single conversation,
 // returning the raw observe output and parsed observations.
 func ObserveForTestVerbose(ctx context.Context, client inference.Client, conv *conversation.Conversation, ctxStrategy ContextStrategy, mode ObserveMode) (string, []Observation, inference.Usage, error) {
+	// Multi-zoom merges at the observation level, not the raw text level.
+	if mode == ObserveMultiZoom {
+		obs, usage, err := observeMultiZoom(ctx, client, conv, true, ctxStrategy)
+		if err != nil {
+			return "", nil, usage, err
+		}
+		// Reconstruct raw text for display
+		var raw strings.Builder
+		for _, o := range obs {
+			if o.Quote != "" {
+				fmt.Fprintf(&raw, "Quote: %s\n", o.Quote)
+			}
+			fmt.Fprintf(&raw, "Observation: %s\n\n", o.Text)
+		}
+		return strings.TrimSpace(raw.String()), obs, usage, nil
+	}
+
 	raw, usage, err := observeAndRefine(ctx, client, conv, true, ctxStrategy, mode)
 	if err != nil {
 		return "", nil, usage, err
@@ -521,19 +539,121 @@ func ObserveForTestVerbose(ctx context.Context, client inference.Client, conv *c
 // exceeds the context window, mechanical compression is applied as a fallback:
 // code blocks are stripped, tool output is collapsed to [tool: name] markers,
 // and long assistant messages are truncated.
-func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, ctxStrategy ContextStrategy) ([]Observation, inference.Usage, error) {
-	refined, usage, err := observeAndRefine(ctx, client, conv, verbose, ctxStrategy, ObserveWindowed)
+func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, ctxStrategy ContextStrategy, mode ObserveMode) ([]Observation, inference.Usage, error) {
+	if mode == ObserveMultiZoom {
+		return observeMultiZoom(ctx, client, conv, verbose, ctxStrategy)
+	}
+
+	refined, usage, err := observeAndRefine(ctx, client, conv, verbose, ctxStrategy, mode)
 	if err != nil {
 		return nil, usage, err
 	}
+	return parseAndFilter(refined, usage, verbose)
+}
+
+// observeMultiZoom runs both windowed (local) and triage+owner-only (global)
+// passes on the same conversation and merges the observations.
+func observeMultiZoom(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, ctxStrategy ContextStrategy) ([]Observation, inference.Usage, error) {
+	turns := extractTurns(conv)
+	// Only run both zoom levels on large conversations. Small ones get a single pass.
+	if len(turns) <= 10 {
+		refined, usage, err := observeAndRefine(ctx, client, conv, verbose, ctxStrategy, ObserveWindowed)
+		if err != nil {
+			return nil, usage, err
+		}
+		return parseAndFilter(refined, usage, verbose)
+	}
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "    multi-zoom: running local (windowed) + global (triage) passes\n")
+	}
+
+	// Local pass: windowed
+	localRaw, localUsage, localErr := observeAndRefine(ctx, client, conv, verbose, ctxStrategy, ObserveWindowed)
+	if localErr != nil {
+		return nil, localUsage, localErr
+	}
+	localObs, _, _ := parseAndFilter(localRaw, inference.Usage{}, false)
+
+	// Global pass: triage + owner-only
+	globalRaw, globalUsage, globalErr := observeAndRefine(ctx, client, conv, verbose, ctxStrategy, ObserveTriageOwnerOnly)
+	totalUsage := localUsage.Add(globalUsage)
+	if globalErr != nil {
+		// Global pass failure is non-fatal — return local observations
+		if verbose {
+			fmt.Fprintf(os.Stderr, "    multi-zoom: global pass failed (%v), using local only\n", globalErr)
+		}
+		return localObs, totalUsage, nil
+	}
+	globalObs, _, _ := parseAndFilter(globalRaw, inference.Usage{}, false)
+
+	// Merge and deduplicate
+	merged := deduplicateObservations(localObs, globalObs)
+	if verbose {
+		fmt.Fprintf(os.Stderr, "    multi-zoom: %d local + %d global → %d merged\n",
+			len(localObs), len(globalObs), len(merged))
+	}
+	return merged, totalUsage, nil
+}
+
+// deduplicateObservations merges two observation sets, dropping duplicates
+// where one observation's text contains the other's (after normalization).
+func deduplicateObservations(a, b []Observation) []Observation {
+	all := make([]Observation, 0, len(a)+len(b))
+	all = append(all, a...)
+	all = append(all, b...)
+
+	type normObs struct {
+		obs  Observation
+		norm string
+	}
+	var items []normObs
+	for _, o := range all {
+		items = append(items, normObs{obs: o, norm: strings.ToLower(strings.TrimSpace(o.Text))})
+	}
+
+	keep := make([]bool, len(items))
+	for i := range keep {
+		keep[i] = true
+	}
+	for i := 0; i < len(items); i++ {
+		if !keep[i] {
+			continue
+		}
+		for j := i + 1; j < len(items); j++ {
+			if !keep[j] {
+				continue
+			}
+			if items[i].norm == items[j].norm {
+				keep[j] = false
+				continue
+			}
+			if strings.Contains(items[i].norm, items[j].norm) {
+				keep[j] = false
+			} else if strings.Contains(items[j].norm, items[i].norm) {
+				keep[i] = false
+				break
+			}
+		}
+	}
+
+	var result []Observation
+	for i, item := range items {
+		if keep[i] {
+			result = append(result, item.obs)
+		}
+	}
+	return result
+}
+
+// parseAndFilter parses raw observe output into discrete observations,
+// filtering irrelevant items.
+func parseAndFilter(refined string, usage inference.Usage, verbose bool) ([]Observation, inference.Usage, error) {
 	if refined == "" {
 		return nil, usage, nil
 	}
-
-	// Parse refined output into discrete items.
 	items := parseObservationItems(refined)
 
-	// Filter irrelevant items: empty responses, LLM meta-commentary, placeholder tokens
 	var relevant []Observation
 	var irrelevant []Observation
 	for _, item := range items {

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -59,6 +59,9 @@ type BaseOptions struct {
 	Limit int
 	// Verbose enables per-item progress logging.
 	Verbose bool
+	// PreserveContext keeps more assistant context before owner corrections,
+	// so the observe prompt can see what the owner was reacting to.
+	PreserveContext bool
 }
 
 // Options configures a map-reduce compose run.
@@ -287,7 +290,7 @@ type turn struct {
 }
 
 func observeConversation(ctx context.Context, client inference.Client, conv *conversation.Conversation) (string, inference.Usage, error) {
-	refined, usage, err := observeAndRefine(ctx, client, conv, false)
+	refined, usage, err := observeAndRefine(ctx, client, conv, false, false)
 	if err != nil {
 		return "", usage, err
 	}

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -63,6 +63,20 @@ const (
 	ContextAdaptive ContextStrategy = "adaptive"
 )
 
+// ObserveMode controls the observation strategy for large conversations.
+type ObserveMode string
+
+const (
+	// ObserveWindowed uses sliding-window observation (default).
+	ObserveWindowed ObserveMode = ""
+	// ObserveTriageOwnerOnly uses the triage + owner-only path.
+	ObserveTriageOwnerOnly ObserveMode = "triage-owner-only"
+	// ObserveFullConversation compresses the full conversation and observes
+	// in chunks. This is the original path that exhibits context rot on long
+	// conversations — kept for eval comparison only.
+	ObserveFullConversation ObserveMode = "full-conversation"
+)
+
 // BaseOptions contains fields shared across all compose strategies.
 type BaseOptions struct {
 	// Reobserve ignores persisted observations and re-observes all conversations.
@@ -301,7 +315,7 @@ type turn struct {
 }
 
 func observeConversation(ctx context.Context, client inference.Client, conv *conversation.Conversation) (string, inference.Usage, error) {
-	refined, usage, err := observeAndRefine(ctx, client, conv, false, ContextDefault)
+	refined, usage, err := observeAndRefine(ctx, client, conv, false, ContextDefault, ObserveWindowed)
 	if err != nil {
 		return "", usage, err
 	}

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -2,6 +2,7 @@ package compose
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -51,6 +52,17 @@ type HitMiss struct {
 	Miss int
 }
 
+// ContextStrategy controls how much assistant context is preserved during
+// compression before the observe prompt sees the conversation.
+type ContextStrategy string
+
+const (
+	// ContextDefault uses the original fixed 500-char limit for all turns.
+	ContextDefault ContextStrategy = ""
+	// ContextAdaptive interpolates the limit by owner message length (500-2000 chars).
+	ContextAdaptive ContextStrategy = "adaptive"
+)
+
 // BaseOptions contains fields shared across all compose strategies.
 type BaseOptions struct {
 	// Reobserve ignores persisted observations and re-observes all conversations.
@@ -59,9 +71,8 @@ type BaseOptions struct {
 	Limit int
 	// Verbose enables per-item progress logging.
 	Verbose bool
-	// PreserveContext keeps more assistant context before owner corrections,
-	// so the observe prompt can see what the owner was reacting to.
-	PreserveContext bool
+	// Context controls the compression strategy for assistant text.
+	Context ContextStrategy
 }
 
 // Options configures a map-reduce compose run.
@@ -290,7 +301,7 @@ type turn struct {
 }
 
 func observeConversation(ctx context.Context, client inference.Client, conv *conversation.Conversation) (string, inference.Usage, error) {
-	refined, usage, err := observeAndRefine(ctx, client, conv, false, false)
+	refined, usage, err := observeAndRefine(ctx, client, conv, false, ContextDefault)
 	if err != nil {
 		return "", usage, err
 	}
@@ -425,4 +436,197 @@ func extractTurns(conv *conversation.Conversation) []turn {
 		}
 	}
 	return turns
+}
+
+// lowSignalPatterns matches owner messages that carry no distinctive reasoning:
+// confirmations, mechanical directives, and single-word responses.
+var lowSignalPatterns = []string{
+	"yes",
+	"yeah",
+	"yep",
+	"sure",
+	"ok",
+	"okay",
+	"do it",
+	"go ahead",
+	"looks good",
+	"lgtm",
+	"sounds good",
+	"thanks",
+	"thank you",
+	"no",
+	"nope",
+	"never mind",
+	"nevermind",
+}
+
+// mechanicalPrefixes matches owner messages that are agent directives without
+// reasoning: git operations, file management, and execution commands.
+var mechanicalPrefixes = []string{
+	"commit",
+	"push",
+	"squash",
+	"rebase",
+	"merge",
+	"deploy",
+	"run ",
+	"install",
+	"delete ",
+	"remove ",
+	"create ",
+}
+
+// filterLowSignalTurns removes turns where the owner's message is a
+// confirmation, mechanical directive, or otherwise carries no distinctive
+// reasoning. Keeps turns where the owner makes decisions, corrects something,
+// or explains why.
+func filterLowSignalTurns(turns []turn) []turn {
+	var kept []turn
+	for _, t := range turns {
+		if isLowSignal(t.humanContent) {
+			continue
+		}
+		kept = append(kept, t)
+	}
+	return kept
+}
+
+// minSignalWords is the minimum word count for a turn to be considered
+// potentially high-signal. Shorter messages are kept only if they contain
+// a question or quotation, which suggest reasoning or correction.
+const minSignalWords = 15
+
+func isLowSignal(content string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(content))
+	words := strings.Fields(normalized)
+
+	// Interrupted requests are always noise
+	if strings.Contains(normalized, "[request interrupted") {
+		return true
+	}
+
+	// Exact-match confirmations at any length
+	clean := strings.TrimRight(normalized, ".!?,")
+	for _, p := range lowSignalPatterns {
+		if clean == p {
+			return true
+		}
+	}
+
+	// Short messages that are mechanical directives
+	if len(words) <= 8 {
+		for _, prefix := range mechanicalPrefixes {
+			if strings.HasPrefix(normalized, prefix) {
+				return true
+			}
+		}
+	}
+
+	// Below the word threshold, keep only if the message asks a question
+	// or contains a quotation (both suggest reasoning or correction)
+	if len(words) < minSignalWords {
+		hasQuestion := strings.Contains(content, "?")
+		hasQuote := strings.Contains(content, "\"")
+		if !hasQuestion && !hasQuote {
+			return true
+		}
+	}
+
+	return false
+}
+
+// triageTurns uses a cheap LLM call to classify turns as reasoning vs
+// housekeeping. Returns only the turns classified as reasoning.
+func triageTurns(ctx context.Context, client inference.Client, turns []turn, source string, verbose bool) ([]turn, inference.Usage, error) {
+	// Build numbered turn text for the triage prompt
+	var b strings.Builder
+	ownerLabel := "[owner]"
+	peerLabel := "[assistant]"
+	if isHumanSource(source) {
+		peerLabel = "[peer]"
+	}
+	for i, t := range turns {
+		if t.assistantContent != "" {
+			// Compress assistant to minimal context for triage (cheap pass)
+			compressed := strings.TrimSpace(t.assistantContent)
+			if len(compressed) > 200 {
+				compressed = compressed[:200] + "..."
+			}
+			fmt.Fprintf(&b, "Turn %d:\n%s: %s\n%s: %s\n\n", i+1, peerLabel, compressed, ownerLabel, t.humanContent)
+		} else {
+			fmt.Fprintf(&b, "Turn %d:\n%s: %s\n\n", i+1, ownerLabel, t.humanContent)
+		}
+	}
+
+	triageInput := b.String()
+	if verbose {
+		fmt.Fprintf(os.Stderr, "    triage input (%d chars):\n", len(triageInput))
+		lines := strings.Split(triageInput, "\n")
+		for _, line := range lines {
+			if strings.HasPrefix(line, "Turn ") || strings.HasPrefix(line, "[owner]") {
+				if len(line) > 100 {
+					line = line[:100] + "..."
+				}
+				fmt.Fprintf(os.Stderr, "      %s\n", line)
+			}
+		}
+	}
+
+	start := time.Now()
+	resp, usage, err := inference.Converse(ctx, client, prompts.Triage, triageInput, inference.WithMaxTokens(1024))
+	if err != nil {
+		return nil, usage, err
+	}
+
+	// Parse the JSON array of turn numbers
+	indices := parseTriageResponse(resp, len(turns))
+
+	if verbose {
+		fmt.Fprintf(os.Stderr, "    triage %d → %d turns (%s, $%.4f) raw: %s\n",
+			len(turns), len(indices), time.Since(start).Round(time.Millisecond), usage.Cost(), strings.TrimSpace(resp))
+	}
+
+	var kept []turn
+	indexSet := make(map[int]bool)
+	for _, idx := range indices {
+		indexSet[idx] = true
+	}
+	for i, t := range turns {
+		if indexSet[i+1] { // turns are 1-indexed in the prompt
+			kept = append(kept, t)
+		}
+	}
+	return kept, usage, nil
+}
+
+// parseTriageResponse extracts turn numbers from the triage LLM response.
+// The response may contain multiple JSON arrays if the model self-corrects.
+// We take the last valid array, which is the model's final answer.
+func parseTriageResponse(resp string, maxTurns int) []int {
+	// Find all JSON arrays in the response, take the last one
+	var lastValid []int
+	for i := 0; i < len(resp); i++ {
+		if resp[i] != '[' {
+			continue
+		}
+		// Find matching ]
+		end := strings.Index(resp[i:], "]")
+		if end < 0 {
+			continue
+		}
+		candidate := resp[i : i+end+1]
+		var numbers []int
+		if err := json.Unmarshal([]byte(candidate), &numbers); err == nil {
+			lastValid = numbers
+		}
+		i = i + end
+	}
+
+	var valid []int
+	for _, n := range lastValid {
+		if n >= 1 && n <= maxTurns {
+			valid = append(valid, n)
+		}
+	}
+	return valid
 }

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -67,9 +67,13 @@ const (
 type ObserveMode string
 
 const (
-	// ObserveWindowed uses sliding-window observation (default).
-	ObserveWindowed ObserveMode = ""
-	// ObserveTriageOwnerOnly uses the triage + owner-only path.
+	// ObserveMultiZoom runs both windowed (local) and triage+owner-only (global)
+	// passes, merges the observations. Each zoom level catches signal the other
+	// misses. This is the default.
+	ObserveMultiZoom ObserveMode = ""
+	// ObserveWindowed uses sliding-window observation only.
+	ObserveWindowed ObserveMode = "windowed"
+	// ObserveTriageOwnerOnly uses the triage + owner-only path only.
 	ObserveTriageOwnerOnly ObserveMode = "triage-owner-only"
 	// ObserveFullConversation compresses the full conversation and observes
 	// in chunks. This is the original path that exhibits context rot on long
@@ -87,6 +91,8 @@ type BaseOptions struct {
 	Verbose bool
 	// Context controls the compression strategy for assistant text.
 	Context ContextStrategy
+	// Observe controls the observation strategy for large conversations.
+	Observe ObserveMode
 }
 
 // Options configures a map-reduce compose run.
@@ -184,7 +190,7 @@ func Run(ctx context.Context, store storage.Store, observeLLM, learnLLM inferenc
 					return
 				}
 				start := time.Now()
-				obs, usage, err := observeConversation(ctx, observeLLM, conv)
+				obs, usage, err := observeConversation(ctx, observeLLM, conv, opts.Observe)
 				n := completed.Add(1)
 				if err != nil {
 					mu.Lock()
@@ -314,8 +320,8 @@ type turn struct {
 	humanContent     string // human's message
 }
 
-func observeConversation(ctx context.Context, client inference.Client, conv *conversation.Conversation) (string, inference.Usage, error) {
-	refined, usage, err := observeAndRefine(ctx, client, conv, false, ContextDefault, ObserveWindowed)
+func observeConversation(ctx context.Context, client inference.Client, conv *conversation.Conversation, mode ObserveMode) (string, inference.Usage, error) {
+	refined, usage, err := observeAndRefine(ctx, client, conv, false, ContextDefault, mode)
 	if err != nil {
 		return "", usage, err
 	}

--- a/prompts/observe.md
+++ b/prompts/observe.md
@@ -1,6 +1,6 @@
 Extract observations about how this person thinks and what they're aware of from their conversation with an AI assistant. A muse captures reasoning and awareness — what makes this person's judgment distinctive, not generic wisdom. Voice is derived separately from human-to-human conversations.
 
-Most conversations are routine. The expected output is NONE.
+Some conversations are routine and produce no observations.
 
 Input: a compressed conversation transcript. [assistant] messages are mechanically compressed (code blocks stripped, tool calls collapsed, long messages truncated). [owner] messages are preserved in full. Focus on the owner's messages.
 
@@ -10,7 +10,9 @@ Reasoning — the owner originates an idea, corrects course, explains why, pushe
 
 Awareness — the owner models their own thinking, calibrates for an audience, or acknowledges limits. Self-awareness and audience-awareness are rare and high-value. Weak: "Is self-aware about their biases." Strong: "Recognizes they over-index on compression and actively checks whether terseness is hurting legibility."
 
-Every observation must describe the owner's own thinking or behavior, not the assistant's. When the owner discusses external content, the signal is their reaction — judgment, disagreement, how they apply it — not the content itself. Ignore routine interactions and tool outputs.
+Every observation must describe the owner's own thinking or behavior, not the assistant's. When the owner discusses external content, the signal is their reaction — judgment, disagreement, how they apply it — not the content itself.
+
+The owner often works through an agent: drafting documents, writing code, composing messages. This looks routine but carries signal when the owner corrects the agent's output, makes design decisions, or rewrites the agent's draft in their own voice. "This is too long" followed by a rewrite reveals editing judgment. "Say disruption cost, not baseline" reveals how the owner thinks about naming. Treat agent-directed work as a window into the owner's thinking, not as routine tool use.
 
 When the owner corrects the AI, distinguish genuine preferences from frustration with model defaults. "Wants less verbose output" might be a reaction to the model being wordy, not a real trait of the person. The observation should capture what the person actually values, traceable to their behavior independent of the model's failings.
 

--- a/prompts/prompts.go
+++ b/prompts/prompts.go
@@ -49,3 +49,6 @@ var GenerateEval string
 
 //go:embed thesis.md
 var Thesis string
+
+//go:embed triage.md
+var Triage string

--- a/prompts/triage.md
+++ b/prompts/triage.md
@@ -1,0 +1,9 @@
+Classify each numbered turn in this conversation as REASONING or SKIP. Evaluate every turn independently.
+
+REASONING: the owner makes a decision, corrects something, explains why, pushes back, reframes a problem, proposes a design, or reveals how they think. Editing the assistant's draft counts as reasoning. Choosing between alternatives counts as reasoning.
+
+SKIP: the owner confirms ("yes", "sure"), gives a mechanical directive ("commit and push", "squash these"), asks a status question ("how are we on the PR?"), or runs a command.
+
+You MUST return a JSON array of turn numbers classified as REASONING. Evaluate ALL turns, not just the last one. Return [] only if truly no turns contain reasoning.
+
+Example: [1, 3, 4, 7]


### PR DESCRIPTION
## Summary

Stacked on #155 (preserve-context). Merge #155 first.

Adds multi-zoom observation as the default pipeline for large conversations. Two findings motivated this:

**Context rot** (009): long conversations produce 0 observations because later mechanical turns wash out earlier reasoning signal. Windowed observation fixes this by observing in sliding windows of 8 turns.

**Attention allocation** (010): different zoom levels find different signal from the same material, even when context rot isn't the problem. Windowed catches craft-level specifics (editing passes, naming decisions). Triage catches strategic patterns (decision allocation, reusable primitives). Neither dominates.

Multi-zoom runs both passes on each large conversation and merges the observations:

| Strategy | Observations | Clusters | Total cost |
|---|---|---|---|
| Multi-zoom (default) | 658 | 25 | $18.25 |
| Windowed only | 462 | 22 | $13.46 |
| Triage only | 243 | 21 | $6.52 |
| Baseline | 151 | 19 | $6.40 |

Confirmed by Orwell experiment on controlled input (orwellian-observation.md).

### Implementation

- `ObserveMultiZoom` is the default mode (empty string)
- `observeMultiZoom` runs `observeWindowed` + `observeTriageOwnerOnly`, merges with `deduplicateObservations`
- Global pass failure is non-fatal (falls back to local only)
- `--observe-mode` flag selects strategy: `windowed`, `triage-owner-only`, `full-conversation`
- eval-context tests all four strategies
- Fingerprint includes mode for cache invalidation

### Design doc

010-observe-strategies.md separates context rot (catastrophic, 0 vs 7-9 obs) from attention allocation (quantitative, different zoom levels find different signal). Documents corpus and Orwell experiments.

## Test plan

- [ ] `go test ./...` passes
- [ ] `muse eval-context <snapshot>` shows multi-zoom producing observations from both passes
- [ ] `muse compose --reobserve` produces richer observation set than single strategy
- [ ] `muse compose --observe-mode=windowed` still works for cost-sensitive runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)