### PR TITLE
Enable extended thinking for muse ask (16k budget)

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -42,11 +42,27 @@ to start a fresh session.`,
 			m := muse.New(llm, document, muse.WithSessionsDir(dir))
 
 			question := strings.Join(args, " ")
+			var inThinking bool
 			result, err := m.Ask(ctx, muse.AskInput{
 				Question: question,
 				New:      newSession,
 				StreamFunc: inference.StreamFunc(func(delta inference.StreamDelta) {
-					fmt.Fprint(os.Stdout, delta.Text)
+					if delta.Thinking && !verbose {
+						return
+					}
+					if delta.Thinking {
+						if !inThinking {
+							inThinking = true
+							fmt.Fprint(os.Stderr, "\033[2m") // dim
+						}
+						fmt.Fprint(os.Stderr, delta.Text)
+					} else {
+						if inThinking {
+							inThinking = false
+							fmt.Fprint(os.Stderr, "\033[0m\n") // reset + newline before response
+						}
+						fmt.Fprint(os.Stdout, delta.Text)
+					}
 				}),
 			})
 			if result != nil && result.Response != "" {

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -1717,8 +1717,8 @@ func runCompose(
 		}
 	}
 
-	stream := newStageStream(16000, 4096)
-	muse, usage, err := inference.ConverseStream(ctx, llm, prompts.ComposeClustered, input.String(), stream.callback(), inference.WithThinking(16000))
+	stream := newStageStream(inference.DefaultThinkingBudget, inference.DefaultMaxTokens)
+	muse, usage, err := inference.ConverseStream(ctx, llm, prompts.ComposeClustered, input.String(), stream.callback(), inference.WithThinking(inference.DefaultThinkingBudget))
 	stream.finish()
 	if err != nil {
 		return "", "", usage, err

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -318,7 +318,7 @@ func learn(ctx context.Context, client inference.Client, store storage.Store, ob
 		return "", "", inference.Usage{}, nil
 	}
 	input := strings.Join(observations, "\n\n---\n\n")
-	muse, usage, err := inference.Converse(ctx, client, prompts.Compose, input, inference.WithThinking(16000))
+	muse, usage, err := inference.Converse(ctx, client, prompts.Compose, input, inference.WithThinking(inference.DefaultThinkingBudget))
 	if err != nil {
 		return "", "", usage, err
 	}

--- a/internal/inference/usage.go
+++ b/internal/inference/usage.go
@@ -12,6 +12,11 @@ type ConverseOptions struct {
 // DefaultMaxTokens is the default output token limit when not overridden.
 const DefaultMaxTokens = 4096
 
+// DefaultThinkingBudget is the standard extended thinking budget used across
+// compose and ask. Providers map this to their native mechanism (Anthropic
+// extended thinking, Bedrock thinking config, OpenAI reasoning effort).
+const DefaultThinkingBudget = 16000
+
 // Apply returns the merged options.
 func Apply(opts []ConverseOption) ConverseOptions {
 	var o ConverseOptions

--- a/internal/muse/muse.go
+++ b/internal/muse/muse.go
@@ -120,9 +120,9 @@ func (m *Muse) Ask(ctx context.Context, input AskInput) (*AskResult, error) {
 	var result *inference.Response
 	var err error
 	if input.StreamFunc != nil {
-		result, err = m.llm.ConverseMessagesStream(ctx, session.System, session.Messages, input.StreamFunc)
+		result, err = m.llm.ConverseMessagesStream(ctx, session.System, session.Messages, input.StreamFunc, inference.WithThinking(inference.DefaultThinkingBudget))
 	} else {
-		result, err = m.llm.ConverseMessages(ctx, session.System, session.Messages)
+		result, err = m.llm.ConverseMessages(ctx, session.System, session.Messages, inference.WithThinking(inference.DefaultThinkingBudget))
 	}
 	if err != nil {
 		return nil, fmt.Errorf("converse failed: %w", err)

--- a/internal/muse/muse_test.go
+++ b/internal/muse/muse_test.go
@@ -1,0 +1,68 @@
+package muse
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ellistarn/muse/internal/inference"
+)
+
+// capturingClient records the ConverseOptions passed to each call so tests
+// can assert that callers (like Ask) set the right options.
+type capturingClient struct {
+	opts []inference.ConverseOptions // captured from the last call
+}
+
+func (c *capturingClient) ConverseMessages(_ context.Context, _ string, _ []inference.Message, opts ...inference.ConverseOption) (*inference.Response, error) {
+	c.opts = append(c.opts, inference.Apply(opts))
+	return &inference.Response{Text: "ok"}, nil
+}
+
+func (c *capturingClient) ConverseMessagesStream(_ context.Context, _ string, _ []inference.Message, fn inference.StreamFunc, opts ...inference.ConverseOption) (*inference.Response, error) {
+	c.opts = append(c.opts, inference.Apply(opts))
+	if fn != nil {
+		fn(inference.StreamDelta{Text: "ok"})
+	}
+	return &inference.Response{Text: "ok"}, nil
+}
+
+func (c *capturingClient) Model() string { return "test" }
+
+func TestAsk_EnablesThinking(t *testing.T) {
+	client := &capturingClient{}
+	m := New(client, "test document")
+
+	_, err := m.Ask(context.Background(), AskInput{
+		Question: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Ask failed: %v", err)
+	}
+
+	if len(client.opts) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(client.opts))
+	}
+	if client.opts[0].ThinkingBudget != inference.DefaultThinkingBudget {
+		t.Errorf("ThinkingBudget = %d, want %d", client.opts[0].ThinkingBudget, inference.DefaultThinkingBudget)
+	}
+}
+
+func TestAsk_EnablesThinkingWithStreaming(t *testing.T) {
+	client := &capturingClient{}
+	m := New(client, "test document")
+
+	_, err := m.Ask(context.Background(), AskInput{
+		Question:   "hello",
+		StreamFunc: func(delta inference.StreamDelta) {},
+	})
+	if err != nil {
+		t.Fatalf("Ask failed: %v", err)
+	}
+
+	if len(client.opts) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(client.opts))
+	}
+	if client.opts[0].ThinkingBudget != inference.DefaultThinkingBudget {
+		t.Errorf("ThinkingBudget = %d, want %d", client.opts[0].ThinkingBudget, inference.DefaultThinkingBudget)
+	}
+}


### PR DESCRIPTION
## Summary

- `muse ask` now passes `inference.WithThinking(16000)` to the LLM, giving the model a 16k token reasoning budget on top of the 4k output limit — matching what `muse compose` already uses.
- Thinking deltas are filtered out of the CLI stream so reasoning tokens don't dump to the terminal.
- Adds `internal/muse/muse_test.go` with tests verifying the thinking budget is forwarded for both streaming and non-streaming paths.