### PR TITLE
Long-conversation pipeline: windowed observation + composition fixes (013, 014)

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -101,7 +101,7 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 	cmd.Flags().BoolVar(&learn, "learn", false, "skip observe, recompose muse from existing observations (map-reduce only)")
 	cmd.Flags().IntVar(&limit, "limit", 0, "max conversations to observe per run (0 = no limit)")
 	cmd.Flags().StringVar(&method, "method", "clustering", "composition method: clustering or map-reduce")
-	cmd.Flags().StringVar(&observeMode, "observe-mode", "", "observation strategy: '' (default) or 'woo' (windowed owner-only)")
+	cmd.Flags().StringVar(&observeMode, "observe-mode", "", "observation strategy: '' (default), 'woo' (windowed owner-only), 'adaptive' (picks per window)")
 	return cmd
 }
 

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -26,6 +26,7 @@ func newComposeCmd() *cobra.Command {
 	var limit int
 	var method string
 	var observeMode string
+	var skipObserve bool
 	cmd := &cobra.Command{
 		Use:   "compose",
 		Short: "Compose a muse from conversations",
@@ -88,7 +89,7 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 
 			switch method {
 			case "clustering":
-				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, compose.ObserveMode(observeMode), limit, uploaded, uploadBytes)
+				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, compose.ObserveMode(observeMode), skipObserve, limit, uploaded, uploadBytes)
 			case "map-reduce":
 				return runMapReduceCompose(ctx, cmd.OutOrStdout(), store, reobserve, learn, limit)
 			default:
@@ -102,10 +103,11 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 	cmd.Flags().IntVar(&limit, "limit", 0, "max conversations to observe per run (0 = no limit)")
 	cmd.Flags().StringVar(&method, "method", "clustering", "composition method: clustering or map-reduce")
 	cmd.Flags().StringVar(&observeMode, "observe-mode", "", "observation strategy: '' (default), 'woo' (windowed owner-only), 'adaptive' (picks per window)")
+	cmd.Flags().BoolVar(&skipObserve, "skip-observe", false, "skip observe, compose from pre-existing observations (for filtered/derived sets)")
 	return cmd
 }
 
-func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel bool, mode compose.ObserveMode, limit, uploaded, uploadBytes int) error {
+func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel bool, mode compose.ObserveMode, skipObserve bool, limit, uploaded, uploadBytes int) error {
 	observeLLM, err := newLLMClient(ctx, TierFast)
 	if err != nil {
 		return err
@@ -122,10 +124,11 @@ func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.St
 		composeLLM, // compose
 		compose.ClusteredOptions{
 			BaseOptions: compose.BaseOptions{
-				Reobserve: reobserve,
-				Limit:     limit,
-				Verbose:   verbose,
-				Observe:   mode,
+				Reobserve:   reobserve,
+				Limit:       limit,
+				Verbose:     verbose,
+				Observe:     mode,
+				SkipObserve: skipObserve,
 			},
 			Relabel:     relabel,
 			Uploaded:    uploaded,

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -25,6 +25,7 @@ func newComposeCmd() *cobra.Command {
 	var learn bool
 	var limit int
 	var method string
+	var observeMode string
 	cmd := &cobra.Command{
 		Use:   "compose",
 		Short: "Compose a muse from conversations",
@@ -87,7 +88,7 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 
 			switch method {
 			case "clustering":
-				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, limit, uploaded, uploadBytes)
+				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, compose.ObserveMode(observeMode), limit, uploaded, uploadBytes)
 			case "map-reduce":
 				return runMapReduceCompose(ctx, cmd.OutOrStdout(), store, reobserve, learn, limit)
 			default:
@@ -100,10 +101,11 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 	cmd.Flags().BoolVar(&learn, "learn", false, "skip observe, recompose muse from existing observations (map-reduce only)")
 	cmd.Flags().IntVar(&limit, "limit", 0, "max conversations to observe per run (0 = no limit)")
 	cmd.Flags().StringVar(&method, "method", "clustering", "composition method: clustering or map-reduce")
+	cmd.Flags().StringVar(&observeMode, "observe-mode", "", "observation strategy: '' (default) or 'woo' (windowed owner-only)")
 	return cmd
 }
 
-func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel bool, limit, uploaded, uploadBytes int) error {
+func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel bool, mode compose.ObserveMode, limit, uploaded, uploadBytes int) error {
 	observeLLM, err := newLLMClient(ctx, TierFast)
 	if err != nil {
 		return err
@@ -123,6 +125,7 @@ func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.St
 				Reobserve: reobserve,
 				Limit:     limit,
 				Verbose:   verbose,
+				Observe:   mode,
 			},
 			Relabel:     relabel,
 			Uploaded:    uploaded,

--- a/cmd/featurize.go
+++ b/cmd/featurize.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/ellistarn/muse/internal/compose"
+	"github.com/ellistarn/muse/internal/storage"
+	"github.com/spf13/cobra"
+)
+
+func newFeaturizeCmd() *cobra.Command {
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "featurize",
+		Short: "Build a feature dataset from observation strategies",
+		Long: `Runs both default (windowed-with-assistant) and woo (windowed-owner-only)
+observation on each window of each conversation. Writes a JSON array of
+per-window records with input features and observation counts from each
+strategy. Use the output to find the threshold for when to use which method.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFeaturize(cmd.Context(), limit)
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 0, "max conversations to process (0 = no limit)")
+	return cmd
+}
+
+func runFeaturize(ctx context.Context, limit int) error {
+	store, err := newStore(ctx)
+	if err != nil {
+		return err
+	}
+
+	entries, err := store.ListConversations(ctx)
+	if err != nil {
+		return fmt.Errorf("list conversations: %w", err)
+	}
+
+	// Sort largest first
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].SizeBytes > entries[j].SizeBytes
+	})
+	if limit > 0 && len(entries) > limit {
+		entries = entries[:limit]
+	}
+
+	llm, err := newLLMClient(ctx, TierFast)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "featurize: %d conversations\n", len(entries))
+
+	var mu sync.Mutex
+	var allFeatures []compose.WindowFeatures
+	var counter atomic.Int32
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(10) // lower concurrency — 2 LLM calls per window
+
+	for _, entry := range entries {
+		g.Go(func() error {
+			conv, err := store.GetConversation(ctx, entry.Source, entry.ConversationID)
+			if err != nil {
+				counter.Add(1)
+				return fmt.Errorf("load %s: %w", entry.Key, err)
+			}
+
+			features, _, err := compose.FeaturizeConversation(ctx, llm, conv, verbose)
+			n := counter.Add(1)
+			if err != nil {
+				return fmt.Errorf("featurize %s: %w", entry.Key, err)
+			}
+
+			mu.Lock()
+			allFeatures = append(allFeatures, features...)
+			mu.Unlock()
+
+			windows := len(features)
+			var defTotal, wooTotal int
+			for _, f := range features {
+				defTotal += f.DefaultObs
+				wooTotal += f.WooObs
+			}
+			fmt.Fprintf(os.Stderr, "  [%d/%d] %s: %d windows, default:%d woo:%d\n",
+				n, len(entries), entry.Key, windows, defTotal, wooTotal)
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// Write JSON to stdout
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(allFeatures)
+}
+
+func registerFeaturize(entries []storage.ConversationEntry) {
+	_ = entries // satisfy linter if needed
+}

--- a/cmd/judge.go
+++ b/cmd/judge.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/ellistarn/muse/internal/compose"
+	"github.com/ellistarn/muse/internal/inference"
+	"github.com/spf13/cobra"
+)
+
+const judgePrompt = `You are evaluating observations extracted from a conversation. For each observation, rate it against the source conversation:
+
+GROUNDED — The observation is well-supported by the conversation. It captures something distinctive about how the person thinks, not just what they said.
+
+GENERIC — The observation is true but not distinctive. Any thoughtful person might think this way. It carries no information about this specific person.
+
+MISLEADING — The observation overstates, mischaracterizes, or fabricates. The conversation doesn't support the claim being made.
+
+For each numbered observation, respond with just the number and the rating. Example:
+1. GROUNDED
+2. GENERIC
+3. MISLEADING`
+
+func newJudgeCmd() *cobra.Command {
+	var mode string
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "judge",
+		Short: "Rate observation quality against source conversations",
+		Long: `Runs an LLM-as-judge on observations from a given observe mode,
+rating each as GROUNDED, GENERIC, or MISLEADING against the source
+conversation. Outputs a JSON summary.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runJudge(cmd.Context(), compose.ObserveMode(mode), limit)
+		},
+	}
+	cmd.Flags().StringVar(&mode, "observe-mode", "woo", "which observation set to judge")
+	cmd.Flags().IntVar(&limit, "limit", 0, "max conversations to judge (0 = all)")
+	return cmd
+}
+
+type judgeResult struct {
+	Source         string `json:"source"`
+	ConversationID string `json:"conversation_id"`
+	Method         string `json:"method"`
+	Total          int    `json:"total"`
+	Grounded       int    `json:"grounded"`
+	Generic        int    `json:"generic"`
+	Misleading     int    `json:"misleading"`
+	Unparsed       int    `json:"unparsed"`
+}
+
+func runJudge(ctx context.Context, mode compose.ObserveMode, limit int) error {
+	store, err := newStore(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Use Opus for judging
+	judge, err := newLLMClient(ctx, TierStrong)
+	if err != nil {
+		return err
+	}
+
+	entries, err := compose.ListObservations(ctx, store, mode)
+	if err != nil {
+		return err
+	}
+	if limit > 0 && len(entries) > limit {
+		entries = entries[:limit]
+	}
+
+	fmt.Fprintf(os.Stderr, "judge: %d conversations, mode=%s\n", len(entries), string(mode))
+
+	var mu sync.Mutex
+	var results []judgeResult
+	var counter atomic.Int32
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(5) // Opus is expensive, keep concurrency low
+
+	for _, entry := range entries {
+		g.Go(func() error {
+			obs, err := compose.GetObservations(ctx, store, entry.Source, entry.ConversationID, mode)
+			if err != nil || len(obs.Items) == 0 {
+				counter.Add(1)
+				return nil
+			}
+
+			// Load the source conversation
+			conv, err := store.GetConversation(ctx, entry.Source, entry.ConversationID)
+			if err != nil {
+				counter.Add(1)
+				return nil // skip conversations we can't load
+			}
+
+			// Build conversation text (compressed)
+			var convText strings.Builder
+			for _, msg := range conv.Messages {
+				if msg.Content == "" {
+					continue
+				}
+				role := msg.Role
+				text := msg.Content
+				if len(text) > 500 {
+					text = text[:500] + "..."
+				}
+				fmt.Fprintf(&convText, "[%s]: %s\n\n", role, text)
+			}
+
+			// Build observation list
+			var obsList strings.Builder
+			for i, item := range obs.Items {
+				text := item.Text
+				fmt.Fprintf(&obsList, "%d. %s\n", i+1, text)
+			}
+
+			input := fmt.Sprintf("## Source conversation\n\n%s\n\n## Observations to evaluate\n\n%s",
+				convText.String(), obsList.String())
+
+			resp, _, err := inference.Converse(ctx, judge, judgePrompt, input, inference.WithMaxTokens(4096))
+			n := counter.Add(1)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "  [%d/%d] %s/%s: judge error: %v\n", n, len(entries), entry.Source, entry.ConversationID, err)
+				return nil
+			}
+
+			// Parse ratings
+			r := judgeResult{
+				Source:         entry.Source,
+				ConversationID: entry.ConversationID,
+				Method:         string(mode),
+				Total:          len(obs.Items),
+			}
+			for _, line := range strings.Split(resp, "\n") {
+				line = strings.TrimSpace(line)
+				upper := strings.ToUpper(line)
+				if strings.Contains(upper, "GROUNDED") {
+					r.Grounded++
+				} else if strings.Contains(upper, "GENERIC") {
+					r.Generic++
+				} else if strings.Contains(upper, "MISLEADING") {
+					r.Misleading++
+				}
+			}
+			r.Unparsed = r.Total - r.Grounded - r.Generic - r.Misleading
+
+			fmt.Fprintf(os.Stderr, "  [%d/%d] %s/%s: %d grounded, %d generic, %d misleading\n",
+				n, len(entries), entry.Source, entry.ConversationID, r.Grounded, r.Generic, r.Misleading)
+
+			mu.Lock()
+			results = append(results, r)
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// Print summary
+	var totalObs, totalGrounded, totalGeneric, totalMisleading int
+	for _, r := range results {
+		totalObs += r.Total
+		totalGrounded += r.Grounded
+		totalGeneric += r.Generic
+		totalMisleading += r.Misleading
+	}
+	fmt.Fprintf(os.Stderr, "\n%s: %d observations, %d grounded (%.0f%%), %d generic (%.0f%%), %d misleading (%.0f%%)\n",
+		string(mode), totalObs,
+		totalGrounded, pct(totalGrounded, totalObs),
+		totalGeneric, pct(totalGeneric, totalObs),
+		totalMisleading, pct(totalMisleading, totalObs))
+
+	// Write JSON to stdout
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(results)
+}
+
+func pct(n, total int) float64 {
+	if total == 0 {
+		return 0
+	}
+	return float64(n) / float64(total) * 100
+}

--- a/cmd/judge.go
+++ b/cmd/judge.go
@@ -32,18 +32,23 @@ For each numbered observation, respond with just the number and the rating. Exam
 func newJudgeCmd() *cobra.Command {
 	var mode string
 	var limit int
+	var filter bool
 	cmd := &cobra.Command{
 		Use:   "judge",
 		Short: "Rate observation quality against source conversations",
 		Long: `Runs an LLM-as-judge on observations from a given observe mode,
 rating each as GROUNDED, GENERIC, or MISLEADING against the source
-conversation. Outputs a JSON summary.`,
+conversation. Outputs a JSON summary.
+
+With --filter, writes grounded-only observations to a new mode called
+"{mode}-filtered" so compose can use them.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runJudge(cmd.Context(), compose.ObserveMode(mode), limit)
+			return runJudge(cmd.Context(), compose.ObserveMode(mode), limit, filter)
 		},
 	}
 	cmd.Flags().StringVar(&mode, "observe-mode", "woo", "which observation set to judge")
 	cmd.Flags().IntVar(&limit, "limit", 0, "max conversations to judge (0 = all)")
+	cmd.Flags().BoolVar(&filter, "filter", false, "write grounded-only observations to {mode}-filtered")
 	return cmd
 }
 
@@ -58,7 +63,7 @@ type judgeResult struct {
 	Unparsed       int    `json:"unparsed"`
 }
 
-func runJudge(ctx context.Context, mode compose.ObserveMode, limit int) error {
+func runJudge(ctx context.Context, mode compose.ObserveMode, limit int, filter bool) error {
 	store, err := newStore(ctx)
 	if err != nil {
 		return err
@@ -133,25 +138,52 @@ func runJudge(ctx context.Context, mode compose.ObserveMode, limit int) error {
 				return nil
 			}
 
-			// Parse ratings
+			// Parse per-observation ratings
 			r := judgeResult{
 				Source:         entry.Source,
 				ConversationID: entry.ConversationID,
 				Method:         string(mode),
 				Total:          len(obs.Items),
 			}
+			ratings := make([]string, len(obs.Items))
 			for _, line := range strings.Split(resp, "\n") {
 				line = strings.TrimSpace(line)
 				upper := strings.ToUpper(line)
-				if strings.Contains(upper, "GROUNDED") {
-					r.Grounded++
-				} else if strings.Contains(upper, "GENERIC") {
-					r.Generic++
-				} else if strings.Contains(upper, "MISLEADING") {
-					r.Misleading++
+				// Parse "N. RATING" format
+				var idx int
+				if n, _ := fmt.Sscanf(line, "%d.", &idx); n == 1 && idx >= 1 && idx <= len(obs.Items) {
+					if strings.Contains(upper, "GROUNDED") {
+						ratings[idx-1] = "GROUNDED"
+						r.Grounded++
+					} else if strings.Contains(upper, "GENERIC") {
+						ratings[idx-1] = "GENERIC"
+						r.Generic++
+					} else if strings.Contains(upper, "MISLEADING") {
+						ratings[idx-1] = "MISLEADING"
+						r.Misleading++
+					}
 				}
 			}
 			r.Unparsed = r.Total - r.Grounded - r.Generic - r.Misleading
+
+			// Optionally write grounded-only observations to filtered mode
+			if filter {
+				filteredMode := compose.ObserveMode(string(mode) + "-filtered")
+				var filtered []compose.Observation
+				for i, item := range obs.Items {
+					if ratings[i] == "GROUNDED" {
+						filtered = append(filtered, item)
+					}
+				}
+				if len(filtered) > 0 {
+					filteredObs := &compose.Observations{
+						Fingerprint: obs.Fingerprint,
+						Date:        obs.Date,
+						Items:       filtered,
+					}
+					compose.PutObservations(ctx, store, entry.Source, entry.ConversationID, filteredObs, filteredMode)
+				}
+			}
 
 			fmt.Fprintf(os.Stderr, "  [%d/%d] %s/%s: %d grounded, %d generic, %d misleading\n",
 				n, len(entries), entry.Source, entry.ConversationID, r.Grounded, r.Generic, r.Misleading)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,6 +64,7 @@ Run "muse listen --help" for MCP server configuration.`,
 	cmd.AddCommand(newRemoveCmd())
 	cmd.AddCommand(newImportCmd())
 	cmd.AddCommand(newVersionCmd())
+	cmd.AddCommand(newFeaturizeCmd())
 	return cmd
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,7 @@ Run "muse listen --help" for MCP server configuration.`,
 	cmd.AddCommand(newImportCmd())
 	cmd.AddCommand(newVersionCmd())
 	cmd.AddCommand(newFeaturizeCmd())
+	cmd.AddCommand(newJudgeCmd())
 	return cmd
 }
 

--- a/designs/013-observation-strategies.md
+++ b/designs/013-observation-strategies.md
@@ -82,6 +82,41 @@ for that mode without affecting others.
 - `"woo"`: windowed owner-only
 - `"adaptive"`: woo-first with default fallback
 
+## Concurrency
+
+Observation has two phases with different parallelism characteristics:
+
+1. **Window observation** — independent API calls. Each window produces raw text; no
+   dependencies between windows, even within the same conversation.
+2. **Dedup + refine** — per-conversation. Needs all window results for that conversation
+   before it can run. One API call per conversation.
+
+The implementation flattens phase 1 into a shared work queue. On entry to `runObserve`:
+
+1. Load all pending conversations and build their window lists (cheap, no API calls).
+2. Emit one work unit per window: `(conversationID, windowIndex, input, method)`.
+   For adaptive mode, each window emits up to two units (woo attempt, then default
+   fallback if woo returns NONE). The fallback is conditional — it becomes a work unit
+   only after the woo attempt completes empty.
+3. Process the queue through an errgroup capped at the rate limiter's max concurrency.
+   The AIMD token bucket already gates actual Bedrock calls; the errgroup cap prevents
+   unbounded goroutine accumulation.
+4. When all windows for a conversation complete, fire the dedup + refine step for that
+   conversation. These are also independent across conversations and enter the same queue.
+
+This eliminates head-of-line blocking: a 30-window conversation no longer serializes 30
+API calls behind one goroutine slot while short conversations finish and free theirs.
+
+Sort order for the queue: largest conversations first (most windows), so their windows
+begin processing immediately rather than arriving as a long tail.
+
+## Edge cases
+
+**Zero clusters.** When all observations land as outliers (0 clusters, 0 summaries), the
+thesis step has no input. The pipeline returns early with an error: "no clusters formed —
+need more observations to compose a muse." This happens with very small `--limit` values
+where the observation count is below the clustering threshold.
+
 ## Deferred
 
 **Window size.** The 8-turn window with stride 4 is untested against alternatives. Larger

--- a/designs/013-observation-strategies.md
+++ b/designs/013-observation-strategies.md
@@ -38,14 +38,25 @@ Adaptive finds more grounded observations than woo alone because some windows co
 owner messages that only make sense with assistant context. The fallback catches those. Exact
 counts vary across runs as the conversation corpus grows; representative numbers are in [1].
 
-## Per-window truncation
+## Per-window failures
 
-Per-window observe calls use a token budget of 4096. Thinking models can spend
-the whole budget reasoning before emitting content; the call returns truncated.
-Aborting the whole conversation in that case is too aggressive. observeWindow
-retries once at 16384 tokens. Windows that truncate again are skipped. Adjacent
-overlapping windows usually cover the same material, so the skip rarely costs
-information.
+Two failure modes are handled per-window rather than aborting the whole
+conversation. Adjacent overlapping windows usually cover the same material, so
+skipping one rarely costs information.
+
+**Output truncation.** Per-window observe calls use a token budget of 4096.
+Thinking models can spend the whole budget reasoning before emitting content;
+the call returns truncated. observeWindow retries once at 16384 tokens.
+Windows that truncate again are skipped.
+
+**Input exceeds context size.** Owner messages occasionally contain large
+pastes (logs, diffs, code dumps) that push a single window past the model's
+context window. observeWindow does not retry (a higher output budget doesn't
+help when the input itself doesn't fit). The window is skipped on the first
+attempt. The openai client classifies these errors via a string-match against
+known patterns (llama.cpp's `exceed_context_size_error`, OpenAI's
+`context_length_exceeded`, "maximum context length") and emits a typed
+`inference.ContextSizeError` so callers can distinguish from other failures.
 
 ## Per-mode observation storage
 

--- a/designs/013-observation-strategies.md
+++ b/designs/013-observation-strategies.md
@@ -1,0 +1,76 @@
+# Observation Strategies
+
+## Problem
+
+The default observation pipeline feeds the full compressed conversation to the observe prompt
+in one pass. On long conversations (27+ turns), it returns zero observations. The owner's
+reasoning from early turns gets washed out by later mechanical turns (git operations, CI,
+formatting). Research on this problem [1] found that the observe prompt loses early signal
+under later noise, and that the failure is catastrophic: conversations that should produce
+7-9 observations produce 0.
+
+## Windowed owner-only observation (woo)
+
+Woo slides an 8-turn window across the conversation with a stride of 4 turns, strips
+assistant text from each window, and observes each window independently. Empty windows
+(mechanical content) return NONE at negligible cost. Reasoning windows produce observations.
+
+Stripping assistant text helps because the assistant's output competes for the observe
+prompt's attention without contributing to the owner's reasoning signal. At matched context
+sizes, assistant text increases the misleading observation rate from 7% to 16% [1].
+
+Observations from overlapping windows are deduplicated by text containment, then refined.
+
+### Evidence
+
+On four conversations of 115-183 turns, the default pipeline produced 0, 1, 4, and 11
+observations. Woo produced 76, 62, 44, and 26. An LLM-as-judge found woo captured 64 of 75
+distinct insights on one conversation; the default captured 15. At corpus scale (453
+conversations), woo produces observations at 91% grounding rate, where grounded means
+well-supported by the source conversation as rated by an Opus quality judge [1].
+
+## Adaptive observation
+
+Adaptive tries woo first on each window. If woo returns NONE, it tries the default method
+(with assistant text) on the same window. At most two calls per window.
+
+Adaptive finds more grounded observations than woo alone because some windows contain terse
+owner messages that only make sense with assistant context. The fallback catches those. Exact
+counts vary across runs as the conversation corpus grows; representative numbers are in [1].
+
+## Per-mode observation storage
+
+Each observation strategy stores results in a separate directory so switching strategies does
+not invalidate cached observations from other strategies.
+
+```
+observations/{source}/{id}.json              (default mode)
+observations/{mode}/{source}/{id}.json       (named modes: woo, adaptive, etc.)
+```
+
+Source is the conversation provider (e.g., `claude-code`, `github`, `kiro-cli`). ID is the
+conversation identifier.
+
+The observation fingerprint includes the mode, so changing strategies forces re-observation
+for that mode without affecting others.
+
+## Interface
+
+`--observe-mode` on `muse compose` selects the strategy:
+
+- `""` (default): full compressed conversation
+- `"woo"`: windowed owner-only
+- `"adaptive"`: woo-first with default fallback
+
+## Deferred
+
+**Window size.** The 8-turn window with stride 4 is untested against alternatives. Larger
+windows risk reintroducing the same problem. Smaller windows may fragment multi-turn
+reasoning arcs.
+
+**Refine step evaluation.** The refine step deduplicates across overlapping windows but may
+collapse useful distinctions.
+
+## References
+
+[1] Orwellian Observation: orwellian-observation.md

--- a/designs/013-observation-strategies.md
+++ b/designs/013-observation-strategies.md
@@ -38,6 +38,15 @@ Adaptive finds more grounded observations than woo alone because some windows co
 owner messages that only make sense with assistant context. The fallback catches those. Exact
 counts vary across runs as the conversation corpus grows; representative numbers are in [1].
 
+## Per-window truncation
+
+Per-window observe calls use a token budget of 4096. Thinking models can spend
+the whole budget reasoning before emitting content; the call returns truncated.
+Aborting the whole conversation in that case is too aggressive. observeWindow
+retries once at 16384 tokens. Windows that truncate again are skipped. Adjacent
+overlapping windows usually cover the same material, so the skip rarely costs
+information.
+
 ## Per-mode observation storage
 
 Each observation strategy stores results in a separate directory so switching strategies does

--- a/designs/013-observation-strategies.md
+++ b/designs/013-observation-strategies.md
@@ -91,24 +91,23 @@ Observation has two phases with different parallelism characteristics:
 2. **Dedup + refine** — per-conversation. Needs all window results for that conversation
    before it can run. One API call per conversation.
 
-The implementation flattens phase 1 into a shared work queue. On entry to `runObserve`:
+The implementation uses nested errgroups:
 
-1. Load all pending conversations and build their window lists (cheap, no API calls).
-2. Emit one work unit per window: `(conversationID, windowIndex, input, method)`.
-   For adaptive mode, each window emits up to two units (woo attempt, then default
-   fallback if woo returns NONE). The fallback is conditional — it becomes a work unit
-   only after the woo attempt completes empty.
-3. Process the queue through an errgroup capped at the rate limiter's max concurrency.
-   The AIMD token bucket already gates actual Bedrock calls; the errgroup cap prevents
-   unbounded goroutine accumulation.
-4. When all windows for a conversation complete, fire the dedup + refine step for that
-   conversation. These are also independent across conversations and enter the same queue.
+- **Outer errgroup** (capped at 50): one goroutine per conversation. Handles loading,
+  storing results, and progress tracking.
+- **Inner errgroup** (uncapped): one goroutine per window within that conversation.
+  All windows fire concurrently; the AIMD rate limiter gates actual Bedrock calls.
+- After the inner errgroup completes, dedup + refine runs synchronously within the
+  conversation's goroutine.
 
 This eliminates head-of-line blocking: a 30-window conversation no longer serializes 30
-API calls behind one goroutine slot while short conversations finish and free theirs.
+API calls behind one goroutine slot. All windows acquire rate-limiter tokens in parallel
+with windows from other conversations.
 
-Sort order for the queue: largest conversations first (most windows), so their windows
-begin processing immediately rather than arriving as a long tail.
+The outer errgroup sorts pending conversations largest-first so the most expensive
+conversations (most windows) start processing immediately rather than arriving as a
+long tail. The conversation remains the unit of retry and storage — if any window
+returns a fatal error, the conversation fails and will be re-observed next run.
 
 ## Edge cases
 

--- a/designs/013-observation-strategies.md
+++ b/designs/013-observation-strategies.md
@@ -100,21 +100,17 @@ The implementation uses nested errgroups:
 - After the inner errgroup completes, dedup + refine runs synchronously within the
   conversation's goroutine.
 
-This eliminates head-of-line blocking: a 30-window conversation no longer serializes 30
-API calls behind one goroutine slot. All windows acquire rate-limiter tokens in parallel
-with windows from other conversations.
+This eliminates head-of-line blocking: a 30-window conversation no longer serializes
+30 API calls behind one goroutine slot.
 
 The outer errgroup sorts pending conversations largest-first so the most expensive
-conversations (most windows) start processing immediately rather than arriving as a
-long tail. The conversation remains the unit of retry and storage — if any window
-returns a fatal error, the conversation fails and will be re-observed next run.
+start immediately rather than arriving as a long tail. The conversation remains the
+unit of retry and storage — if any window returns a fatal error, the conversation
+fails and will be re-observed next run.
 
-## Edge cases
-
-**Zero clusters.** When all observations land as outliers (0 clusters, 0 summaries), the
-thesis step has no input. The pipeline returns early with an error: "no clusters formed —
-need more observations to compose a muse." This happens with very small `--limit` values
-where the observation count is below the clustering threshold.
+When all observations land as outliers (0 clusters, 0 summaries), the thesis step has
+no input. The pipeline returns early with an error rather than sending an empty request
+to Bedrock. This happens with very small `--limit` values.
 
 ## Deferred
 

--- a/designs/014-composition-fixes.md
+++ b/designs/014-composition-fixes.md
@@ -54,9 +54,8 @@ $0.02 per conversation, cacheable across runs.
 
 Filtered observations are stored separately so the unfiltered set is preserved. The current
 implementation encodes filtering as a storage-level convention (`observations/{mode}-filtered/`
-accessed via `--observe-mode=adaptive-filtered --skip-observe`). This is a workaround.
-Filtering is a pipeline stage between observe and compose, and the deferred work below
-addresses making it one.
+accessed via `--observe-mode=adaptive-filtered --skip-observe`). Filtering should be a
+pipeline stage between observe and compose; the deferred work below addresses that.
 
 ## Provenance metadata
 
@@ -71,8 +70,6 @@ clusters: {count}
 corpus: {count} conversations
 -->
 ```
-
-This tells a future reader or pipeline version what produced the muse.
 
 ## Evidence
 

--- a/designs/014-composition-fixes.md
+++ b/designs/014-composition-fixes.md
@@ -68,6 +68,7 @@ composed: {date}
 observe: {mode}
 observations: {count}
 clusters: {count}
+corpus: {count} conversations
 -->
 ```
 

--- a/designs/014-composition-fixes.md
+++ b/designs/014-composition-fixes.md
@@ -34,12 +34,12 @@ This is a stable partition and shuffle.
 
 Two sentences added to the summarize prompt:
 
-> If the cluster contains observations with quotes, include at least one verbatim quote in
-> the summary. The quote should anchor a concrete behavioral example.
+> Summarize the pattern first, then include one or two verbatim quotes that illustrate the
+> pattern in action. The summary tells the reader what the person does. The quotes show them
+> doing it.
 
-This pulls specific owner language through the summarize step into the final muse. Without it,
-the summarize step produces accurate abstractions. With it, the abstractions are anchored by
-concrete examples.
+Without this, the summarize step produces accurate abstractions. With it, the abstractions
+are followed by the owner's actual words demonstrating the pattern.
 
 ### Quality gate
 

--- a/designs/014-composition-fixes.md
+++ b/designs/014-composition-fixes.md
@@ -1,0 +1,101 @@
+# Composition Fixes
+
+## Problem
+
+Better observation strategies [1] find three to five times more grounded observations than
+the default pipeline. But the composition pipeline compresses additional observations into
+more abstract summaries. A cluster containing "I would never say ablate," "colons paper over
+conceptual gaps," and "negative definitions are a pathology" becomes "tracks linguistic
+precision across multiple dimensions." The details that make a muse distinctive are lost.
+
+This matters when clusters are large (20+ observations). The default pipeline produces small
+clusters (~5 per cluster) where the summarize step already has manageable input. The adaptive
+observation strategy produces large clusters (~25 per cluster) where the summarize step
+over-compresses [2].
+
+The composition pipeline has four stages between observations and the muse. **Label** assigns
+a topic label to each observation. **Cluster** groups observations by label. **Sample** selects
+observations up to a token budget per cluster. **Summarize** writes one paragraph per cluster.
+The fixes below target the sample and summarize stages.
+
+## Three fixes
+
+### Quote-prioritized sampling
+
+The sample step selects observations up to a token budget per cluster. It currently shuffles
+randomly. Observations with verbatim owner quotes compete equally with quoteless observations,
+and the budget often fills before quoted observations get a chance.
+
+The fix partitions observations into two groups: those with quotes and those without. Quoted
+observations fill the budget first. Within each group, observations are shuffled randomly.
+This is a stable partition and shuffle.
+
+### Exemplar prompt
+
+Two sentences added to the summarize prompt:
+
+> If the cluster contains observations with quotes, include at least one verbatim quote in
+> the summary. The quote should anchor a concrete behavioral example.
+
+This pulls specific owner language through the summarize step into the final muse. Without it,
+the summarize step produces accurate abstractions. With it, the abstractions are anchored by
+concrete examples.
+
+### Quality gate
+
+A judge command (`muse judge --filter`) rates each observation against its source conversation
+as grounded, generic, or misleading, using a more capable model (Opus) than the one used for
+observation. Filtering to grounded-only before composition removes observations that compete
+for attention without contributing signal.
+
+On a representative run of adaptive observations, roughly 88% rate grounded, 6% generic, 6%
+misleading. Exact counts vary across runs as the corpus grows. The quality gate costs roughly
+$0.02 per conversation, cacheable across runs.
+
+Filtered observations are stored separately so the unfiltered set is preserved. The current
+implementation encodes filtering as a storage-level convention (`observations/{mode}-filtered/`
+accessed via `--observe-mode=adaptive-filtered --skip-observe`). This is a workaround.
+Filtering is a pipeline stage between observe and compose, and the deferred work below
+addresses making it one.
+
+## Provenance metadata
+
+The composed muse includes an HTML comment header with composition metadata:
+
+```html
+<!--
+composed: {date}
+observe: {mode}
+observations: {count}
+clusters: {count}
+-->
+```
+
+This tells a future reader or pipeline version what produced the muse.
+
+## Evidence
+
+Research [2] tested these three fixes independently and in combination on a corpus of 453
+conversations. The qualitative evidence is strongest: the same topic (language precision)
+composed without the exemplar prompt produces "I treat abbreviations as contracts. Naming the
+steps is part of the design." With the exemplar prompt, it produces "I don't like
+'consolidateAfter determines candidacy,' because consolidateAfter determines which nodes
+CANNOT be candidates. Related, but different in goal."
+
+The fixes help proportionally to cluster size. On adaptive observations (25 per cluster),
+all three fixes improve concreteness. On default observations (5 per cluster), the fixes
+barely register because the summarize step was already working with manageable input.
+
+## Deferred
+
+**Automating the quality gate.** The judge step is currently a separate command. It should
+run as a pipeline stage between observe and label.
+
+**Single-command adaptive-filtered compose.** Currently requires three commands: compose,
+judge --filter, compose --skip-observe. Should be one command.
+
+## References
+
+[1] designs/013-observation-strategies.md
+
+[2] Improving Muse Composition: improving-muse-composition.md

--- a/internal/compose/artifacts.go
+++ b/internal/compose/artifacts.go
@@ -9,12 +9,15 @@ import (
 	"github.com/ellistarn/muse/internal/storage"
 )
 
-// Artifact path conventions. Observations are shared across all strategies and
-// stored at the top level. Strategy-specific derived artifacts live under
-// "compose/". All paths use the Store's generic PutData/GetData/ListData methods.
+// Artifact path conventions. Observations are stored per observe-mode so
+// different strategies can coexist without clobbering each other. The default
+// mode ("") stores at the top level for backward compatibility. Named modes
+// store under observations/{mode}/. Strategy-specific derived artifacts live
+// under "compose/".
 //
-// Shared:
-//   observations/{source}/{conversationID}.json
+// Observations:
+//   observations/{source}/{conversationID}.json              (default mode)
+//   observations/{mode}/{source}/{conversationID}.json       (named modes)
 //
 // Clustering-specific:
 //   compose/labels/{source}/{conversationID}.json
@@ -31,21 +34,37 @@ func composePath(kind, source, conversationID string) string {
 	return fmt.Sprintf("compose/%s/%s/%s.json", kind, source, conversationID)
 }
 
-// observationPath returns the key for a shared observation artifact.
-func observationPath(source, conversationID string) string {
-	return fmt.Sprintf("observations/%s/%s.json", source, conversationID)
+// observationPath returns the key for an observation artifact. Named modes
+// get their own directory so different strategies don't clobber each other.
+func observationPath(source, conversationID string, mode ...ObserveMode) string {
+	m := ObserveDefault
+	if len(mode) > 0 {
+		m = mode[0]
+	}
+	if m == "" || m == ObserveDefault {
+		return fmt.Sprintf("observations/%s/%s.json", source, conversationID)
+	}
+	return fmt.Sprintf("observations/%s/%s/%s.json", string(m), source, conversationID)
+}
+
+// observationDirPrefix returns the storage prefix for listing/deleting observations.
+func observationDirPrefix(mode ObserveMode) string {
+	if mode == "" || mode == ObserveDefault {
+		return "observations/"
+	}
+	return fmt.Sprintf("observations/%s/", string(mode))
 }
 
 // PutObservations writes observations for a conversation.
-func PutObservations(ctx context.Context, store storage.Store, source, conversationID string, obs *Observations) error {
-	return putJSON(ctx, store, observationPath(source, conversationID), obs)
+func PutObservations(ctx context.Context, store storage.Store, source, conversationID string, obs *Observations, mode ...ObserveMode) error {
+	return putJSON(ctx, store, observationPath(source, conversationID, mode...), obs)
 }
 
 // GetObservations reads observations for a conversation.
 // Returns storage.NotFoundError when no artifact exists.
-func GetObservations(ctx context.Context, store storage.Store, source, conversationID string) (*Observations, error) {
+func GetObservations(ctx context.Context, store storage.Store, source, conversationID string, mode ...ObserveMode) (*Observations, error) {
 	var obs Observations
-	if err := getJSON(ctx, store, observationPath(source, conversationID), &obs); err != nil {
+	if err := getJSON(ctx, store, observationPath(source, conversationID, mode...), &obs); err != nil {
 		return nil, err
 	}
 	return &obs, nil
@@ -85,20 +104,24 @@ func DeleteThemes(ctx context.Context, store storage.Store) error {
 }
 
 // ListObservations returns all (source, conversationID) pairs that have observations.
-func ListObservations(ctx context.Context, store storage.Store) ([]SourceConversation, error) {
-	return listArtifacts(ctx, store, "observations/")
+func ListObservations(ctx context.Context, store storage.Store, mode ...ObserveMode) ([]SourceConversation, error) {
+	m := ObserveDefault
+	if len(mode) > 0 {
+		m = mode[0]
+	}
+	return listArtifacts(ctx, store, observationDirPrefix(m))
 }
 
 // CountObservationItems returns the total number of discrete observation items
 // per source by reading each observation file and summing its Items.
-func CountObservationItems(ctx context.Context, store storage.Store) (map[string]int, error) {
-	entries, err := ListObservations(ctx, store)
+func CountObservationItems(ctx context.Context, store storage.Store, mode ...ObserveMode) (map[string]int, error) {
+	entries, err := ListObservations(ctx, store, mode...)
 	if err != nil {
 		return nil, err
 	}
 	counts := make(map[string]int, len(entries))
 	for _, e := range entries {
-		obs, err := GetObservations(ctx, store, e.Source, e.ConversationID)
+		obs, err := GetObservations(ctx, store, e.Source, e.ConversationID, mode...)
 		if err != nil {
 			return nil, err
 		}
@@ -112,9 +135,13 @@ func ListLabels(ctx context.Context, store storage.Store) ([]SourceConversation,
 	return listArtifacts(ctx, store, "compose/labels/")
 }
 
-// DeleteObservations removes all observation artifacts.
-func DeleteObservations(ctx context.Context, store storage.Store) error {
-	return store.DeletePrefix(ctx, "observations/")
+// DeleteObservations removes all observation artifacts for the given mode.
+func DeleteObservations(ctx context.Context, store storage.Store, mode ...ObserveMode) error {
+	m := ObserveDefault
+	if len(mode) > 0 {
+		m = mode[0]
+	}
+	return store.DeletePrefix(ctx, observationDirPrefix(m))
 }
 
 // DeleteObservationsForSource removes observation artifacts for a specific source.

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -72,7 +72,7 @@ func RunClustered(
 	})
 
 	// Load all observations
-	allObs, err := loadAllStructuredObservations(ctx, store)
+	allObs, err := loadAllStructuredObservations(ctx, store, opts.Observe)
 	if err != nil {
 		return nil, fmt.Errorf("load observations: %w", err)
 	}
@@ -341,7 +341,7 @@ func runObserve(
 
 	// Handle reobserve
 	if opts.Reobserve {
-		DeleteObservations(ctx, store)
+		DeleteObservations(ctx, store, opts.Observe)
 		fmt.Fprintln(os.Stderr, "  Cleared all observations")
 	}
 
@@ -370,7 +370,7 @@ func runObserve(
 		}
 		fp := Fingerprint(e.LastModified.Format(time.RFC3339Nano), promptHash)
 
-		existing, err := GetObservations(ctx, store, e.Source, e.ConversationID)
+		existing, err := GetObservations(ctx, store, e.Source, e.ConversationID, opts.Observe)
 		if err == nil && existing.Fingerprint == fp {
 			pruned++
 			continue
@@ -448,13 +448,13 @@ func runObserve(
 					Date:        entry.LastModified.Format("2006-01-02"),
 					Items:       items,
 				}
-				if err := PutObservations(ctx, store, entry.Source, entry.ConversationID, obs); err != nil {
+				if err := PutObservations(ctx, store, entry.Source, entry.ConversationID, obs, opts.Observe); err != nil {
 					return fmt.Errorf("save observations for %s: %w", entry.Key, err)
 				}
 
 				if opts.Verbose {
 					fmt.Fprintf(os.Stderr, "  [%d/%d] Observed ~/.muse/%s (%d obs, %s, $%.4f)\n",
-						n, len(pending), observationPath(entry.Source, entry.ConversationID), len(items),
+						n, len(pending), observationPath(entry.Source, entry.ConversationID, opts.Observe), len(items),
 						time.Since(start).Round(time.Millisecond), u.Cost())
 				}
 				mu.Lock()
@@ -1190,8 +1190,8 @@ func (e observationEntry) FormatTokens() int {
 
 // loadAllStructuredObservations loads all observation artifacts and returns
 // a flat list of observation entries, loading conversations in parallel.
-func loadAllStructuredObservations(ctx context.Context, store storage.Store) ([]observationEntry, error) {
-	convList, err := ListObservations(ctx, store)
+func loadAllStructuredObservations(ctx context.Context, store storage.Store, mode ...ObserveMode) ([]observationEntry, error) {
+	convList, err := ListObservations(ctx, store, mode...)
 	if err != nil {
 		return nil, err
 	}
@@ -1206,7 +1206,7 @@ func loadAllStructuredObservations(ctx context.Context, store storage.Store) ([]
 	g.SetLimit(20)
 	for i, ss := range convList {
 		g.Go(func() error {
-			obs, err := GetObservations(ctx, store, ss.Source, ss.ConversationID)
+			obs, err := GetObservations(ctx, store, ss.Source, ss.ConversationID, mode...)
 			if err != nil {
 				results[i] = result{err: fmt.Errorf("get observations %s/%s: %w", ss.Source, ss.ConversationID, err)}
 				return results[i].err

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -358,7 +358,8 @@ func runObserve(
 	discovered := len(entries)
 
 	// Compute prompt chain hash for fingerprinting
-	promptHash := Fingerprint(prompts.Observe, prompts.ObserveHuman, prompts.Refine)
+	promptHash := Fingerprint(prompts.Observe, prompts.ObserveHuman, prompts.Refine,
+		fmt.Sprintf("mode:%s", opts.Observe))
 
 	// Determine which conversations need (re)observation
 	var pending []storage.ConversationEntry
@@ -435,7 +436,7 @@ func runObserve(
 				convBytes := conversationDataSize(conv)
 
 				start := time.Now()
-				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose, humanOverrides)
+				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose, humanOverrides, opts.Observe)
 				n := counter.Add(1)
 				if err != nil {
 					return fmt.Errorf("observe %s: %w", entry.Key, err)
@@ -503,7 +504,10 @@ func conversationDataSize(conv *conversation.Conversation) int {
 // exceeds the context window, mechanical compression is applied as a fallback:
 // code blocks are stripped, tool output is collapsed to [tool: name] markers,
 // and long assistant messages are truncated.
-func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, humanOverrides map[string]bool) ([]Observation, inference.Usage, error) {
+func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, humanOverrides map[string]bool, mode ObserveMode) ([]Observation, inference.Usage, error) {
+	if mode == ObserveWoo {
+		return observeWoo(ctx, client, conv, verbose, humanOverrides)
+	}
 	refined, usage, err := observeAndRefine(ctx, client, conv, verbose, humanOverrides)
 	if err != nil {
 		return nil, usage, err
@@ -536,6 +540,170 @@ func observeAndParse(ctx context.Context, client inference.Client, conv *convers
 		}
 	}
 	return relevant, usage, nil
+}
+
+// Window parameters for windowed observation. Each window is small enough that
+// local signal survives without being washed out by distant mechanical turns.
+// Adjacent windows overlap so multi-turn reasoning arcs aren't split.
+const (
+	windowSize   = 8 // turns per window
+	windowStride = 4 // advance between windows
+)
+
+// observeWoo runs windowed owner-only observation. It slides an 8-turn window
+// across the conversation, strips assistant text from each window, and observes
+// each window independently. Deduplicates across overlapping windows, then refines.
+func observeWoo(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, humanOverrides map[string]bool) ([]Observation, inference.Usage, error) {
+	turns := extractTurns(conv, humanOverrides)
+	if len(turns) == 0 {
+		return nil, inference.Usage{}, nil
+	}
+
+	windows := buildWindows(turns, windowSize, windowStride)
+	if verbose {
+		fmt.Fprintf(os.Stderr, "    woo: %d turns → %d windows (size %d, stride %d)\n",
+			len(turns), len(windows), windowSize, windowStride)
+	}
+
+	observePrompt := prompts.Observe
+	if isHumanSource(conv.Source, humanOverrides) {
+		observePrompt = prompts.ObserveHuman
+	}
+
+	var totalUsage inference.Usage
+	var allCandidates []string
+
+	for i, w := range windows {
+		// Owner-only: strip assistant text
+		var b strings.Builder
+		for _, t := range w {
+			fmt.Fprintf(&b, "[owner]: %s\n\n", t.humanContent)
+		}
+		input := b.String()
+
+		start := time.Now()
+		obs, usage, err := inference.Converse(ctx, client, observePrompt, input, inference.WithMaxTokens(4096))
+		totalUsage = totalUsage.Add(usage)
+		if verbose {
+			fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, %d chars → %d chars (%s, $%.4f)\n",
+				i+1, len(windows), len(w), len(input), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+		}
+		if err != nil && obs == "" {
+			return nil, totalUsage, err
+		}
+		if obs != "" && !isEmpty(obs) {
+			allCandidates = append(allCandidates, obs)
+		}
+	}
+
+	if len(allCandidates) == 0 {
+		return nil, totalUsage, nil
+	}
+
+	// Deduplicate across overlapping windows, then refine
+	candidates := deduplicateObservationText(strings.Join(allCandidates, "\n\n"))
+	start := time.Now()
+	refined, usage, err := inference.Converse(ctx, client, prompts.Refine, candidates, inference.WithMaxTokens(4096))
+	totalUsage = totalUsage.Add(usage)
+	if verbose {
+		fmt.Fprintf(os.Stderr, "      refine %d chars → %d chars (%s, $%.4f)\n",
+			len(candidates), len(refined), time.Since(start).Round(time.Millisecond), usage.Cost())
+	}
+	if err != nil && refined == "" {
+		return nil, totalUsage, err
+	}
+	if isEmpty(refined) {
+		return nil, totalUsage, nil
+	}
+
+	items := parseObservationItems(refined)
+	var relevant []Observation
+	for _, item := range items {
+		if isRelevant(item.Text) {
+			relevant = append(relevant, item)
+		}
+	}
+	return relevant, totalUsage, nil
+}
+
+// buildWindows splits turns into overlapping windows of the given size and stride.
+// The last window is extended to avoid a tiny tail.
+func buildWindows(turns []turn, size, stride int) [][]turn {
+	if len(turns) <= size {
+		return [][]turn{turns}
+	}
+	var windows [][]turn
+	for start := 0; start < len(turns); start += stride {
+		end := start + size
+		if end > len(turns) {
+			end = len(turns)
+		}
+		if len(turns)-end < stride {
+			end = len(turns)
+		}
+		windows = append(windows, turns[start:end])
+		if end == len(turns) {
+			break
+		}
+	}
+	return windows
+}
+
+// deduplicateObservationText removes duplicate observations from raw LLM output
+// across overlapping windows. Two observations are duplicates if their text
+// (after normalization) is identical or one contains the other.
+func deduplicateObservationText(text string) string {
+	items := parseObservationItems(text)
+	if len(items) == 0 {
+		return text
+	}
+
+	type normalizedObs struct {
+		original Observation
+		norm     string
+	}
+	var normalized []normalizedObs
+	for _, item := range items {
+		n := strings.ToLower(strings.TrimSpace(item.Text))
+		normalized = append(normalized, normalizedObs{original: item, norm: n})
+	}
+
+	keep := make([]bool, len(normalized))
+	for i := range keep {
+		keep[i] = true
+	}
+	for i := 0; i < len(normalized); i++ {
+		if !keep[i] {
+			continue
+		}
+		for j := i + 1; j < len(normalized); j++ {
+			if !keep[j] {
+				continue
+			}
+			if normalized[i].norm == normalized[j].norm {
+				keep[j] = false
+				continue
+			}
+			if strings.Contains(normalized[i].norm, normalized[j].norm) {
+				keep[j] = false
+			} else if strings.Contains(normalized[j].norm, normalized[i].norm) {
+				keep[i] = false
+				break
+			}
+		}
+	}
+
+	var b strings.Builder
+	for i, n := range normalized {
+		if !keep[i] {
+			continue
+		}
+		if n.original.Quote != "" {
+			fmt.Fprintf(&b, "Quote: %s\n", n.original.Quote)
+		}
+		fmt.Fprintf(&b, "Observation: %s\n\n", n.original.Text)
+	}
+	return strings.TrimSpace(b.String())
 }
 
 // observeAndRefine is the shared core of the observation pipeline. It extracts

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -282,6 +282,24 @@ func RunClustered(
 	})
 	logAfter("muse.md").Cost(time.Since(composeStart), composeUsage.Cost()).Print()
 
+	// Prepend provenance metadata
+	mode := string(opts.Observe)
+	if mode == "" {
+		mode = "default"
+	}
+	var corpusNote string
+	if obsResult.discovered > 0 {
+		corpusNote = fmt.Sprintf("\ncorpus: %d conversations", obsResult.discovered)
+	}
+	metadata := fmt.Sprintf("<!--\ncomposed: %s\nobserve: %s\nobservations: %d\nclusters: %d%s\n-->\n\n",
+		time.Now().UTC().Format("2006-01-02"),
+		mode,
+		len(allObs),
+		len(clusters),
+		corpusNote,
+	)
+	muse = metadata + muse
+
 	// ── DONE ────────────────────────────────────────────────────────────
 	logStage("done", "%d patterns → muse.md", len(clusters)).
 		Cost(time.Since(pipelineStart), totalUsage.Cost()).Print()

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -56,44 +56,52 @@ func RunClustered(
 	var stages []StageStats
 
 	// ── OBSERVE ─────────────────────────────────────────────────────────
-	var observeCounter atomic.Int32
-	observeStart := time.Now()
-	observeResult, err := runObserve(ctx, store, observeLLM, opts, &observeCounter)
-	if err != nil {
-		return nil, fmt.Errorf("observe: %w", err)
-	}
-	totalUsage = totalUsage.Add(observeResult.usage)
-	stages = append(stages, StageStats{
-		Name:     "observe",
-		Model:    observeLLM.Model(),
-		Duration: time.Since(observeStart),
-		Usage:    observeResult.usage,
-		DataSize: observeResult.dataSize,
-	})
+	var allObs []observationEntry
+	var obsResult observeResult
+	if opts.SkipObserve {
+		// Load pre-existing observations without re-observing.
+		var err error
+		allObs, err = loadAllStructuredObservations(ctx, store, opts.Observe)
+		if err != nil {
+			return nil, fmt.Errorf("load observations: %w", err)
+		}
+		logStage("observe", "skipped, %d pre-existing observations", len(allObs)).Print()
+	} else {
+		var observeCounter atomic.Int32
+		observeStart := time.Now()
+		or, err := runObserve(ctx, store, observeLLM, opts, &observeCounter)
+		if err != nil {
+			return nil, fmt.Errorf("observe: %w", err)
+		}
+		obsResult = *or
+		totalUsage = totalUsage.Add(obsResult.usage)
+		stages = append(stages, StageStats{
+			Name:     "observe",
+			Model:    observeLLM.Model(),
+			Duration: time.Since(observeStart),
+			Usage:    obsResult.usage,
+			DataSize: obsResult.dataSize,
+		})
 
-	// Load all observations
-	allObs, err := loadAllStructuredObservations(ctx, store, opts.Observe)
-	if err != nil {
-		return nil, fmt.Errorf("load observations: %w", err)
-	}
+		allObs, err = loadAllStructuredObservations(ctx, store, opts.Observe)
+		if err != nil {
+			return nil, fmt.Errorf("load observations: %w", err)
+		}
 
-	// discover + observe log lines (printed after observe completes since
-	// discovery happens inside runObserve before the LLM work)
-
-	// observe result line
-	observeNote := ""
-	if observeResult.remaining > 0 {
-		observeNote = fmt.Sprintf(" [%d remaining]", observeResult.remaining)
+		observeNote := ""
+		if obsResult.remaining > 0 {
+			observeNote = fmt.Sprintf(" [%d remaining]", obsResult.remaining)
+		}
+		logAfter("%d observations%s",
+			len(allObs), observeNote,
+		).Cost(time.Since(observeStart), obsResult.usage.Cost()).Print()
 	}
-	logAfter("%d observations%s",
-		len(allObs), observeNote,
-	).Cost(time.Since(observeStart), observeResult.usage.Cost()).Print()
 
 	if len(allObs) == 0 {
 		return &Result{
-			Processed: observeResult.processed,
-			Pruned:    observeResult.pruned,
-			Remaining: observeResult.remaining,
+			Processed: obsResult.processed,
+			Pruned:    obsResult.pruned,
+			Remaining: obsResult.remaining,
 			Stages:    stages,
 		}, nil
 	}
@@ -278,16 +286,16 @@ func RunClustered(
 	logStage("done", "%d patterns → muse.md", len(clusters)).
 		Cost(time.Since(pipelineStart), totalUsage.Cost()).Print()
 
-	processed := observeResult.processed
+	processed := obsResult.processed
 	return &Result{
 		Processed:    processed,
-		Pruned:       observeResult.pruned,
-		Remaining:    observeResult.remaining,
+		Pruned:       obsResult.pruned,
+		Remaining:    obsResult.remaining,
 		Observations: len(allObs),
 		Clusters:     len(clusters),
 		Noise:        len(noiseObs),
 		Cache: CacheStats{
-			Observe: HitMiss{Hit: observeResult.pruned, Miss: observeResult.processed},
+			Observe: HitMiss{Hit: obsResult.pruned, Miss: obsResult.processed},
 			Label:   labelCache,
 		},
 		Stages: stages,

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -232,6 +232,9 @@ func RunClustered(
 	logAfter("%d summaries", len(summaries)).Cost(time.Since(synthStart), synthUsage.Cost()).Print()
 
 	// ── THESIS ─────────────────────────────────────────────────────────
+	if len(summaries) == 0 {
+		return nil, fmt.Errorf("no clusters formed — need more observations to compose a muse (try increasing --limit or removing it)")
+	}
 	thesisStart := time.Now()
 	logBefore("thesis", "%d summaries", len(summaries))
 	thesis, thesisUsage, err := runThesis(ctx, composeLLM, summaries)

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -505,8 +505,11 @@ func conversationDataSize(conv *conversation.Conversation) int {
 // code blocks are stripped, tool output is collapsed to [tool: name] markers,
 // and long assistant messages are truncated.
 func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, humanOverrides map[string]bool, mode ObserveMode) ([]Observation, inference.Usage, error) {
-	if mode == ObserveWoo {
+	switch mode {
+	case ObserveWoo:
 		return observeWoo(ctx, client, conv, verbose, humanOverrides)
+	case ObserveAdaptive:
+		return observeAdaptive(ctx, client, conv, verbose, humanOverrides)
 	}
 	refined, usage, err := observeAndRefine(ctx, client, conv, verbose, humanOverrides)
 	if err != nil {
@@ -587,6 +590,105 @@ func observeWoo(ctx context.Context, client inference.Client, conv *conversation
 		if verbose {
 			fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, %d chars → %d chars (%s, $%.4f)\n",
 				i+1, len(windows), len(w), len(input), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+		}
+		if err != nil && obs == "" {
+			return nil, totalUsage, err
+		}
+		if obs != "" && !isEmpty(obs) {
+			allCandidates = append(allCandidates, obs)
+		}
+	}
+
+	if len(allCandidates) == 0 {
+		return nil, totalUsage, nil
+	}
+
+	// Deduplicate across overlapping windows, then refine
+	candidates := deduplicateObservationText(strings.Join(allCandidates, "\n\n"))
+	start := time.Now()
+	refined, usage, err := inference.Converse(ctx, client, prompts.Refine, candidates, inference.WithMaxTokens(4096))
+	totalUsage = totalUsage.Add(usage)
+	if verbose {
+		fmt.Fprintf(os.Stderr, "      refine %d chars → %d chars (%s, $%.4f)\n",
+			len(candidates), len(refined), time.Since(start).Round(time.Millisecond), usage.Cost())
+	}
+	if err != nil && refined == "" {
+		return nil, totalUsage, err
+	}
+	if isEmpty(refined) {
+		return nil, totalUsage, nil
+	}
+
+	items := parseObservationItems(refined)
+	var relevant []Observation
+	for _, item := range items {
+		if isRelevant(item.Text) {
+			relevant = append(relevant, item)
+		}
+	}
+	return relevant, totalUsage, nil
+}
+
+// adaptiveThreshold is the average owner message length (in chars) below which
+// woo (owner-only) is used. At or above this, default (with assistant) is used.
+// Derived from featurize across 1054 windows: woo wins 1.5-1.9x below 300,
+// default wins ~2x above 600, wash in between.
+const adaptiveThreshold = 300
+
+// observeAdaptive runs windowed observation, choosing woo or default framing
+// per window based on average owner message length.
+func observeAdaptive(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, humanOverrides map[string]bool) ([]Observation, inference.Usage, error) {
+	turns := extractTurns(conv, humanOverrides)
+	if len(turns) == 0 {
+		return nil, inference.Usage{}, nil
+	}
+
+	windows := buildWindows(turns, windowSize, windowStride)
+	if verbose {
+		fmt.Fprintf(os.Stderr, "    adaptive: %d turns → %d windows (size %d, stride %d)\n",
+			len(turns), len(windows), windowSize, windowStride)
+	}
+
+	observePrompt := prompts.Observe
+	if isHumanSource(conv.Source, humanOverrides) {
+		observePrompt = prompts.ObserveHuman
+	}
+
+	var totalUsage inference.Usage
+	var allCandidates []string
+
+	for i, w := range windows {
+		// Compute average owner message length for this window
+		var totalOwner int
+		for _, t := range w {
+			totalOwner += len(t.humanContent)
+		}
+		avgOwner := totalOwner / len(w)
+
+		// Pick framing based on threshold
+		var input string
+		var method string
+		if avgOwner < adaptiveThreshold {
+			// Woo: owner-only
+			var b strings.Builder
+			for _, t := range w {
+				fmt.Fprintf(&b, "[owner]: %s\n\n", t.humanContent)
+			}
+			input = b.String()
+			method = "woo"
+		} else {
+			// Default: compressed with assistant context
+			chunks := compressConversation(w, conv.Source, humanOverrides)
+			input = strings.Join(chunks, "\n")
+			method = "default"
+		}
+
+		start := time.Now()
+		obs, usage, err := inference.Converse(ctx, client, observePrompt, input, inference.WithMaxTokens(4096))
+		totalUsage = totalUsage.Add(usage)
+		if verbose {
+			fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, avg %d chars, %s → %d chars (%s, $%.4f)\n",
+				i+1, len(windows), len(w), avgOwner, method, len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
 		}
 		if err != nil && obs == "" {
 			return nil, totalUsage, err

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -583,7 +583,33 @@ func observeAndParse(ctx context.Context, client inference.Client, conv *convers
 const (
 	windowSize   = 8 // turns per window
 	windowStride = 4 // advance between windows
+
+	// windowObserveBudget is the initial max-tokens budget for a per-window
+	// observe call. Sized for non-thinking models; thinking models that exceed
+	// it are caught by retry-on-truncation in observeWindow.
+	windowObserveBudget = 4096
+
+	// windowObserveRetryBudget is the budget used after truncation. Sized to
+	// absorb thinking from typical thinking-by-default models (Qwen3 Thinking
+	// emits ~3-5k of reasoning per window). Windows that still truncate at
+	// this budget are skipped — no observation from that window.
+	windowObserveRetryBudget = 16384
 )
+
+// observeWindow runs the configured observe prompt against a single window's
+// input. If the call truncates (TruncatedError, typically because a
+// thinking-by-default model spent the whole budget reasoning), it retries
+// once at windowObserveRetryBudget. If the retry also truncates, the
+// TruncatedError is returned for the caller to skip this window.
+func observeWindow(ctx context.Context, client inference.Client, prompt, input string) (string, inference.Usage, error) {
+	obs, usage, err := inference.Converse(ctx, client, prompt, input, inference.WithMaxTokens(windowObserveBudget))
+	if !inference.IsTruncated(err) {
+		return obs, usage, err
+	}
+	retryObs, retryUsage, retryErr := inference.Converse(ctx, client, prompt, input, inference.WithMaxTokens(windowObserveRetryBudget))
+	usage = usage.Add(retryUsage)
+	return retryObs, usage, retryErr
+}
 
 // observeWoo runs windowed owner-only observation. It slides an 8-turn window
 // across the conversation, strips assistant text from each window, and observes
@@ -617,11 +643,19 @@ func observeWoo(ctx context.Context, client inference.Client, conv *conversation
 		input := b.String()
 
 		start := time.Now()
-		obs, usage, err := inference.Converse(ctx, client, observePrompt, input, inference.WithMaxTokens(4096))
+		obs, usage, err := observeWindow(ctx, client, observePrompt, input)
 		totalUsage = totalUsage.Add(usage)
 		if verbose {
 			fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, %d chars → %d chars (%s, $%.4f)\n",
 				i+1, len(windows), len(w), len(input), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+		}
+		if inference.IsTruncated(err) {
+			// Pathological window: still truncated after retry. Skip rather
+			// than aborting the whole conversation.
+			if verbose {
+				fmt.Fprintf(os.Stderr, "      window[%d/%d] truncated after retry, skipping\n", i+1, len(windows))
+			}
+			continue
 		}
 		if err != nil && obs == "" {
 			return nil, totalUsage, err
@@ -712,9 +746,14 @@ func observeAdaptive(ctx context.Context, client inference.Client, conv *convers
 		}
 
 		start := time.Now()
+		truncated := false
 		for j, a := range attempts {
-			obs, usage, err := inference.Converse(ctx, client, observePrompt, a.input, inference.WithMaxTokens(4096))
+			obs, usage, err := observeWindow(ctx, client, observePrompt, a.input)
 			totalUsage = totalUsage.Add(usage)
+			if inference.IsTruncated(err) {
+				truncated = true
+				break
+			}
 			if err != nil && obs == "" {
 				return nil, totalUsage, err
 			}
@@ -730,6 +769,12 @@ func observeAdaptive(ctx context.Context, client inference.Client, conv *convers
 				fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, woo → NONE, trying default\n",
 					i+1, len(windows), len(w))
 			}
+		}
+		if truncated {
+			if verbose {
+				fmt.Fprintf(os.Stderr, "      window[%d/%d] truncated after retry, skipping\n", i+1, len(windows))
+			}
+			continue
 		}
 	}
 

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -649,11 +649,16 @@ func observeWoo(ctx context.Context, client inference.Client, conv *conversation
 			fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, %d chars → %d chars (%s, $%.4f)\n",
 				i+1, len(windows), len(w), len(input), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
 		}
-		if inference.IsTruncated(err) {
-			// Pathological window: still truncated after retry. Skip rather
-			// than aborting the whole conversation.
+		if inference.IsTruncated(err) || inference.IsContextSize(err) {
+			// Pathological window: output truncated after retry, or input
+			// exceeded the model's context window. Skip rather than aborting
+			// the whole conversation.
 			if verbose {
-				fmt.Fprintf(os.Stderr, "      window[%d/%d] truncated after retry, skipping\n", i+1, len(windows))
+				reason := "truncated after retry"
+				if inference.IsContextSize(err) {
+					reason = "exceeded context size"
+				}
+				fmt.Fprintf(os.Stderr, "      window[%d/%d] %s, skipping\n", i+1, len(windows), reason)
 			}
 			continue
 		}
@@ -746,12 +751,16 @@ func observeAdaptive(ctx context.Context, client inference.Client, conv *convers
 		}
 
 		start := time.Now()
-		truncated := false
+		skipReason := ""
 		for j, a := range attempts {
 			obs, usage, err := observeWindow(ctx, client, observePrompt, a.input)
 			totalUsage = totalUsage.Add(usage)
 			if inference.IsTruncated(err) {
-				truncated = true
+				skipReason = "truncated after retry"
+				break
+			}
+			if inference.IsContextSize(err) {
+				skipReason = "exceeded context size"
 				break
 			}
 			if err != nil && obs == "" {
@@ -770,9 +779,9 @@ func observeAdaptive(ctx context.Context, client inference.Client, conv *convers
 					i+1, len(windows), len(w))
 			}
 		}
-		if truncated {
+		if skipReason != "" {
 			if verbose {
-				fmt.Fprintf(os.Stderr, "      window[%d/%d] truncated after retry, skipping\n", i+1, len(windows))
+				fmt.Fprintf(os.Stderr, "      window[%d/%d] %s, skipping\n", i+1, len(windows), skipReason)
 			}
 			continue
 		}

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -1832,12 +1832,28 @@ func runSampleWithObs(ctx context.Context, clusters []clusterResult, allObs []ob
 	for _, cl := range clusters {
 		indices := cl.ObservationIdxs
 
-		// Shuffle for random selection
+		// Prioritize observations with quotes (concrete exemplars), then
+		// shuffle within each group. Quotes carry voice and specificity that
+		// the summarize step can preserve; quoteless observations tend to
+		// produce more abstract summaries.
 		shuffled := make([]int, len(indices))
 		copy(shuffled, indices)
-		rand.Shuffle(len(shuffled), func(i, j int) {
-			shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+		// Partition: quotes first, then non-quotes
+		var withQuote, withoutQuote []int
+		for _, idx := range shuffled {
+			if allObs[idx].Quote != "" {
+				withQuote = append(withQuote, idx)
+			} else {
+				withoutQuote = append(withoutQuote, idx)
+			}
+		}
+		rand.Shuffle(len(withQuote), func(i, j int) {
+			withQuote[i], withQuote[j] = withQuote[j], withQuote[i]
 		})
+		rand.Shuffle(len(withoutQuote), func(i, j int) {
+			withoutQuote[i], withoutQuote[j] = withoutQuote[j], withoutQuote[i]
+		})
+		shuffled = append(withQuote, withoutQuote...)
 
 		var selected []string
 		tokens := 0

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -634,43 +634,60 @@ func observeWoo(ctx context.Context, client inference.Client, conv *conversation
 		observePrompt = prompts.ObserveHuman
 	}
 
+	// Process windows concurrently. Each window observation is independent;
+	// the rate limiter gates actual API calls.
+	type windowResult struct {
+		obs   string
+		usage inference.Usage
+	}
+	results := make([]windowResult, len(windows))
+	var windowErr error
+
+	wg, wctx := errgroup.WithContext(ctx)
+	for i, w := range windows {
+		wg.Go(func() error {
+			// Owner-only: strip assistant text
+			var b strings.Builder
+			for _, t := range w {
+				fmt.Fprintf(&b, "[owner]: %s\n\n", t.humanContent)
+			}
+			input := b.String()
+
+			start := time.Now()
+			obs, usage, err := observeWindow(wctx, client, observePrompt, input)
+			results[i] = windowResult{obs: obs, usage: usage}
+			if verbose {
+				fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, %d chars → %d chars (%s, $%.4f)\n",
+					i+1, len(windows), len(w), len(input), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+			}
+			if inference.IsTruncated(err) || inference.IsContextSize(err) {
+				if verbose {
+					reason := "truncated after retry"
+					if inference.IsContextSize(err) {
+						reason = "exceeded context size"
+					}
+					fmt.Fprintf(os.Stderr, "      window[%d/%d] %s, skipping\n", i+1, len(windows), reason)
+				}
+				return nil // skip this window
+			}
+			if err != nil && obs == "" {
+				return err
+			}
+			return nil
+		})
+	}
+	windowErr = wg.Wait()
+
 	var totalUsage inference.Usage
 	var allCandidates []string
-
-	for i, w := range windows {
-		// Owner-only: strip assistant text
-		var b strings.Builder
-		for _, t := range w {
-			fmt.Fprintf(&b, "[owner]: %s\n\n", t.humanContent)
+	for _, r := range results {
+		totalUsage = totalUsage.Add(r.usage)
+		if r.obs != "" && !isEmpty(r.obs) {
+			allCandidates = append(allCandidates, r.obs)
 		}
-		input := b.String()
-
-		start := time.Now()
-		obs, usage, err := observeWindow(ctx, client, observePrompt, input)
-		totalUsage = totalUsage.Add(usage)
-		if verbose {
-			fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, %d chars → %d chars (%s, $%.4f)\n",
-				i+1, len(windows), len(w), len(input), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
-		}
-		if inference.IsTruncated(err) || inference.IsContextSize(err) {
-			// Pathological window: output truncated after retry, or input
-			// exceeded the model's context window. Skip rather than aborting
-			// the whole conversation.
-			if verbose {
-				reason := "truncated after retry"
-				if inference.IsContextSize(err) {
-					reason = "exceeded context size"
-				}
-				fmt.Fprintf(os.Stderr, "      window[%d/%d] %s, skipping\n", i+1, len(windows), reason)
-			}
-			continue
-		}
-		if err != nil && obs == "" {
-			return nil, totalUsage, err
-		}
-		if obs != "" && !isEmpty(obs) {
-			allCandidates = append(allCandidates, obs)
-		}
+	}
+	if windowErr != nil {
+		return nil, totalUsage, windowErr
 	}
 
 	if len(allCandidates) == 0 {
@@ -730,64 +747,88 @@ func observeAdaptive(ctx context.Context, client inference.Client, conv *convers
 		observePrompt = prompts.ObserveHuman
 	}
 
+	// Process windows concurrently. Each window's woo→default fallback is
+	// sequential (at most 2 calls), but windows are independent.
+	type windowResult struct {
+		obs   string
+		usage inference.Usage
+	}
+	results := make([]windowResult, len(windows))
+	var windowErr error
+
+	wg, wctx := errgroup.WithContext(ctx)
+	for i, w := range windows {
+		wg.Go(func() error {
+			// Build both inputs upfront
+			var wooB strings.Builder
+			for _, t := range w {
+				fmt.Fprintf(&wooB, "[owner]: %s\n\n", t.humanContent)
+			}
+			wooInput := wooB.String()
+
+			chunks := compressConversation(w, conv.Source, humanOverrides)
+			defaultInput := strings.Join(chunks, "\n")
+
+			attempts := []struct {
+				input  string
+				method string
+			}{
+				{wooInput, "woo"},
+				{defaultInput, "default"},
+			}
+
+			start := time.Now()
+			var winUsage inference.Usage
+			for j, a := range attempts {
+				obs, usage, err := observeWindow(wctx, client, observePrompt, a.input)
+				winUsage = winUsage.Add(usage)
+				if inference.IsTruncated(err) {
+					if verbose {
+						fmt.Fprintf(os.Stderr, "      window[%d/%d] truncated after retry, skipping\n", i+1, len(windows))
+					}
+					results[i] = windowResult{usage: winUsage}
+					return nil
+				}
+				if inference.IsContextSize(err) {
+					if verbose {
+						fmt.Fprintf(os.Stderr, "      window[%d/%d] exceeded context size, skipping\n", i+1, len(windows))
+					}
+					results[i] = windowResult{usage: winUsage}
+					return nil
+				}
+				if err != nil && obs == "" {
+					results[i] = windowResult{usage: winUsage}
+					return err
+				}
+				if obs != "" && !isEmpty(obs) {
+					if verbose {
+						fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, %s → %d chars (%s, $%.4f)\n",
+							i+1, len(windows), len(w), a.method, len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+					}
+					results[i] = windowResult{obs: obs, usage: winUsage}
+					return nil
+				}
+				if j == 0 && verbose {
+					fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, woo → NONE, trying default\n",
+						i+1, len(windows), len(w))
+				}
+			}
+			results[i] = windowResult{usage: winUsage}
+			return nil
+		})
+	}
+	windowErr = wg.Wait()
+
 	var totalUsage inference.Usage
 	var allCandidates []string
-
-	for i, w := range windows {
-		// Build both inputs upfront
-		var wooB strings.Builder
-		for _, t := range w {
-			fmt.Fprintf(&wooB, "[owner]: %s\n\n", t.humanContent)
+	for _, r := range results {
+		totalUsage = totalUsage.Add(r.usage)
+		if r.obs != "" && !isEmpty(r.obs) {
+			allCandidates = append(allCandidates, r.obs)
 		}
-		wooInput := wooB.String()
-
-		chunks := compressConversation(w, conv.Source, humanOverrides)
-		defaultInput := strings.Join(chunks, "\n")
-
-		// Try woo first, fall back to default
-		attempts := []struct {
-			input  string
-			method string
-		}{
-			{wooInput, "woo"},
-			{defaultInput, "default"},
-		}
-
-		start := time.Now()
-		skipReason := ""
-		for j, a := range attempts {
-			obs, usage, err := observeWindow(ctx, client, observePrompt, a.input)
-			totalUsage = totalUsage.Add(usage)
-			if inference.IsTruncated(err) {
-				skipReason = "truncated after retry"
-				break
-			}
-			if inference.IsContextSize(err) {
-				skipReason = "exceeded context size"
-				break
-			}
-			if err != nil && obs == "" {
-				return nil, totalUsage, err
-			}
-			if obs != "" && !isEmpty(obs) {
-				if verbose {
-					fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, %s → %d chars (%s, $%.4f)\n",
-						i+1, len(windows), len(w), a.method, len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
-				}
-				allCandidates = append(allCandidates, obs)
-				break
-			}
-			if j == 0 && verbose {
-				fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, woo → NONE, trying default\n",
-					i+1, len(windows), len(w))
-			}
-		}
-		if skipReason != "" {
-			if verbose {
-				fmt.Fprintf(os.Stderr, "      window[%d/%d] %s, skipping\n", i+1, len(windows), skipReason)
-			}
-			continue
-		}
+	}
+	if windowErr != nil {
+		return nil, totalUsage, windowErr
 	}
 
 	if len(allCandidates) == 0 {

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -629,15 +629,16 @@ func observeWoo(ctx context.Context, client inference.Client, conv *conversation
 	return relevant, totalUsage, nil
 }
 
-// adaptiveThreshold is the average owner message length (in chars) below which
-// woo (owner-only) is used. At or above this, default (with assistant) is used.
-// Derived from featurize across 1054 windows: woo wins 1.5-1.9x below 300,
-// default wins ~2x above 600, wash in between.
-const adaptiveThreshold = 300
-
-// observeAdaptive runs windowed observation, picking the likely-better method
-// per window based on average owner message length. If the first method returns
-// NONE, falls back to the other. At most 2 calls per window.
+// observeAdaptive runs windowed observation, trying woo (owner-only) first
+// on each window and falling back to default (with assistant) on NONE. At most
+// 2 calls per window.
+//
+// Featurize data showed avg owner message length doesn't cleanly separate
+// which method wins — the distributions overlap. But woo-first with fallback
+// captures 557 total observations vs 492 for default-first, because woo
+// produces richer output when both methods find signal. The fallback is cheap
+// (NONE windows cost ~4 output tokens) and catches the 63 windows where only
+// default finds signal.
 func observeAdaptive(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, humanOverrides map[string]bool) ([]Observation, inference.Usage, error) {
 	turns := extractTurns(conv, humanOverrides)
 	if len(turns) == 0 {
@@ -659,14 +660,7 @@ func observeAdaptive(ctx context.Context, client inference.Client, conv *convers
 	var allCandidates []string
 
 	for i, w := range windows {
-		// Compute average owner message length for this window
-		var totalOwner int
-		for _, t := range w {
-			totalOwner += len(t.humanContent)
-		}
-		avgOwner := totalOwner / len(w)
-
-		// Build both inputs
+		// Build both inputs upfront
 		var wooB strings.Builder
 		for _, t := range w {
 			fmt.Fprintf(&wooB, "[owner]: %s\n\n", t.humanContent)
@@ -676,20 +670,17 @@ func observeAdaptive(ctx context.Context, client inference.Client, conv *convers
 		chunks := compressConversation(w, conv.Source, humanOverrides)
 		defaultInput := strings.Join(chunks, "\n")
 
-		// Pick order based on threshold
-		type attempt struct {
+		// Try woo first, fall back to default
+		attempts := []struct {
 			input  string
 			method string
-		}
-		var attempts []attempt
-		if avgOwner < adaptiveThreshold {
-			attempts = []attempt{{wooInput, "woo"}, {defaultInput, "default"}}
-		} else {
-			attempts = []attempt{{defaultInput, "default"}, {wooInput, "woo"}}
+		}{
+			{wooInput, "woo"},
+			{defaultInput, "default"},
 		}
 
 		start := time.Now()
-		for _, a := range attempts {
+		for j, a := range attempts {
 			obs, usage, err := inference.Converse(ctx, client, observePrompt, a.input, inference.WithMaxTokens(4096))
 			totalUsage = totalUsage.Add(usage)
 			if err != nil && obs == "" {
@@ -697,21 +688,16 @@ func observeAdaptive(ctx context.Context, client inference.Client, conv *convers
 			}
 			if obs != "" && !isEmpty(obs) {
 				if verbose {
-					fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, avg %d chars, %s → %d chars (%s, $%.4f)\n",
-						i+1, len(windows), len(w), avgOwner, a.method, len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+					fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, %s → %d chars (%s, $%.4f)\n",
+						i+1, len(windows), len(w), a.method, len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
 				}
 				allCandidates = append(allCandidates, obs)
 				break
 			}
-			// First method returned NONE, try fallback
-			if verbose && a.method == attempts[0].method {
-				fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, avg %d chars, %s → NONE, trying %s\n",
-					i+1, len(windows), len(w), avgOwner, a.method, attempts[1].method)
+			if j == 0 && verbose {
+				fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, woo → NONE, trying default\n",
+					i+1, len(windows), len(w))
 			}
-		}
-		// Both returned NONE — log it
-		if verbose && len(allCandidates) == 0 || (len(allCandidates) > 0 && allCandidates[len(allCandidates)-1] == "") {
-			// already logged above
 		}
 	}
 

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -635,8 +635,9 @@ func observeWoo(ctx context.Context, client inference.Client, conv *conversation
 // default wins ~2x above 600, wash in between.
 const adaptiveThreshold = 300
 
-// observeAdaptive runs windowed observation, choosing woo or default framing
-// per window based on average owner message length.
+// observeAdaptive runs windowed observation, picking the likely-better method
+// per window based on average owner message length. If the first method returns
+// NONE, falls back to the other. At most 2 calls per window.
 func observeAdaptive(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, humanOverrides map[string]bool) ([]Observation, inference.Usage, error) {
 	turns := extractTurns(conv, humanOverrides)
 	if len(turns) == 0 {
@@ -665,36 +666,52 @@ func observeAdaptive(ctx context.Context, client inference.Client, conv *convers
 		}
 		avgOwner := totalOwner / len(w)
 
-		// Pick framing based on threshold
-		var input string
-		var method string
+		// Build both inputs
+		var wooB strings.Builder
+		for _, t := range w {
+			fmt.Fprintf(&wooB, "[owner]: %s\n\n", t.humanContent)
+		}
+		wooInput := wooB.String()
+
+		chunks := compressConversation(w, conv.Source, humanOverrides)
+		defaultInput := strings.Join(chunks, "\n")
+
+		// Pick order based on threshold
+		type attempt struct {
+			input  string
+			method string
+		}
+		var attempts []attempt
 		if avgOwner < adaptiveThreshold {
-			// Woo: owner-only
-			var b strings.Builder
-			for _, t := range w {
-				fmt.Fprintf(&b, "[owner]: %s\n\n", t.humanContent)
-			}
-			input = b.String()
-			method = "woo"
+			attempts = []attempt{{wooInput, "woo"}, {defaultInput, "default"}}
 		} else {
-			// Default: compressed with assistant context
-			chunks := compressConversation(w, conv.Source, humanOverrides)
-			input = strings.Join(chunks, "\n")
-			method = "default"
+			attempts = []attempt{{defaultInput, "default"}, {wooInput, "woo"}}
 		}
 
 		start := time.Now()
-		obs, usage, err := inference.Converse(ctx, client, observePrompt, input, inference.WithMaxTokens(4096))
-		totalUsage = totalUsage.Add(usage)
-		if verbose {
-			fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, avg %d chars, %s → %d chars (%s, $%.4f)\n",
-				i+1, len(windows), len(w), avgOwner, method, len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+		for _, a := range attempts {
+			obs, usage, err := inference.Converse(ctx, client, observePrompt, a.input, inference.WithMaxTokens(4096))
+			totalUsage = totalUsage.Add(usage)
+			if err != nil && obs == "" {
+				return nil, totalUsage, err
+			}
+			if obs != "" && !isEmpty(obs) {
+				if verbose {
+					fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, avg %d chars, %s → %d chars (%s, $%.4f)\n",
+						i+1, len(windows), len(w), avgOwner, a.method, len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+				}
+				allCandidates = append(allCandidates, obs)
+				break
+			}
+			// First method returned NONE, try fallback
+			if verbose && a.method == attempts[0].method {
+				fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, avg %d chars, %s → NONE, trying %s\n",
+					i+1, len(windows), len(w), avgOwner, a.method, attempts[1].method)
+			}
 		}
-		if err != nil && obs == "" {
-			return nil, totalUsage, err
-		}
-		if obs != "" && !isEmpty(obs) {
-			allCandidates = append(allCandidates, obs)
+		// Both returned NONE — log it
+		if verbose && len(allCandidates) == 0 || (len(allCandidates) > 0 && allCandidates[len(allCandidates)-1] == "") {
+			// already logged above
 		}
 	}
 

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -300,6 +300,12 @@ func RunClustered(
 	)
 	muse = metadata + muse
 
+	// Re-save with metadata prepended
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+	if err := store.PutMuse(ctx, timestamp, muse); err != nil {
+		return nil, fmt.Errorf("failed to write muse with metadata: %w", err)
+	}
+
 	// ── DONE ────────────────────────────────────────────────────────────
 	logStage("done", "%d patterns → muse.md", len(clusters)).
 		Cost(time.Since(pipelineStart), totalUsage.Cost()).Print()

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -51,6 +51,19 @@ type HitMiss struct {
 	Miss int
 }
 
+// ObserveMode controls the observation strategy for conversations.
+type ObserveMode string
+
+const (
+	// ObserveDefault compresses the full conversation and observes in chunks.
+	ObserveDefault ObserveMode = ""
+	// ObserveWoo (windowed owner-only) slides an 8-turn window across the
+	// conversation, strips assistant text from each window, and observes each
+	// window independently. Produces more distinct insights at higher grounding
+	// rate than the default, at lower token cost per window.
+	ObserveWoo ObserveMode = "woo"
+)
+
 // BaseOptions contains fields shared across all compose strategies.
 type BaseOptions struct {
 	// Reobserve ignores persisted observations and re-observes all conversations.
@@ -59,6 +72,8 @@ type BaseOptions struct {
 	Limit int
 	// Verbose enables per-item progress logging.
 	Verbose bool
+	// Observe controls the observation strategy.
+	Observe ObserveMode
 }
 
 // Options configures a map-reduce compose run.

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -78,6 +78,9 @@ type BaseOptions struct {
 	Verbose bool
 	// Observe controls the observation strategy.
 	Observe ObserveMode
+	// SkipObserve skips the observe step and composes from existing observations.
+	// Used for derived/filtered observation sets that were written externally.
+	SkipObserve bool
 }
 
 // Options configures a map-reduce compose run.

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -62,6 +62,10 @@ const (
 	// window independently. Produces more distinct insights at higher grounding
 	// rate than the default, at lower token cost per window.
 	ObserveWoo ObserveMode = "woo"
+	// ObserveAdaptive checks average owner message length per window and picks
+	// woo (owner-only) below the threshold or default (with assistant) above it.
+	// One observe call per window, same cost as either single strategy.
+	ObserveAdaptive ObserveMode = "adaptive"
 )
 
 // BaseOptions contains fields shared across all compose strategies.

--- a/internal/compose/featurize.go
+++ b/internal/compose/featurize.go
@@ -1,0 +1,128 @@
+package compose
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ellistarn/muse/internal/conversation"
+	"github.com/ellistarn/muse/internal/inference"
+	"github.com/ellistarn/muse/prompts"
+)
+
+// WindowFeatures records observation results and input features for a single
+// window of a single conversation. Used to build a dataset for predicting
+// which observation strategy works best.
+type WindowFeatures struct {
+	Source         string `json:"source"`
+	ConversationID string `json:"conversation_id"`
+	Window         int    `json:"window"`
+	TurnCount      int    `json:"turns"`
+	AvgOwnerChars  int    `json:"avg_owner_chars"`
+	MaxOwnerChars  int    `json:"max_owner_chars"`
+	TotalOwnerChars int   `json:"total_owner_chars"`
+	AvgAssistChars int    `json:"avg_assist_chars"`
+	TotalChars     int    `json:"total_chars"`
+	DefaultObs     int    `json:"default_obs"`
+	WooObs         int    `json:"woo_obs"`
+	DefaultCost    float64 `json:"default_cost"`
+	WooCost        float64 `json:"woo_cost"`
+}
+
+// FeaturizeConversation runs both default (windowed-with-assistant) and woo
+// (windowed-owner-only) on each window of a conversation, returning per-window
+// features and observation counts.
+func FeaturizeConversation(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool) ([]WindowFeatures, inference.Usage, error) {
+	turns := extractTurns(conv, nil)
+	if len(turns) == 0 {
+		return nil, inference.Usage{}, nil
+	}
+
+	windows := buildWindows(turns, windowSize, windowStride)
+
+	observePrompt := prompts.Observe
+	if isHumanSource(conv.Source, nil) {
+		observePrompt = prompts.ObserveHuman
+	}
+
+	var totalUsage inference.Usage
+	var features []WindowFeatures
+
+	for i, w := range windows {
+		f := WindowFeatures{
+			Source:         conv.Source,
+			ConversationID: conv.ConversationID,
+			Window:         i,
+			TurnCount:      len(w),
+		}
+
+		// Compute input features
+		var maxOwner, totalOwner, totalAssist int
+		for _, t := range w {
+			n := len(t.humanContent)
+			totalOwner += n
+			if n > maxOwner {
+				maxOwner = n
+			}
+			totalAssist += len(t.assistantContent)
+		}
+		f.AvgOwnerChars = totalOwner / len(w)
+		f.MaxOwnerChars = maxOwner
+		f.TotalOwnerChars = totalOwner
+		f.AvgAssistChars = totalAssist / len(w)
+		f.TotalChars = totalOwner + totalAssist
+
+		// Default: compressed with assistant context
+		defaultInput := compressWindow(w, conv.Source)
+		start := time.Now()
+		defaultRaw, defaultUsage, err := inference.Converse(ctx, client, observePrompt, defaultInput, inference.WithMaxTokens(4096))
+		totalUsage = totalUsage.Add(defaultUsage)
+		f.DefaultCost = defaultUsage.Cost()
+		if err == nil && defaultRaw != "" && !isEmpty(defaultRaw) {
+			items := parseObservationItems(defaultRaw)
+			for _, item := range items {
+				if isRelevant(item.Text) {
+					f.DefaultObs++
+				}
+			}
+		}
+
+		// Woo: owner-only
+		var b strings.Builder
+		for _, t := range w {
+			fmt.Fprintf(&b, "[owner]: %s\n\n", t.humanContent)
+		}
+		wooInput := b.String()
+		wooRaw, wooUsage, err := inference.Converse(ctx, client, observePrompt, wooInput, inference.WithMaxTokens(4096))
+		totalUsage = totalUsage.Add(wooUsage)
+		f.WooCost = wooUsage.Cost()
+		if err == nil && wooRaw != "" && !isEmpty(wooRaw) {
+			items := parseObservationItems(wooRaw)
+			for _, item := range items {
+				if isRelevant(item.Text) {
+					f.WooObs++
+				}
+			}
+		}
+
+		if verbose {
+			fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, avg %d chars → default:%d woo:%d (%s)\n",
+				i+1, len(windows), len(w), f.AvgOwnerChars, f.DefaultObs, f.WooObs,
+				time.Since(start).Round(time.Millisecond))
+		}
+
+		features = append(features, f)
+	}
+
+	return features, totalUsage, nil
+}
+
+// compressWindow compresses a single window of turns into text for the
+// default observe prompt. Uses the same compression as compressConversation
+// but returns a single string.
+func compressWindow(turns []turn, source string) string {
+	chunks := compressConversation(turns, source, nil)
+	return strings.Join(chunks, "\n")
+}

--- a/internal/compose/observe_window_test.go
+++ b/internal/compose/observe_window_test.go
@@ -1,0 +1,138 @@
+package compose
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ellistarn/muse/internal/conversation"
+	"github.com/ellistarn/muse/internal/inference"
+)
+
+// scriptedLLM is a minimal inference.Client that returns a sequence of
+// (text, error) responses across calls. Used to script truncation behavior
+// in retry tests.
+type scriptedLLM struct {
+	mu        sync.Mutex
+	responses []scriptedResponse
+	calls     atomic.Int32
+}
+
+type scriptedResponse struct {
+	text string
+	err  error
+}
+
+func (m *scriptedLLM) ConverseMessages(_ context.Context, _ string, _ []inference.Message, _ ...inference.ConverseOption) (*inference.Response, error) {
+	idx := int(m.calls.Add(1)) - 1
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if idx >= len(m.responses) {
+		return &inference.Response{}, nil
+	}
+	r := m.responses[idx]
+	return &inference.Response{Text: r.text, Usage: inference.Usage{}}, r.err
+}
+
+func (m *scriptedLLM) ConverseMessagesStream(ctx context.Context, system string, messages []inference.Message, _ inference.StreamFunc, opts ...inference.ConverseOption) (*inference.Response, error) {
+	return m.ConverseMessages(ctx, system, messages, opts...)
+}
+
+func (m *scriptedLLM) Model() string { return "scripted" }
+
+// twoTurnConversation builds a minimal conversation with two user turns
+// (the minimum for AI sources to pass extractTurns) so observeWoo produces a
+// single window with one observe call (plus refine when observations exist).
+func twoTurnConversation() *conversation.Conversation {
+	return &conversation.Conversation{
+		Source: "test",
+		Messages: []conversation.Message{
+			{Role: "user", Content: "the owner says something distinctive"},
+			{Role: "assistant", Content: "ack"},
+			{Role: "user", Content: "and follows up with another distinctive thing"},
+			{Role: "assistant", Content: "ack"},
+		},
+	}
+}
+
+func TestObserveWindowRetriesOnTruncation(t *testing.T) {
+	mock := &scriptedLLM{
+		responses: []scriptedResponse{
+			{text: "", err: &inference.TruncatedError{OutputTokens: windowObserveBudget}},
+			{text: "Observation: distinctive thinking pattern\n", err: nil},
+		},
+	}
+
+	obs, _, err := observeWindow(context.Background(), mock, "prompt", "input")
+	if err != nil {
+		t.Fatalf("observeWindow returned error: %v", err)
+	}
+	if obs == "" {
+		t.Errorf("expected observations after retry, got empty")
+	}
+	if got, want := mock.calls.Load(), int32(2); got != want {
+		t.Errorf("call count = %d, want %d (initial + retry)", got, want)
+	}
+}
+
+func TestObserveWindowReturnsTruncationAfterRetryFails(t *testing.T) {
+	mock := &scriptedLLM{
+		responses: []scriptedResponse{
+			{text: "", err: &inference.TruncatedError{OutputTokens: windowObserveBudget}},
+			{text: "", err: &inference.TruncatedError{OutputTokens: windowObserveRetryBudget}},
+		},
+	}
+
+	_, _, err := observeWindow(context.Background(), mock, "prompt", "input")
+	if !inference.IsTruncated(err) {
+		t.Errorf("expected TruncatedError after persistent truncation, got %v", err)
+	}
+	if got, want := mock.calls.Load(), int32(2); got != want {
+		t.Errorf("call count = %d, want %d (no third attempt)", got, want)
+	}
+}
+
+func TestObserveWindowDoesNotRetryOnNonTruncationError(t *testing.T) {
+	mock := &scriptedLLM{
+		responses: []scriptedResponse{
+			{text: "", err: &nonTruncationError{}},
+		},
+	}
+
+	_, _, err := observeWindow(context.Background(), mock, "prompt", "input")
+	if err == nil {
+		t.Fatal("expected non-truncation error to propagate, got nil")
+	}
+	if got, want := mock.calls.Load(), int32(1); got != want {
+		t.Errorf("call count = %d, want %d (no retry for non-truncation errors)", got, want)
+	}
+}
+
+func TestObserveWooSkipsWindowOnPersistentTruncation(t *testing.T) {
+	// Verifies the integration: observeWoo treats a persistently-truncated
+	// window as a skip rather than aborting the conversation. Mock script:
+	// initial truncates, retry truncates → window skipped → no candidates
+	// → observeWoo returns nil with no error and no refine call.
+	mock := &scriptedLLM{
+		responses: []scriptedResponse{
+			{text: "", err: &inference.TruncatedError{OutputTokens: windowObserveBudget}},
+			{text: "", err: &inference.TruncatedError{OutputTokens: windowObserveRetryBudget}},
+		},
+	}
+
+	obs, _, err := observeWoo(context.Background(), mock, twoTurnConversation(), false, nil)
+	if err != nil {
+		t.Fatalf("observeWoo returned error on skip-after-retry: %v", err)
+	}
+	if got, want := mock.calls.Load(), int32(2); got != want {
+		t.Errorf("call count = %d, want %d (initial + retry, no refine because no candidates)", got, want)
+	}
+	if len(obs) != 0 {
+		t.Errorf("expected no observations when sole window skipped, got %d", len(obs))
+	}
+}
+
+type nonTruncationError struct{}
+
+func (e *nonTruncationError) Error() string { return "non-truncation network error" }

--- a/internal/compose/observe_window_test.go
+++ b/internal/compose/observe_window_test.go
@@ -109,6 +109,50 @@ func TestObserveWindowDoesNotRetryOnNonTruncationError(t *testing.T) {
 	}
 }
 
+func TestObserveWooSkipsWindowOnContextSizeError(t *testing.T) {
+	// Pathological window with input too big for the model's context window.
+	// observeWindow doesn't retry (retry only helps for output truncation).
+	// observeWoo should skip rather than abort.
+	mock := &scriptedLLM{
+		responses: []scriptedResponse{
+			{text: "", err: &inference.ContextSizeError{PromptTokens: 23956, ContextSize: 16384}},
+		},
+	}
+
+	obs, _, err := observeWoo(context.Background(), mock, twoTurnConversation(), false, nil)
+	if err != nil {
+		t.Fatalf("observeWoo returned error on context-size skip: %v", err)
+	}
+	if got, want := mock.calls.Load(), int32(1); got != want {
+		t.Errorf("call count = %d, want %d (no retry on context-size; no refine because no candidates)", got, want)
+	}
+	if len(obs) != 0 {
+		t.Errorf("expected no observations when sole window skipped, got %d", len(obs))
+	}
+}
+
+func TestObserveAdaptiveSkipsWindowOnContextSizeError(t *testing.T) {
+	// Adaptive's per-window two-attempt loop should also skip on context-size
+	// errors so a single pathological owner-paste doesn't abort the whole
+	// conversation.
+	mock := &scriptedLLM{
+		responses: []scriptedResponse{
+			{text: "", err: &inference.ContextSizeError{PromptTokens: 23956, ContextSize: 16384}},
+		},
+	}
+
+	obs, _, err := observeAdaptive(context.Background(), mock, twoTurnConversation(), false, nil)
+	if err != nil {
+		t.Fatalf("observeAdaptive returned error on context-size skip: %v", err)
+	}
+	if got, want := mock.calls.Load(), int32(1); got != want {
+		t.Errorf("call count = %d, want %d (skip on first attempt's context-size; no fallback)", got, want)
+	}
+	if len(obs) != 0 {
+		t.Errorf("expected no observations when sole window skipped, got %d", len(obs))
+	}
+}
+
 func TestObserveWooSkipsWindowOnPersistentTruncation(t *testing.T) {
 	// Verifies the integration: observeWoo treats a persistently-truncated
 	// window as a skip rather than aborting the conversation. Mock script:

--- a/internal/inference/client.go
+++ b/internal/inference/client.go
@@ -35,6 +35,29 @@ func IsTruncated(err error) bool {
 	return errors.As(err, &te)
 }
 
+// ContextSizeError indicates the request prompt did not fit in the model's
+// context window. Distinct from TruncatedError, which is about output budget.
+// Pathological windows in compose/observe pipelines should usually skip on
+// this rather than abort the whole conversation.
+type ContextSizeError struct {
+	PromptTokens int // tokens in the rejected prompt, if known (0 otherwise)
+	ContextSize  int // server's configured context window, if known (0 otherwise)
+}
+
+func (e *ContextSizeError) Error() string {
+	if e.PromptTokens > 0 && e.ContextSize > 0 {
+		return fmt.Sprintf("prompt (%d tokens) exceeds context size (%d tokens)", e.PromptTokens, e.ContextSize)
+	}
+	return "prompt exceeds context size"
+}
+
+// IsContextSize reports whether err indicates the prompt did not fit in the
+// model's context window.
+func IsContextSize(err error) bool {
+	var ce *ContextSizeError
+	return errors.As(err, &ce)
+}
+
 // Client is the inference interface. Providers implement multi-turn
 // conversation with optional streaming. Single-turn callers use the
 // Converse/ConverseStream free functions.

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/openai/openai-go"
@@ -107,6 +109,9 @@ func (c *Client) ConverseMessages(ctx context.Context, system string, messages [
 	err := throttle.Retry(ctx, c.limiter, throttle.DefaultRetryConfig(), isThrottled, func() error {
 		completion, err := c.client.Chat.Completions.New(ctx, params)
 		if err != nil {
+			if cse, ok := classifyContextSizeError(err); ok {
+				return cse
+			}
 			return fmt.Errorf("openai chat.completions.new: %w", err)
 		}
 
@@ -167,6 +172,9 @@ func (c *Client) ConverseMessagesStream(ctx context.Context, system string, mess
 		}
 
 		if err := stream.Err(); err != nil {
+			if cse, ok := classifyContextSizeError(err); ok {
+				return cse
+			}
 			return fmt.Errorf("openai stream: %w", err)
 		}
 
@@ -186,6 +194,41 @@ func isThrottled(err error) bool {
 	return strings.Contains(err.Error(), fmt.Sprintf("%d", http.StatusTooManyRequests)) ||
 		strings.Contains(err.Error(), "rate_limit")
 }
+
+// classifyContextSizeError detects errors indicating the prompt did not fit
+// the model's context window and returns a typed inference.ContextSizeError.
+// Recognized patterns:
+//   - llama.cpp: "exceeds the available context size" with type "exceed_context_size_error"
+//     and JSON fields n_prompt_tokens / n_ctx
+//   - OpenAI cloud: "context_length_exceeded" or "maximum context length"
+//
+// Returns (nil, false) if the error doesn't match any known context-size pattern.
+func classifyContextSizeError(err error) (*inference.ContextSizeError, bool) {
+	msg := err.Error()
+	if !strings.Contains(msg, "exceed_context_size") &&
+		!strings.Contains(msg, "exceeds the available context size") &&
+		!strings.Contains(msg, "context_length_exceeded") &&
+		!strings.Contains(msg, "maximum context length") {
+		return nil, false
+	}
+	cse := &inference.ContextSizeError{}
+	if m := contextSizePromptRe.FindStringSubmatch(msg); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			cse.PromptTokens = n
+		}
+	}
+	if m := contextSizeCtxRe.FindStringSubmatch(msg); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			cse.ContextSize = n
+		}
+	}
+	return cse, true
+}
+
+var (
+	contextSizePromptRe = regexp.MustCompile(`"n_prompt_tokens"\s*:\s*(\d+)`)
+	contextSizeCtxRe    = regexp.MustCompile(`"n_ctx"\s*:\s*(\d+)`)
+)
 
 func (c *Client) buildParams(system string, messages []inference.Message, opts inference.ConverseOptions) openai.ChatCompletionNewParams {
 	maxTokens := int64(inference.DefaultMaxTokens)

--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"errors"
 	"testing"
 
 	sdkopenai "github.com/openai/openai-go"
@@ -37,5 +38,44 @@ func TestBuildParamsSetsReasoningEffortForReasoningModels(t *testing.T) {
 	}
 	if got, want := params.MaxCompletionTokens.Value, int64(inference.DefaultMaxTokens+8000); got != want {
 		t.Fatalf("MaxCompletionTokens = %d, want %d", got, want)
+	}
+}
+
+func TestClassifyContextSizeErrorLlamaCpp(t *testing.T) {
+	// llama.cpp's HTTP 400 body shape (the actual error the user hit).
+	raw := errors.New(`POST "http://127.0.0.1:8080/v1/chat/completions": 400 Bad Request {"code":400,"message":"request (23956 tokens) exceeds the available context size (16384 tokens), try increasing it","type":"exceed_context_size_error","n_prompt_tokens":23956,"n_ctx":16384}`)
+	cse, ok := classifyContextSizeError(raw)
+	if !ok {
+		t.Fatalf("expected llama.cpp context-size error to classify; raw: %v", raw)
+	}
+	if got, want := cse.PromptTokens, 23956; got != want {
+		t.Errorf("PromptTokens = %d, want %d", got, want)
+	}
+	if got, want := cse.ContextSize, 16384; got != want {
+		t.Errorf("ContextSize = %d, want %d", got, want)
+	}
+}
+
+func TestClassifyContextSizeErrorOpenAI(t *testing.T) {
+	raw := errors.New(`This model's maximum context length is 8192 tokens, however you requested 12000 tokens (context_length_exceeded)`)
+	cse, ok := classifyContextSizeError(raw)
+	if !ok {
+		t.Fatalf("expected OpenAI-style context-size error to classify; raw: %v", raw)
+	}
+	// OpenAI's text doesn't carry the JSON fields, so token counts default to 0.
+	if cse.PromptTokens != 0 || cse.ContextSize != 0 {
+		t.Errorf("expected zero token fields when not parseable; got PromptTokens=%d ContextSize=%d", cse.PromptTokens, cse.ContextSize)
+	}
+}
+
+func TestClassifyContextSizeErrorIgnoresUnrelated(t *testing.T) {
+	for _, msg := range []string{
+		"connection refused",
+		"401 Unauthorized",
+		"response truncated: hit max token limit (4096 output tokens)",
+	} {
+		if _, ok := classifyContextSizeError(errors.New(msg)); ok {
+			t.Errorf("classifyContextSizeError matched unrelated error: %q", msg)
+		}
 	}
 }

--- a/prompts/summarize.md
+++ b/prompts/summarize.md
@@ -2,7 +2,7 @@ Summarize these related observations about a person's thinking into a concise fi
 
 Some observations include verbatim quotes from the person. These quotes carry voice — register, phrasing, how conviction and uncertainty land. Let the quotes calibrate how the summary sounds. The summary should read like this person wrote it, not like a clinical description of them.
 
-If the cluster contains observations with quotes, include at least one verbatim quote in the summary. The quote should anchor a concrete behavioral example — a specific moment where the person applied the pattern. Abstract principles without concrete instances produce generic summaries that could describe anyone.
+If the cluster contains observations with quotes, summarize the pattern first, then include one or two verbatim quotes that illustrate the pattern in action. The summary tells the reader what the person does. The quotes show them doing it.
 
 Observations carry dates. Note the temporal range — a pattern appearing across years is more durable than one appearing only recently or only in the past. If all observations in a cluster are old with no recent instances, flag that in your summary.
 

--- a/prompts/summarize.md
+++ b/prompts/summarize.md
@@ -2,6 +2,8 @@ Summarize these related observations about a person's thinking into a concise fi
 
 Some observations include verbatim quotes from the person. These quotes carry voice — register, phrasing, how conviction and uncertainty land. Let the quotes calibrate how the summary sounds. The summary should read like this person wrote it, not like a clinical description of them.
 
+If the cluster contains observations with quotes, include at least one verbatim quote in the summary. The quote should anchor a concrete behavioral example — a specific moment where the person applied the pattern. Abstract principles without concrete instances produce generic summaries that could describe anyone.
+
 Observations carry dates. Note the temporal range — a pattern appearing across years is more durable than one appearing only recently or only in the past. If all observations in a cluster are old with no recent instances, flag that in your summary.
 
 Distill to the most accurate claim, not the punchiest one. Prefer precision over assertiveness — a nuanced position with a real tension acknowledged is more valuable than a confident-sounding slogan. If the cluster contains multiple genuinely distinct claims, keep each as a separate sentence.


### PR DESCRIPTION
## Summary

The default observation pipeline fails on long conversations — full-context single-pass observation loses early signal under later mechanical turns. This PR adds windowed observation strategies (woo, adaptive) and fixes the composition pipeline to preserve specificity from the additional observations.

**Observation strategies (design 013):**
- Woo: 8-turn sliding window, owner-only text, stride 4. Skips assistant output that competes for attention without contributing to owner reasoning signal.
- Adaptive: tries woo first per window, falls back to default (with assistant) when woo returns NONE. At most 2 calls per window.
- Per-window retry on output truncation (4096 → 16384 tokens). Skip on persistent truncation or context-size overflow.
- Windows processed concurrently within each conversation via nested errgroup. The AIMD rate limiter gates actual API calls.

**Composition fixes (design 014):**
- Quote-prioritized sampling: quoted observations fill the cluster budget first.
- Exemplar prompt: summarize step asked to produce pattern-then-quote structure.
- Quality gate: `muse judge --filter` rates observations as grounded/generic/misleading, filters to grounded-only before composition.

**Edge case fix:**
- When all observations land as outliers (0 clusters), return a clear error instead of sending an empty string to Bedrock.

**Results on 553-conversation corpus:**

| | Default | Adaptive |
|---|---|---|
| Observations | 77 | 678 |
| Clusters | 11 | 25 |
| Cost | ~$6 | ~$25 |

Costs increase by about 4x, and the quality feels better too — more specificity, more of the owner's actual words preserved, broader coverage of distinct behavioral patterns.

## Test plan

- [x] `go test ./...` passes (except pre-existing e2e/TestClustered_* failures on main)
- [x] Lima VM: `--limit 1` exits cleanly with helpful error (0-cluster case)
- [x] Lima VM: `--limit 5` runs full pipeline end-to-end
- [x] Lima VM: full corpus adaptive compose produces muse.md
- [x] Parallel windows: 10 conversations observed in 19.8s vs 127.6s sequential

## Follow-up

- Integrate paper's grounding eval method into `muse eval` so observation quality is tested automatically, not manually.
- Single-command adaptive-filtered compose (currently 3 commands: compose, judge --filter, compose --skip-observe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)