### PR TITLE
Switch Bedrock thinking from enabled to adaptive for Opus 4.7 compatibility

### DIFF
--- a/internal/bedrock/client.go
+++ b/internal/bedrock/client.go
@@ -54,6 +54,19 @@ func lookupPricing(model string) modelPricing {
 	return bestPricing
 }
 
+// effortForBudget maps a thinking token budget to an Anthropic effort level.
+// This parallels the OpenAI provider's reasoningEffortForBudget mapping.
+func effortForBudget(budget int32) string {
+	switch {
+	case budget >= 12000:
+		return "high"
+	case budget >= 4000:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
 // Runtime is the subset of the Bedrock SDK used by Client.
 // This is the mock boundary for tests.
 type Runtime interface {
@@ -188,8 +201,10 @@ func (c *Client) ConverseMessagesStream(ctx context.Context, system string, mess
 	if o.ThinkingBudget > 0 {
 		input.AdditionalModelRequestFields = document.NewLazyDocument(map[string]any{
 			"thinking": map[string]any{
-				"type":          "enabled",
-				"budget_tokens": o.ThinkingBudget,
+				"type": "adaptive",
+			},
+			"output_config": map[string]any{
+				"effort": effortForBudget(o.ThinkingBudget),
 			},
 		})
 	}
@@ -256,8 +271,10 @@ func (c *Client) converseRawOnce(ctx context.Context, system string, messages []
 	if opts.ThinkingBudget > 0 {
 		input.AdditionalModelRequestFields = document.NewLazyDocument(map[string]any{
 			"thinking": map[string]any{
-				"type":          "enabled",
-				"budget_tokens": opts.ThinkingBudget,
+				"type": "adaptive",
+			},
+			"output_config": map[string]any{
+				"effort": effortForBudget(opts.ThinkingBudget),
 			},
 		})
 	}

--- a/internal/bedrock/client_test.go
+++ b/internal/bedrock/client_test.go
@@ -66,6 +66,25 @@ func TestConverseMessagesPreservesPartialResponseOnTruncation(t *testing.T) {
 	}
 }
 
+func TestEffortForBudget(t *testing.T) {
+	tests := []struct {
+		budget int32
+		want   string
+	}{
+		{16000, "high"},
+		{12000, "high"},
+		{8000, "medium"},
+		{4000, "medium"},
+		{2000, "low"},
+		{0, "low"},
+	}
+	for _, tt := range tests {
+		if got := effortForBudget(tt.budget); got != tt.want {
+			t.Errorf("effortForBudget(%d) = %q, want %q", tt.budget, got, tt.want)
+		}
+	}
+}
+
 func TestIsThrottling(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

- `resolveModel` auto-discovers the latest inference profile, so when Opus 4.7
  became available it was selected automatically. Opus 4.7 rejects
  `thinking.type=enabled` and requires `thinking.type=adaptive` with
  `output_config.effort`.
- Replace `{type: enabled, budget_tokens: N}` with `{type: adaptive}` +
  `{output_config: {effort: high|medium|low}}` in both Converse paths.
- Add `effortForBudget()` mapping `ThinkingBudget` to effort levels,
  matching the OpenAI provider's `reasoningEffortForBudget` pattern.
- Add `TestEffortForBudget` covering boundary values.