### PR TITLE
Stream thinking tokens through MCP to prevent client timeouts

### DIFF
--- a/e2e/mcp_test.go
+++ b/e2e/mcp_test.go
@@ -3,18 +3,18 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/ellistarn/muse/internal/bedrock"
+	"github.com/ellistarn/muse/internal/inference"
 	musemcp "github.com/ellistarn/muse/internal/mcp"
 	museinternal "github.com/ellistarn/muse/internal/muse"
 )
@@ -31,9 +31,16 @@ func newMCPClientWithOpts(t *testing.T, document string, opts []museinternal.Opt
 	runtime := &mockRuntime{responses: responses}
 	ctx := context.Background()
 	bedrockClient := bedrock.NewClientWithRuntime(ctx, runtime)
-	m := museinternal.New(bedrockClient, document, opts...)
+	return newMCPClientWithLLM(t, bedrockClient, document, opts...)
+}
+
+// newMCPClientWithLLM creates an in-process MCP client backed by an arbitrary inference.Client.
+func newMCPClientWithLLM(t *testing.T, llm inference.Client, document string, opts ...museinternal.Option) *client.Client {
+	t.Helper()
+	m := museinternal.New(llm, document, opts...)
 	srv := musemcp.NewServer(m)
 
+	ctx := context.Background()
 	c, err := client.NewInProcessClient(srv)
 	if err != nil {
 		t.Fatalf("failed to create in-process client: %v", err)
@@ -321,5 +328,68 @@ func TestMCP_DoesNotResumeAskSession(t *testing.T) {
 	}
 	if string(latestData) != "ask-session-id" {
 		t.Errorf("latest = %q, want %q; MCP session overwrote the CLI latest pointer", string(latestData), "ask-session-id")
+	}
+}
+
+// thinkingLLM is an inference.Client that emits thinking tokens before the response.
+type thinkingLLM struct {
+	thinking string
+	response string
+}
+
+func (t *thinkingLLM) Model() string { return "test-model" }
+
+func (t *thinkingLLM) ConverseMessages(_ context.Context, _ string, _ []inference.Message, _ ...inference.ConverseOption) (*inference.Response, error) {
+	return &inference.Response{Text: t.response}, nil
+}
+
+func (t *thinkingLLM) ConverseMessagesStream(_ context.Context, _ string, _ []inference.Message, fn inference.StreamFunc, _ ...inference.ConverseOption) (*inference.Response, error) {
+	if fn != nil {
+		fn(inference.StreamDelta{Text: t.thinking, Thinking: true})
+		fn(inference.StreamDelta{Text: t.response, Thinking: false})
+	}
+	return &inference.Response{Text: t.response}, nil
+}
+
+func TestMCP_ThinkingIncludedInResponse(t *testing.T) {
+	llm := &thinkingLLM{
+		thinking: "Let me consider how files should be named...",
+		response: "Use kebab-case.",
+	}
+	c := newMCPClientWithLLM(t, llm, "test document")
+
+	result := callAsk(t, c, "how should I name files?")
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "<thinking>") {
+		t.Error("response should contain <thinking> tag")
+	}
+	if !strings.Contains(text, "Let me consider how files should be named...") {
+		t.Error("response should contain thinking content")
+	}
+	if !strings.Contains(text, "Use kebab-case.") {
+		t.Error("response should contain the actual response")
+	}
+}
+
+func TestMCP_NoThinkingOmitsTag(t *testing.T) {
+	// When the model doesn't produce thinking tokens (e.g. non-streaming
+	// fallback), the response should not contain thinking tags.
+	c := newMCPClient(t, "test document",
+		textResponse("Plain answer."),
+	)
+
+	result := callAsk(t, c, "hello")
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if strings.Contains(text, "<thinking>") {
+		t.Error("response should not contain <thinking> tag when no thinking tokens were produced")
+	}
+	if text != "Plain answer." {
+		t.Errorf("response = %q, want %q", text, "Plain answer.")
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3,14 +3,21 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/ellistarn/muse/internal/inference"
 	"github.com/ellistarn/muse/internal/muse"
 	"github.com/ellistarn/muse/prompts"
 )
+
+// flushInterval controls how often thinking tokens are flushed as log
+// notifications to keep the MCP connection alive during long inference calls.
+const flushInterval = 3 * time.Second
 
 // NewServer creates an MCP server with an ask tool.
 // Each MCP client connection gets its own Bedrock session so concurrent
@@ -43,11 +50,51 @@ func NewServer(m *muse.Muse) *server.MCPServer {
 			museSessionID := museSessionByClient[clientID]
 			mu.Unlock()
 
+			// Stream thinking tokens as log notifications to keep the
+			// connection alive during long inference calls. The calling
+			// agent also benefits from seeing the muse's reasoning chain.
+			mcpServer := server.ServerFromContext(ctx)
+			var thinking strings.Builder
+			var notifyBuf strings.Builder
+			var lastFlush time.Time
+			notifyFailed := false
+
+			streamFunc := func(delta inference.StreamDelta) {
+				if !delta.Thinking {
+					return
+				}
+				thinking.WriteString(delta.Text)
+				notifyBuf.WriteString(delta.Text)
+
+				if notifyFailed || time.Since(lastFlush) < flushInterval {
+					return
+				}
+				lastFlush = time.Now()
+				if err := mcpServer.SendNotificationToClient(ctx, "notifications/message", map[string]any{
+					"level":  "info",
+					"logger": "muse",
+					"data":   notifyBuf.String(),
+				}); err != nil {
+					notifyFailed = true // stop sending; don't abort inference
+				}
+				notifyBuf.Reset()
+			}
+
 			result, err := m.Ask(ctx, muse.AskInput{
-				Question:  question,
-				SessionID: museSessionID,
-				New:       museSessionID == "", // First call for this client; don't resume latest from "muse ask".
+				Question:   question,
+				SessionID:  museSessionID,
+				New:        museSessionID == "", // First call for this client; don't resume latest from "muse ask".
+				StreamFunc: streamFunc,
 			})
+			// Flush any remaining thinking tokens that didn't hit the
+			// time threshold.
+			if !notifyFailed && notifyBuf.Len() > 0 {
+				_ = mcpServer.SendNotificationToClient(ctx, "notifications/message", map[string]any{
+					"level":  "info",
+					"logger": "muse",
+					"data":   notifyBuf.String(),
+				})
+			}
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("failed to ask: %v", err)), nil
 			}
@@ -56,7 +103,13 @@ func NewServer(m *muse.Muse) *server.MCPServer {
 			museSessionByClient[clientID] = result.SessionID
 			mu.Unlock()
 
-			return mcp.NewToolResultText(result.Response), nil
+			// Include the muse's reasoning chain when available so the
+			// calling agent can calibrate its use of the response.
+			response := result.Response
+			if thinking.Len() > 0 {
+				response = fmt.Sprintf("<thinking>\n%s\n</thinking>\n\n%s", thinking.String(), response)
+			}
+			return mcp.NewToolResultText(response), nil
 		},
 	)
 	return srv


### PR DESCRIPTION
## Summary

- Wire `ConverseMessagesStream` into the MCP `ask` handler and send thinking tokens as `notifications/message` (log notifications) every 3 seconds to keep the connection alive during long Opus inference calls
- Include the full thinking chain in the tool result wrapped in `<thinking>` tags so calling agents can calibrate their use of the muse's response
- Flush any remaining thinking tokens after the stream completes to ensure the notification log is complete

## Problem

The MCP `ask` handler was making a synchronous blocking `m.Ask()` call with no `StreamFunc` and no intermediate output. With extended thinking (16K token budget), Opus calls can take 30-60+ seconds. MCP clients with inactivity timeouts would time out waiting for the response since zero bytes flowed over the transport during that window.

## Approach

The thinking tokens naturally flow during inference and serve as the keepalive — no synthetic heartbeat needed. `notifications/message` is the right primitive: no progress token required from the client, semantically correct for diagnostic content, and writes bytes to the transport regardless of client capability negotiation.

Error handling: notification failures are swallowed (`notifyFailed` flag) and never abort inference. If `SendNotificationToClient` fails once (e.g., no session registered), we stop trying.

## Tests

- `TestMCP_ThinkingIncludedInResponse` — verifies thinking tags + content appear in tool result when the model produces thinking tokens
- `TestMCP_NoThinkingOmitsTag` — verifies clean response with no thinking tags when no thinking tokens are produced (backward compat, e.g. non-streaming fallback)
- All 7 existing MCP tests pass unchanged
- Note: notification delivery cannot be tested with the in-process MCP transport (it doesn't support server→client notifications); the keepalive mechanism relies on `mcp-go`'s `SendNotificationToClient` which is tested in their own suite