### PR TITLE
feat: support version cmd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,6 +63,7 @@ Run "muse listen --help" for MCP server configuration.`,
 	cmd.AddCommand(newAddCmd())
 	cmd.AddCommand(newRemoveCmd())
 	cmd.AddCommand(newImportCmd())
+	cmd.AddCommand(newVersionCmd())
 	return cmd
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the build version (git commit)",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version())
+		},
+	}
+}
+
+// version returns the VCS revision from Go's embedded build info,
+// falling back to "dev" when build info is unavailable (e.g. go run).
+func version() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "dev"
+	}
+	var revision string
+	var dirty string
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			if s.Value == "true" {
+				dirty = "-dirty"
+			}
+		}
+	}
+	if revision == "" {
+		return "dev"
+	}
+	if len(revision) > 12 {
+		revision = revision[:12]
+	}
+	return revision + dirty
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,10 @@
+package cmd
+
+import "testing"
+
+func TestVersion_ReturnsNonEmpty(t *testing.T) {
+	v := version()
+	if v == "" {
+		t.Fatal("version() returned empty string")
+	}
+}


### PR DESCRIPTION
Wanted to be able to verify which build I'm currently on

Output when working with in progress change
```
muse version
ee6651346a05-dirty
```
Output when working with committed changes
```
./muse version
925ae74c3c99
```