### PR TITLE
009: context rot findings and abandoned approaches

### DIFF
--- a/designs/009-observations.md
+++ b/designs/009-observations.md
@@ -38,13 +38,85 @@ When the owner says "on line 12, be more specific," compression preserves the di
 strips line 12. The observation captures a general preference instead of a specific
 transformation.
 
-The fix is to make compression context-aware. When the owner's next message is a short
-correction (under ~50 words), the preceding assistant content is likely what prompted it.
-Preserving more of that content (assistant text, code blocks, or tool results depending on
-where the context lives) gives the observe prompt what it needs to produce specific
-observations.
+### Approaches attempted and abandoned after experiments
 
-`--preserve-context` enables this. Default off to preserve current token costs.
+**A: Adaptive compression.** Scale the assistant text limit by owner message length
+(500-2000 chars). More context diluted signal in local experiments: 17k chars
+produced 0 observations while 13k produced 5. The extra context made the
+conversation look less interesting to muse.
+
+**B: Prompt-driven extraction.** Ask the observe prompt for transformations, not just
+principles. Made the LLM more cautious, producing fewer observations.
+
+**C: Context-aware prompting.** Ask the LLM to reason about what context each response
+requires. Same performance regression relative to mainline as B.
+
+**D: Word-count and pattern filters.** Remove confirmations and short directives before
+observe by matching known low-signal phrases and applying a minimum word count. Insufficient:
+many low-signal turns survive the patterns, and the turns that are removed aren't the ones
+causing observe to fail.
+
+**E: LLM triage + compressed conversation.** Cheap LLM call classifies turns as reasoning vs
+housekeeping, then pass triaged turns through the standard compression pipeline. Triage
+works as a classifier — it correctly identifies which turns contain reasoning. But observe
+still returns NONE on the compressed triaged conversation. The triaged output still includes
+compressed assistant text (~500 chars per turn), and that's enough to trigger the same
+failure. We don't have a proven mechanism for why assistant text in reasoning turns kills
+observe. Possible explanations: pure volume (11 triaged turns × 500 chars of assistant text),
+attention shifting to the assistant's framing instead of the owner's reasoning, or mixed-role
+presentation changing how the model processes the input. We tested the endpoint (owner-only
+works, mixed doesn't) but not the mechanism.
+
+### What we found: context rot
+
+Long conversations exhibit context rot. Early turns carry design decisions, corrections,
+and reasoning. Later turns accumulate mechanical work: git operations, CI checks,
+formatting fixes. The signal-to-noise ratio degrades as the conversation grows.
+
+The observe prompt reads through the compressed conversation sequentially. When reasoning
+turns from early in the conversation are followed by pages of mechanical turns, the LLM's
+attention drifts to the recent, mechanical content. Reasoning that is still in the context
+window gets washed out by surrounding noise. The result is NONE for the whole conversation.
+
+This is a local signal problem, not a global ratio problem. Turn 4 is a design decision
+regardless of what turns 15-27 contain. But observing the full conversation forces the
+LLM to evaluate turn 4 in the context of everything that came after it.
+
+The triage + owner-only approach works around this by stripping noise before observe sees
+it. A more fundamental fix would observe in local windows so that no turn is ever evaluated
+in the context of distant mechanical turns. See reboot.md for next steps.
+
+### Solution: triage + owner-only observe
+
+For conversations with more than 10 turns:
+
+1. **Mechanical filter.** Remove confirmations, mechanical directives, interrupted
+   requests. Pattern matching on known low-signal phrases.
+2. **LLM triage.** Cheap classification pass identifies which remaining turns contain
+   reasoning, decisions, corrections, or design thinking.
+3. **Owner-only observe.** Feed only the owner's messages from triaged turns to the
+   observe prompt. No assistant context, no compression, no refine step.
+
+For small conversations (10 turns or fewer), the original pipeline works: compress
+the full conversation and run observe + refine.
+
+Results on two test conversations:
+
+| Conversation | Turns | Old pipeline | New pipeline |
+|---|---|---|---|
+| RFC design session (104 msgs, 27 turns) | 27 → 15 → 11 | 0 observations | 7 observations |
+| Orwell pass editing (211 msgs, 26 turns) | 26 → 19 → 16 | 0 observations | 9 observations |
+
+The observations are specific: "Uses formal analysis to constrain the design space,
+then derives a natural set ({1, 2, 3}) rather than making it configurable beyond what
+the math supports." "Monitors the AI's vocabulary for jargon that doesn't match how
+they actually speak, and flags it directly."
+
+### Prompt update: agent-directed work
+
+The observe prompt now recognizes that agent-directed work carries signal. When the
+owner corrects the agent's draft, makes design decisions through the agent, or rewrites
+the agent's output in their own voice, the prompt treats it as reasoning, not routine.
 
 ## Fingerprinting
 


### PR DESCRIPTION
## Summary

Updates the compression section of 009-observations.md with experimental findings from the preserve-context branch.

- Documents five approaches that failed (adaptive compression, prompt changes, context-aware prompting, mechanical filtering, LLM triage + compressed conversation)
- Documents context rot as a local signal problem: early reasoning washed out by later mechanical turns
- Documents the fix: triage + owner-only observation (0 → 7-9 observations)
- Notes that the mechanism for why compressed assistant text in triaged turns still kills observe is unproven

Design doc only. Implementation is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)