### PR TITLE
feat: windowed observation strategies (woo, adaptive)

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -25,6 +25,7 @@ func newComposeCmd() *cobra.Command {
 	var learn bool
 	var limit int
 	var method string
+	var observeMode string
 	cmd := &cobra.Command{
 		Use:   "compose",
 		Short: "Compose a muse from conversations",
@@ -87,7 +88,7 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 
 			switch method {
 			case "clustering":
-				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, limit, uploaded, uploadBytes)
+				return runClusteredCompose(ctx, cmd.OutOrStdout(), store, reobserve, relabel, compose.ObserveMode(observeMode), limit, uploaded, uploadBytes)
 			case "map-reduce":
 				return runMapReduceCompose(ctx, cmd.OutOrStdout(), store, reobserve, learn, limit)
 			default:
@@ -100,10 +101,11 @@ reprocessing conversations. Use --reobserve to reprocess conversations from scra
 	cmd.Flags().BoolVar(&learn, "learn", false, "skip observe, recompose muse from existing observations (map-reduce only)")
 	cmd.Flags().IntVar(&limit, "limit", 0, "max conversations to observe per run (0 = no limit)")
 	cmd.Flags().StringVar(&method, "method", "clustering", "composition method: clustering or map-reduce")
+	cmd.Flags().StringVar(&observeMode, "observe-mode", "", "observation strategy: '' (default), 'woo' (windowed owner-only), 'adaptive' (picks per window)")
 	return cmd
 }
 
-func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel bool, limit, uploaded, uploadBytes int) error {
+func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.Store, reobserve, relabel bool, mode compose.ObserveMode, limit, uploaded, uploadBytes int) error {
 	observeLLM, err := newLLMClient(ctx, TierFast)
 	if err != nil {
 		return err
@@ -121,8 +123,9 @@ func runClusteredCompose(ctx context.Context, stdout io.Writer, store storage.St
 		compose.ClusteredOptions{
 			BaseOptions: compose.BaseOptions{
 				Reobserve: reobserve,
-				Limit:     limit,
-				Verbose:   verbose,
+				Limit:    limit,
+				Verbose:  verbose,
+				Observe:  mode,
 			},
 			Relabel:     relabel,
 			Uploaded:    uploaded,

--- a/internal/compose/artifacts.go
+++ b/internal/compose/artifacts.go
@@ -9,12 +9,15 @@ import (
 	"github.com/ellistarn/muse/internal/storage"
 )
 
-// Artifact path conventions. Observations are shared across all strategies and
-// stored at the top level. Strategy-specific derived artifacts live under
-// "compose/". All paths use the Store's generic PutData/GetData/ListData methods.
+// Artifact path conventions. Observations are stored per observe-mode so
+// different strategies can coexist without clobbering each other. The default
+// mode ("") stores at the top level for backward compatibility. Named modes
+// store under observations/{mode}/. Strategy-specific derived artifacts live
+// under "compose/".
 //
-// Shared:
-//   observations/{source}/{conversationID}.json
+// Observations:
+//   observations/{source}/{conversationID}.json              (default mode)
+//   observations/{mode}/{source}/{conversationID}.json       (named modes)
 //
 // Clustering-specific:
 //   compose/labels/{source}/{conversationID}.json
@@ -31,21 +34,37 @@ func composePath(kind, source, conversationID string) string {
 	return fmt.Sprintf("compose/%s/%s/%s.json", kind, source, conversationID)
 }
 
-// observationPath returns the key for a shared observation artifact.
-func observationPath(source, conversationID string) string {
-	return fmt.Sprintf("observations/%s/%s.json", source, conversationID)
+// observationPath returns the key for an observation artifact. Named modes
+// get their own directory so different strategies don't clobber each other.
+func observationPath(source, conversationID string, mode ...ObserveMode) string {
+	m := ObserveDefault
+	if len(mode) > 0 {
+		m = mode[0]
+	}
+	if m == "" || m == ObserveDefault {
+		return fmt.Sprintf("observations/%s/%s.json", source, conversationID)
+	}
+	return fmt.Sprintf("observations/%s/%s/%s.json", string(m), source, conversationID)
+}
+
+// observationDirPrefix returns the storage prefix for listing/deleting observations.
+func observationDirPrefix(mode ObserveMode) string {
+	if mode == "" || mode == ObserveDefault {
+		return "observations/"
+	}
+	return fmt.Sprintf("observations/%s/", string(mode))
 }
 
 // PutObservations writes observations for a conversation.
-func PutObservations(ctx context.Context, store storage.Store, source, conversationID string, obs *Observations) error {
-	return putJSON(ctx, store, observationPath(source, conversationID), obs)
+func PutObservations(ctx context.Context, store storage.Store, source, conversationID string, obs *Observations, mode ...ObserveMode) error {
+	return putJSON(ctx, store, observationPath(source, conversationID, mode...), obs)
 }
 
 // GetObservations reads observations for a conversation.
 // Returns storage.NotFoundError when no artifact exists.
-func GetObservations(ctx context.Context, store storage.Store, source, conversationID string) (*Observations, error) {
+func GetObservations(ctx context.Context, store storage.Store, source, conversationID string, mode ...ObserveMode) (*Observations, error) {
 	var obs Observations
-	if err := getJSON(ctx, store, observationPath(source, conversationID), &obs); err != nil {
+	if err := getJSON(ctx, store, observationPath(source, conversationID, mode...), &obs); err != nil {
 		return nil, err
 	}
 	return &obs, nil
@@ -85,20 +104,24 @@ func DeleteThemes(ctx context.Context, store storage.Store) error {
 }
 
 // ListObservations returns all (source, conversationID) pairs that have observations.
-func ListObservations(ctx context.Context, store storage.Store) ([]SourceConversation, error) {
-	return listArtifacts(ctx, store, "observations/")
+func ListObservations(ctx context.Context, store storage.Store, mode ...ObserveMode) ([]SourceConversation, error) {
+	m := ObserveDefault
+	if len(mode) > 0 {
+		m = mode[0]
+	}
+	return listArtifacts(ctx, store, observationDirPrefix(m))
 }
 
 // CountObservationItems returns the total number of discrete observation items
 // per source by reading each observation file and summing its Items.
-func CountObservationItems(ctx context.Context, store storage.Store) (map[string]int, error) {
-	entries, err := ListObservations(ctx, store)
+func CountObservationItems(ctx context.Context, store storage.Store, mode ...ObserveMode) (map[string]int, error) {
+	entries, err := ListObservations(ctx, store, mode...)
 	if err != nil {
 		return nil, err
 	}
 	counts := make(map[string]int, len(entries))
 	for _, e := range entries {
-		obs, err := GetObservations(ctx, store, e.Source, e.ConversationID)
+		obs, err := GetObservations(ctx, store, e.Source, e.ConversationID, mode...)
 		if err != nil {
 			return nil, err
 		}
@@ -112,9 +135,13 @@ func ListLabels(ctx context.Context, store storage.Store) ([]SourceConversation,
 	return listArtifacts(ctx, store, "compose/labels/")
 }
 
-// DeleteObservations removes all observation artifacts.
-func DeleteObservations(ctx context.Context, store storage.Store) error {
-	return store.DeletePrefix(ctx, "observations/")
+// DeleteObservations removes all observation artifacts for the given mode.
+func DeleteObservations(ctx context.Context, store storage.Store, mode ...ObserveMode) error {
+	m := ObserveDefault
+	if len(mode) > 0 {
+		m = mode[0]
+	}
+	return store.DeletePrefix(ctx, observationDirPrefix(m))
 }
 
 // DeleteObservationsForSource removes observation artifacts for a specific source.

--- a/internal/compose/clustered.go
+++ b/internal/compose/clustered.go
@@ -72,13 +72,10 @@ func RunClustered(
 	})
 
 	// Load all observations
-	allObs, err := loadAllStructuredObservations(ctx, store)
+	allObs, err := loadAllStructuredObservations(ctx, store, opts.Observe)
 	if err != nil {
 		return nil, fmt.Errorf("load observations: %w", err)
 	}
-
-	// discover + observe log lines (printed after observe completes since
-	// discovery happens inside runObserve before the LLM work)
 
 	// observe result line
 	observeNote := ""
@@ -341,7 +338,7 @@ func runObserve(
 
 	// Handle reobserve
 	if opts.Reobserve {
-		DeleteObservations(ctx, store)
+		DeleteObservations(ctx, store, opts.Observe)
 		fmt.Fprintln(os.Stderr, "  Cleared all observations")
 	}
 
@@ -358,7 +355,8 @@ func runObserve(
 	discovered := len(entries)
 
 	// Compute prompt chain hash for fingerprinting
-	promptHash := Fingerprint(prompts.Observe, prompts.ObserveHuman, prompts.Refine)
+	promptHash := Fingerprint(prompts.Observe, prompts.ObserveHuman, prompts.Refine,
+		fmt.Sprintf("mode:%s", opts.Observe))
 
 	// Determine which conversations need (re)observation
 	var pending []storage.ConversationEntry
@@ -369,7 +367,7 @@ func runObserve(
 		}
 		fp := Fingerprint(e.LastModified.Format(time.RFC3339Nano), promptHash)
 
-		existing, err := GetObservations(ctx, store, e.Source, e.ConversationID)
+		existing, err := GetObservations(ctx, store, e.Source, e.ConversationID, opts.Observe)
 		if err == nil && existing.Fingerprint == fp {
 			pruned++
 			continue
@@ -435,7 +433,7 @@ func runObserve(
 				convBytes := conversationDataSize(conv)
 
 				start := time.Now()
-				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose, humanOverrides)
+				items, u, err := observeAndParse(ctx, llm, conv, opts.Verbose, humanOverrides, opts.Observe)
 				n := counter.Add(1)
 				if err != nil {
 					return fmt.Errorf("observe %s: %w", entry.Key, err)
@@ -447,13 +445,13 @@ func runObserve(
 					Date:        entry.LastModified.Format("2006-01-02"),
 					Items:       items,
 				}
-				if err := PutObservations(ctx, store, entry.Source, entry.ConversationID, obs); err != nil {
+				if err := PutObservations(ctx, store, entry.Source, entry.ConversationID, obs, opts.Observe); err != nil {
 					return fmt.Errorf("save observations for %s: %w", entry.Key, err)
 				}
 
 				if opts.Verbose {
 					fmt.Fprintf(os.Stderr, "  [%d/%d] Observed ~/.muse/%s (%d obs, %s, $%.4f)\n",
-						n, len(pending), observationPath(entry.Source, entry.ConversationID), len(items),
+						n, len(pending), observationPath(entry.Source, entry.ConversationID, opts.Observe), len(items),
 						time.Since(start).Round(time.Millisecond), u.Cost())
 				}
 				mu.Lock()
@@ -503,7 +501,13 @@ func conversationDataSize(conv *conversation.Conversation) int {
 // exceeds the context window, mechanical compression is applied as a fallback:
 // code blocks are stripped, tool output is collapsed to [tool: name] markers,
 // and long assistant messages are truncated.
-func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, humanOverrides map[string]bool) ([]Observation, inference.Usage, error) {
+func observeAndParse(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, humanOverrides map[string]bool, mode ObserveMode) ([]Observation, inference.Usage, error) {
+	switch mode {
+	case ObserveWoo:
+		return observeWoo(ctx, client, conv, verbose, humanOverrides)
+	case ObserveAdaptive:
+		return observeAdaptive(ctx, client, conv, verbose, humanOverrides)
+	}
 	refined, usage, err := observeAndRefine(ctx, client, conv, verbose, humanOverrides)
 	if err != nil {
 		return nil, usage, err
@@ -536,6 +540,403 @@ func observeAndParse(ctx context.Context, client inference.Client, conv *convers
 		}
 	}
 	return relevant, usage, nil
+}
+
+// Window parameters for windowed observation. Each window is small enough that
+// local signal survives without being washed out by distant mechanical turns.
+// Adjacent windows overlap so multi-turn reasoning arcs aren't split.
+const (
+	windowSize   = 8 // turns per window
+	windowStride = 4 // advance between windows
+
+	// windowObserveBudget is the initial max-tokens budget for a per-window
+	// observe call. Sized for non-thinking models; thinking models that exceed
+	// it are caught by retry-on-truncation in observeWindow.
+	windowObserveBudget = 4096
+
+	// windowObserveRetryBudget is the budget used after truncation. Sized to
+	// absorb thinking from typical thinking-by-default models (Qwen3 Thinking
+	// emits ~3-5k of reasoning per window). Windows that still truncate at
+	// this budget are skipped — no observation from that window.
+	windowObserveRetryBudget = 16384
+
+	// minWindowedContentLen is the minimum total owner content (chars) required
+	// to attempt windowed observation. Below this, the conversation can't contain
+	// enough reasoning to justify per-window LLM calls.
+	minWindowedContentLen = 200
+
+	// maxRefineCandidateChars caps the input to the refine call. Prevents
+	// context overflow when many windows produce observations. 100k chars is
+	// ~22k tokens, fitting comfortably in 128k+ context windows.
+	maxRefineCandidateChars = 100_000
+)
+
+// ownerContentLen returns the total character count of owner messages.
+func ownerContentLen(turns []turn) int {
+	n := 0
+	for _, t := range turns {
+		n += len(t.humanContent)
+	}
+	return n
+}
+
+// observeWindow runs the configured observe prompt against a single window's
+// input. If the call truncates (TruncatedError, typically because a
+// thinking-by-default model spent the whole budget reasoning), it retries
+// once at windowObserveRetryBudget. If the retry also truncates, the
+// TruncatedError is returned for the caller to skip this window.
+func observeWindow(ctx context.Context, client inference.Client, prompt, input string) (string, inference.Usage, error) {
+	obs, usage, err := inference.Converse(ctx, client, prompt, input, inference.WithMaxTokens(windowObserveBudget))
+	if !inference.IsTruncated(err) {
+		return obs, usage, err
+	}
+	retryObs, retryUsage, retryErr := inference.Converse(ctx, client, prompt, input, inference.WithMaxTokens(windowObserveRetryBudget))
+	usage = usage.Add(retryUsage)
+	return retryObs, usage, retryErr
+}
+
+// observeWoo runs windowed owner-only observation. It slides an 8-turn window
+// across the conversation, strips assistant text from each window, and observes
+// each window independently. Deduplicates across overlapping windows, then refines.
+func observeWoo(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, humanOverrides map[string]bool) ([]Observation, inference.Usage, error) {
+	turns := extractTurns(conv, humanOverrides)
+	if len(turns) == 0 {
+		return nil, inference.Usage{}, nil
+	}
+	if ownerContentLen(turns) < minWindowedContentLen {
+		return nil, inference.Usage{}, nil
+	}
+
+	windows := buildWindows(turns, windowSize, windowStride)
+	if verbose {
+		fmt.Fprintf(os.Stderr, "    woo: %d turns → %d windows (size %d, stride %d)\n",
+			len(turns), len(windows), windowSize, windowStride)
+	}
+
+	observePrompt := prompts.Observe
+	if isHumanSource(conv.Source, humanOverrides) {
+		observePrompt = prompts.ObserveHuman
+	}
+
+	// Process windows concurrently. Each window observation is independent;
+	// the rate limiter gates actual API calls.
+	type windowResult struct {
+		obs   string
+		usage inference.Usage
+	}
+	results := make([]windowResult, len(windows))
+	var windowErr error
+
+	wg, wctx := errgroup.WithContext(ctx)
+	for i, w := range windows {
+		wg.Go(func() error {
+			// Owner-only: strip assistant text
+			var b strings.Builder
+			for _, t := range w {
+				fmt.Fprintf(&b, "[owner]: %s\n\n", t.humanContent)
+			}
+			input := b.String()
+
+			start := time.Now()
+			obs, usage, err := observeWindow(wctx, client, observePrompt, input)
+			results[i] = windowResult{obs: obs, usage: usage}
+			if verbose {
+				fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, %d chars → %d chars (%s, $%.4f)\n",
+					i+1, len(windows), len(w), len(input), len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+			}
+			if inference.IsTruncated(err) || inference.IsContextSize(err) {
+				if verbose {
+					reason := "truncated after retry"
+					if inference.IsContextSize(err) {
+						reason = "exceeded context size"
+					}
+					fmt.Fprintf(os.Stderr, "      window[%d/%d] %s, skipping\n", i+1, len(windows), reason)
+				}
+				return nil // skip this window
+			}
+			if err != nil && obs == "" {
+				return err
+			}
+			return nil
+		})
+	}
+	windowErr = wg.Wait()
+
+	var totalUsage inference.Usage
+	var allCandidates []string
+	for _, r := range results {
+		totalUsage = totalUsage.Add(r.usage)
+		if r.obs != "" && !isEmpty(r.obs) {
+			allCandidates = append(allCandidates, r.obs)
+		}
+	}
+	if windowErr != nil {
+		return nil, totalUsage, windowErr
+	}
+
+	if len(allCandidates) == 0 {
+		return nil, totalUsage, nil
+	}
+
+	// Deduplicate across overlapping windows, then refine
+	candidates := deduplicateObservationText(strings.Join(allCandidates, "\n\n"))
+	if len(candidates) > maxRefineCandidateChars {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "      refine input %d chars exceeds %d, truncating\n",
+				len(candidates), maxRefineCandidateChars)
+		}
+		candidates = candidates[:maxRefineCandidateChars]
+	}
+	start := time.Now()
+	refined, usage, err := inference.Converse(ctx, client, prompts.Refine, candidates, inference.WithMaxTokens(4096))
+	totalUsage = totalUsage.Add(usage)
+	if verbose {
+		fmt.Fprintf(os.Stderr, "      refine %d chars → %d chars (%s, $%.4f)\n",
+			len(candidates), len(refined), time.Since(start).Round(time.Millisecond), usage.Cost())
+	}
+	if err != nil && refined == "" {
+		return nil, totalUsage, err
+	}
+	if isEmpty(refined) {
+		return nil, totalUsage, nil
+	}
+
+	items := parseObservationItems(refined)
+	var relevant []Observation
+	for _, item := range items {
+		if isRelevant(item.Text) {
+			relevant = append(relevant, item)
+		}
+	}
+	return relevant, totalUsage, nil
+}
+
+// observeAdaptive runs windowed observation, trying woo (owner-only) first
+// on each window and falling back to default (with assistant) if woo finds
+// nothing. At most 2 calls per window. Woo-first captures more observations
+// (557 vs 492) because woo produces more per window when both methods find
+// signal. The fallback is cheap (NONE windows cost ~4 output tokens) and
+// catches windows where terse owner messages only make sense with assistant
+// context.
+func observeAdaptive(ctx context.Context, client inference.Client, conv *conversation.Conversation, verbose bool, humanOverrides map[string]bool) ([]Observation, inference.Usage, error) {
+	turns := extractTurns(conv, humanOverrides)
+	if len(turns) == 0 {
+		return nil, inference.Usage{}, nil
+	}
+	if ownerContentLen(turns) < minWindowedContentLen {
+		return nil, inference.Usage{}, nil
+	}
+
+	windows := buildWindows(turns, windowSize, windowStride)
+	if verbose {
+		fmt.Fprintf(os.Stderr, "    adaptive: %d turns → %d windows (size %d, stride %d)\n",
+			len(turns), len(windows), windowSize, windowStride)
+	}
+
+	observePrompt := prompts.Observe
+	if isHumanSource(conv.Source, humanOverrides) {
+		observePrompt = prompts.ObserveHuman
+	}
+
+	// Process windows concurrently. Each window's woo→default fallback is
+	// sequential (at most 2 calls), but windows are independent.
+	type windowResult struct {
+		obs   string
+		usage inference.Usage
+	}
+	results := make([]windowResult, len(windows))
+	var windowErr error
+
+	wg, wctx := errgroup.WithContext(ctx)
+	for i, w := range windows {
+		wg.Go(func() error {
+			// Build both inputs upfront
+			var wooB strings.Builder
+			for _, t := range w {
+				fmt.Fprintf(&wooB, "[owner]: %s\n\n", t.humanContent)
+			}
+			wooInput := wooB.String()
+
+			chunks := compressConversation(w, conv.Source, humanOverrides)
+			defaultInput := strings.Join(chunks, "\n")
+
+			attempts := []struct {
+				input  string
+				method string
+			}{
+				{wooInput, "woo"},
+				{defaultInput, "default"},
+			}
+
+			start := time.Now()
+			var winUsage inference.Usage
+			for j, a := range attempts {
+				obs, usage, err := observeWindow(wctx, client, observePrompt, a.input)
+				winUsage = winUsage.Add(usage)
+				if inference.IsTruncated(err) {
+					if verbose {
+						fmt.Fprintf(os.Stderr, "      window[%d/%d] truncated after retry, skipping\n", i+1, len(windows))
+					}
+					results[i] = windowResult{usage: winUsage}
+					return nil
+				}
+				if inference.IsContextSize(err) {
+					if verbose {
+						fmt.Fprintf(os.Stderr, "      window[%d/%d] exceeded context size, skipping\n", i+1, len(windows))
+					}
+					results[i] = windowResult{usage: winUsage}
+					return nil
+				}
+				if err != nil && obs == "" {
+					results[i] = windowResult{usage: winUsage}
+					return err
+				}
+				if obs != "" && !isEmpty(obs) {
+					if verbose {
+						fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, %s → %d chars (%s, $%.4f)\n",
+							i+1, len(windows), len(w), a.method, len(obs), time.Since(start).Round(time.Millisecond), usage.Cost())
+					}
+					results[i] = windowResult{obs: obs, usage: winUsage}
+					return nil
+				}
+				if j == 0 && verbose {
+					fmt.Fprintf(os.Stderr, "      window[%d/%d] %d turns, woo → NONE, trying default\n",
+						i+1, len(windows), len(w))
+				}
+			}
+			results[i] = windowResult{usage: winUsage}
+			return nil
+		})
+	}
+	windowErr = wg.Wait()
+
+	var totalUsage inference.Usage
+	var allCandidates []string
+	for _, r := range results {
+		totalUsage = totalUsage.Add(r.usage)
+		if r.obs != "" && !isEmpty(r.obs) {
+			allCandidates = append(allCandidates, r.obs)
+		}
+	}
+	if windowErr != nil {
+		return nil, totalUsage, windowErr
+	}
+
+	if len(allCandidates) == 0 {
+		return nil, totalUsage, nil
+	}
+
+	// Deduplicate across overlapping windows, then refine
+	candidates := deduplicateObservationText(strings.Join(allCandidates, "\n\n"))
+	if len(candidates) > maxRefineCandidateChars {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "      refine input %d chars exceeds %d, truncating\n",
+				len(candidates), maxRefineCandidateChars)
+		}
+		candidates = candidates[:maxRefineCandidateChars]
+	}
+	start := time.Now()
+	refined, usage, err := inference.Converse(ctx, client, prompts.Refine, candidates, inference.WithMaxTokens(4096))
+	totalUsage = totalUsage.Add(usage)
+	if verbose {
+		fmt.Fprintf(os.Stderr, "      refine %d chars → %d chars (%s, $%.4f)\n",
+			len(candidates), len(refined), time.Since(start).Round(time.Millisecond), usage.Cost())
+	}
+	if err != nil && refined == "" {
+		return nil, totalUsage, err
+	}
+	if isEmpty(refined) {
+		return nil, totalUsage, nil
+	}
+
+	items := parseObservationItems(refined)
+	var relevant []Observation
+	for _, item := range items {
+		if isRelevant(item.Text) {
+			relevant = append(relevant, item)
+		}
+	}
+	return relevant, totalUsage, nil
+}
+
+// buildWindows splits turns into overlapping windows of the given size and stride.
+// The last window is extended to avoid a tiny tail.
+func buildWindows(turns []turn, size, stride int) [][]turn {
+	if len(turns) <= size {
+		return [][]turn{turns}
+	}
+	var windows [][]turn
+	for start := 0; start < len(turns); start += stride {
+		end := start + size
+		if end > len(turns) {
+			end = len(turns)
+		}
+		if len(turns)-end < stride {
+			end = len(turns)
+		}
+		windows = append(windows, turns[start:end])
+		if end == len(turns) {
+			break
+		}
+	}
+	return windows
+}
+
+// deduplicateObservationText removes duplicate observations from raw LLM output
+// across overlapping windows. Two observations are duplicates if their text
+// (after normalization) is identical or one contains the other.
+func deduplicateObservationText(text string) string {
+	items := parseObservationItems(text)
+	if len(items) == 0 {
+		return text
+	}
+
+	type normalizedObs struct {
+		original Observation
+		norm     string
+	}
+	var normalized []normalizedObs
+	for _, item := range items {
+		n := strings.ToLower(strings.TrimSpace(item.Text))
+		normalized = append(normalized, normalizedObs{original: item, norm: n})
+	}
+
+	keep := make([]bool, len(normalized))
+	for i := range keep {
+		keep[i] = true
+	}
+	for i := 0; i < len(normalized); i++ {
+		if !keep[i] {
+			continue
+		}
+		for j := i + 1; j < len(normalized); j++ {
+			if !keep[j] {
+				continue
+			}
+			if normalized[i].norm == normalized[j].norm {
+				keep[j] = false
+				continue
+			}
+			if strings.Contains(normalized[i].norm, normalized[j].norm) {
+				keep[j] = false
+			} else if strings.Contains(normalized[j].norm, normalized[i].norm) {
+				keep[i] = false
+				break
+			}
+		}
+	}
+
+	var b strings.Builder
+	for i, n := range normalized {
+		if !keep[i] {
+			continue
+		}
+		if n.original.Quote != "" {
+			fmt.Fprintf(&b, "Quote: %s\n", n.original.Quote)
+		}
+		fmt.Fprintf(&b, "Observation: %s\n\n", n.original.Text)
+	}
+	return strings.TrimSpace(b.String())
 }
 
 // observeAndRefine is the shared core of the observation pipeline. It extracts
@@ -917,8 +1318,8 @@ func (e observationEntry) FormatTokens() int {
 
 // loadAllStructuredObservations loads all observation artifacts and returns
 // a flat list of observation entries, loading conversations in parallel.
-func loadAllStructuredObservations(ctx context.Context, store storage.Store) ([]observationEntry, error) {
-	convList, err := ListObservations(ctx, store)
+func loadAllStructuredObservations(ctx context.Context, store storage.Store, mode ...ObserveMode) ([]observationEntry, error) {
+	convList, err := ListObservations(ctx, store, mode...)
 	if err != nil {
 		return nil, err
 	}
@@ -933,7 +1334,7 @@ func loadAllStructuredObservations(ctx context.Context, store storage.Store) ([]
 	g.SetLimit(20)
 	for i, ss := range convList {
 		g.Go(func() error {
-			obs, err := GetObservations(ctx, store, ss.Source, ss.ConversationID)
+			obs, err := GetObservations(ctx, store, ss.Source, ss.ConversationID, mode...)
 			if err != nil {
 				results[i] = result{err: fmt.Errorf("get observations %s/%s: %w", ss.Source, ss.ConversationID, err)}
 				return results[i].err

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -51,6 +51,23 @@ type HitMiss struct {
 	Miss int
 }
 
+// ObserveMode controls the observation strategy for conversations.
+type ObserveMode string
+
+const (
+	// ObserveDefault compresses the full conversation and observes in chunks.
+	ObserveDefault ObserveMode = ""
+	// ObserveWoo (windowed owner-only) slides an 8-turn window across the
+	// conversation, strips assistant text from each window, and observes each
+	// window independently. Produces more distinct insights at higher grounding
+	// rate than the default, at lower token cost per window.
+	ObserveWoo ObserveMode = "woo"
+	// ObserveAdaptive tries woo first on each window. If woo returns NONE
+	// (no observations), falls back to default (with assistant) on the same
+	// window. At most two observe calls per window.
+	ObserveAdaptive ObserveMode = "adaptive"
+)
+
 // BaseOptions contains fields shared across all compose strategies.
 type BaseOptions struct {
 	// Reobserve ignores persisted observations and re-observes all conversations.
@@ -59,6 +76,8 @@ type BaseOptions struct {
 	Limit int
 	// Verbose enables per-item progress logging.
 	Verbose bool
+	// Observe controls the observation strategy.
+	Observe ObserveMode
 }
 
 // Options configures a map-reduce compose run.

--- a/internal/compose/observe_window_test.go
+++ b/internal/compose/observe_window_test.go
@@ -1,0 +1,183 @@
+package compose
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ellistarn/muse/internal/conversation"
+	"github.com/ellistarn/muse/internal/inference"
+)
+
+// scriptedLLM is a minimal inference.Client that returns a sequence of
+// (text, error) responses across calls. Used to script truncation behavior
+// in retry tests.
+type scriptedLLM struct {
+	mu        sync.Mutex
+	responses []scriptedResponse
+	calls     atomic.Int32
+}
+
+type scriptedResponse struct {
+	text string
+	err  error
+}
+
+func (m *scriptedLLM) ConverseMessages(_ context.Context, _ string, _ []inference.Message, _ ...inference.ConverseOption) (*inference.Response, error) {
+	idx := int(m.calls.Add(1)) - 1
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if idx >= len(m.responses) {
+		return &inference.Response{}, nil
+	}
+	r := m.responses[idx]
+	return &inference.Response{Text: r.text, Usage: inference.Usage{}}, r.err
+}
+
+func (m *scriptedLLM) ConverseMessagesStream(ctx context.Context, system string, messages []inference.Message, _ inference.StreamFunc, opts ...inference.ConverseOption) (*inference.Response, error) {
+	return m.ConverseMessages(ctx, system, messages, opts...)
+}
+
+func (m *scriptedLLM) Model() string { return "scripted" }
+
+// twoTurnConversation builds a minimal conversation with two user turns
+// (the minimum for AI sources to pass extractTurns) so observeWoo produces a
+// single window with one observe call (plus refine when observations exist).
+// Content is padded above minWindowedContentLen so the early-exit check doesn't fire.
+func twoTurnConversation() *conversation.Conversation {
+	return &conversation.Conversation{
+		Source: "test",
+		Messages: []conversation.Message{
+			{Role: "user", Content: "the owner says something distinctive about how they approach design problems and what matters to them when making architectural decisions in complex systems"},
+			{Role: "assistant", Content: "ack"},
+			{Role: "user", Content: "and follows up with another distinctive thing about their reasoning process and how they evaluate tradeoffs between competing concerns"},
+			{Role: "assistant", Content: "ack"},
+		},
+	}
+}
+
+func TestObserveWindowRetriesOnTruncation(t *testing.T) {
+	mock := &scriptedLLM{
+		responses: []scriptedResponse{
+			{text: "", err: &inference.TruncatedError{OutputTokens: windowObserveBudget}},
+			{text: "Observation: distinctive thinking pattern\n", err: nil},
+		},
+	}
+
+	obs, _, err := observeWindow(context.Background(), mock, "prompt", "input")
+	if err != nil {
+		t.Fatalf("observeWindow returned error: %v", err)
+	}
+	if obs == "" {
+		t.Errorf("expected observations after retry, got empty")
+	}
+	if got, want := mock.calls.Load(), int32(2); got != want {
+		t.Errorf("call count = %d, want %d (initial + retry)", got, want)
+	}
+}
+
+func TestObserveWindowReturnsTruncationAfterRetryFails(t *testing.T) {
+	mock := &scriptedLLM{
+		responses: []scriptedResponse{
+			{text: "", err: &inference.TruncatedError{OutputTokens: windowObserveBudget}},
+			{text: "", err: &inference.TruncatedError{OutputTokens: windowObserveRetryBudget}},
+		},
+	}
+
+	_, _, err := observeWindow(context.Background(), mock, "prompt", "input")
+	if !inference.IsTruncated(err) {
+		t.Errorf("expected TruncatedError after persistent truncation, got %v", err)
+	}
+	if got, want := mock.calls.Load(), int32(2); got != want {
+		t.Errorf("call count = %d, want %d (no third attempt)", got, want)
+	}
+}
+
+func TestObserveWindowDoesNotRetryOnNonTruncationError(t *testing.T) {
+	mock := &scriptedLLM{
+		responses: []scriptedResponse{
+			{text: "", err: &nonTruncationError{}},
+		},
+	}
+
+	_, _, err := observeWindow(context.Background(), mock, "prompt", "input")
+	if err == nil {
+		t.Fatal("expected non-truncation error to propagate, got nil")
+	}
+	if got, want := mock.calls.Load(), int32(1); got != want {
+		t.Errorf("call count = %d, want %d (no retry for non-truncation errors)", got, want)
+	}
+}
+
+func TestObserveWooSkipsWindowOnContextSizeError(t *testing.T) {
+	// Pathological window with input too big for the model's context window.
+	// observeWindow doesn't retry (retry only helps for output truncation).
+	// observeWoo should skip rather than abort.
+	mock := &scriptedLLM{
+		responses: []scriptedResponse{
+			{text: "", err: &inference.ContextSizeError{PromptTokens: 23956, ContextSize: 16384}},
+		},
+	}
+
+	obs, _, err := observeWoo(context.Background(), mock, twoTurnConversation(), false, nil)
+	if err != nil {
+		t.Fatalf("observeWoo returned error on context-size skip: %v", err)
+	}
+	if got, want := mock.calls.Load(), int32(1); got != want {
+		t.Errorf("call count = %d, want %d (no retry on context-size; no refine because no candidates)", got, want)
+	}
+	if len(obs) != 0 {
+		t.Errorf("expected no observations when sole window skipped, got %d", len(obs))
+	}
+}
+
+func TestObserveAdaptiveSkipsWindowOnContextSizeError(t *testing.T) {
+	// Adaptive's per-window two-attempt loop should also skip on context-size
+	// errors so a single pathological owner-paste doesn't abort the whole
+	// conversation.
+	mock := &scriptedLLM{
+		responses: []scriptedResponse{
+			{text: "", err: &inference.ContextSizeError{PromptTokens: 23956, ContextSize: 16384}},
+		},
+	}
+
+	obs, _, err := observeAdaptive(context.Background(), mock, twoTurnConversation(), false, nil)
+	if err != nil {
+		t.Fatalf("observeAdaptive returned error on context-size skip: %v", err)
+	}
+	if got, want := mock.calls.Load(), int32(1); got != want {
+		t.Errorf("call count = %d, want %d (skip on first attempt's context-size; no fallback)", got, want)
+	}
+	if len(obs) != 0 {
+		t.Errorf("expected no observations when sole window skipped, got %d", len(obs))
+	}
+}
+
+func TestObserveWooSkipsWindowOnPersistentTruncation(t *testing.T) {
+	// Verifies the integration: observeWoo treats a persistently-truncated
+	// window as a skip rather than aborting the conversation. Mock script:
+	// initial truncates, retry truncates → window skipped → no candidates
+	// → observeWoo returns nil with no error and no refine call.
+	mock := &scriptedLLM{
+		responses: []scriptedResponse{
+			{text: "", err: &inference.TruncatedError{OutputTokens: windowObserveBudget}},
+			{text: "", err: &inference.TruncatedError{OutputTokens: windowObserveRetryBudget}},
+		},
+	}
+
+	obs, _, err := observeWoo(context.Background(), mock, twoTurnConversation(), false, nil)
+	if err != nil {
+		t.Fatalf("observeWoo returned error on skip-after-retry: %v", err)
+	}
+	if got, want := mock.calls.Load(), int32(2); got != want {
+		t.Errorf("call count = %d, want %d (initial + retry, no refine because no candidates)", got, want)
+	}
+	if len(obs) != 0 {
+		t.Errorf("expected no observations when sole window skipped, got %d", len(obs))
+	}
+}
+
+type nonTruncationError struct{}
+
+func (e *nonTruncationError) Error() string { return "non-truncation network error" }

--- a/internal/inference/client.go
+++ b/internal/inference/client.go
@@ -35,6 +35,29 @@ func IsTruncated(err error) bool {
 	return errors.As(err, &te)
 }
 
+// ContextSizeError indicates the request prompt did not fit in the model's
+// context window. Distinct from TruncatedError, which is about output budget.
+// Pathological windows in compose/observe pipelines should usually skip on
+// this rather than abort the whole conversation.
+type ContextSizeError struct {
+	PromptTokens int // tokens in the rejected prompt, if known (0 otherwise)
+	ContextSize  int // server's configured context window, if known (0 otherwise)
+}
+
+func (e *ContextSizeError) Error() string {
+	if e.PromptTokens > 0 && e.ContextSize > 0 {
+		return fmt.Sprintf("prompt (%d tokens) exceeds context size (%d tokens)", e.PromptTokens, e.ContextSize)
+	}
+	return "prompt exceeds context size"
+}
+
+// IsContextSize reports whether err indicates the prompt did not fit in the
+// model's context window.
+func IsContextSize(err error) bool {
+	var ce *ContextSizeError
+	return errors.As(err, &ce)
+}
+
 // Client is the inference interface. Providers implement multi-turn
 // conversation with optional streaming. Single-turn callers use the
 // Converse/ConverseStream free functions.

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/openai/openai-go"
@@ -107,6 +109,9 @@ func (c *Client) ConverseMessages(ctx context.Context, system string, messages [
 	err := throttle.Retry(ctx, c.limiter, throttle.DefaultRetryConfig(), isThrottled, func() error {
 		completion, err := c.client.Chat.Completions.New(ctx, params)
 		if err != nil {
+			if cse, ok := classifyContextSizeError(err); ok {
+				return cse
+			}
 			return fmt.Errorf("openai chat.completions.new: %w", err)
 		}
 
@@ -167,6 +172,9 @@ func (c *Client) ConverseMessagesStream(ctx context.Context, system string, mess
 		}
 
 		if err := stream.Err(); err != nil {
+			if cse, ok := classifyContextSizeError(err); ok {
+				return cse
+			}
 			return fmt.Errorf("openai stream: %w", err)
 		}
 
@@ -186,6 +194,41 @@ func isThrottled(err error) bool {
 	return strings.Contains(err.Error(), fmt.Sprintf("%d", http.StatusTooManyRequests)) ||
 		strings.Contains(err.Error(), "rate_limit")
 }
+
+// classifyContextSizeError detects errors indicating the prompt did not fit
+// the model's context window and returns a typed inference.ContextSizeError.
+// Recognized patterns:
+//   - llama.cpp: "exceeds the available context size" with type "exceed_context_size_error"
+//     and JSON fields n_prompt_tokens / n_ctx
+//   - OpenAI cloud: "context_length_exceeded" or "maximum context length"
+//
+// Returns (nil, false) if the error doesn't match any known context-size pattern.
+func classifyContextSizeError(err error) (*inference.ContextSizeError, bool) {
+	msg := err.Error()
+	if !strings.Contains(msg, "exceed_context_size") &&
+		!strings.Contains(msg, "exceeds the available context size") &&
+		!strings.Contains(msg, "context_length_exceeded") &&
+		!strings.Contains(msg, "maximum context length") {
+		return nil, false
+	}
+	cse := &inference.ContextSizeError{}
+	if m := contextSizePromptRe.FindStringSubmatch(msg); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			cse.PromptTokens = n
+		}
+	}
+	if m := contextSizeCtxRe.FindStringSubmatch(msg); len(m) == 2 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			cse.ContextSize = n
+		}
+	}
+	return cse, true
+}
+
+var (
+	contextSizePromptRe = regexp.MustCompile(`"n_prompt_tokens"\s*:\s*(\d+)`)
+	contextSizeCtxRe    = regexp.MustCompile(`"n_ctx"\s*:\s*(\d+)`)
+)
 
 func (c *Client) buildParams(system string, messages []inference.Message, opts inference.ConverseOptions) openai.ChatCompletionNewParams {
 	maxTokens := int64(inference.DefaultMaxTokens)

--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"errors"
 	"testing"
 
 	sdkopenai "github.com/openai/openai-go"
@@ -37,5 +38,44 @@ func TestBuildParamsSetsReasoningEffortForReasoningModels(t *testing.T) {
 	}
 	if got, want := params.MaxCompletionTokens.Value, int64(inference.DefaultMaxTokens+8000); got != want {
 		t.Fatalf("MaxCompletionTokens = %d, want %d", got, want)
+	}
+}
+
+func TestClassifyContextSizeErrorLlamaCpp(t *testing.T) {
+	// llama.cpp's HTTP 400 body shape (the actual error the user hit).
+	raw := errors.New(`POST "http://127.0.0.1:8080/v1/chat/completions": 400 Bad Request {"code":400,"message":"request (23956 tokens) exceeds the available context size (16384 tokens), try increasing it","type":"exceed_context_size_error","n_prompt_tokens":23956,"n_ctx":16384}`)
+	cse, ok := classifyContextSizeError(raw)
+	if !ok {
+		t.Fatalf("expected llama.cpp context-size error to classify; raw: %v", raw)
+	}
+	if got, want := cse.PromptTokens, 23956; got != want {
+		t.Errorf("PromptTokens = %d, want %d", got, want)
+	}
+	if got, want := cse.ContextSize, 16384; got != want {
+		t.Errorf("ContextSize = %d, want %d", got, want)
+	}
+}
+
+func TestClassifyContextSizeErrorOpenAI(t *testing.T) {
+	raw := errors.New(`This model's maximum context length is 8192 tokens, however you requested 12000 tokens (context_length_exceeded)`)
+	cse, ok := classifyContextSizeError(raw)
+	if !ok {
+		t.Fatalf("expected OpenAI-style context-size error to classify; raw: %v", raw)
+	}
+	// OpenAI's text doesn't carry the JSON fields, so token counts default to 0.
+	if cse.PromptTokens != 0 || cse.ContextSize != 0 {
+		t.Errorf("expected zero token fields when not parseable; got PromptTokens=%d ContextSize=%d", cse.PromptTokens, cse.ContextSize)
+	}
+}
+
+func TestClassifyContextSizeErrorIgnoresUnrelated(t *testing.T) {
+	for _, msg := range []string{
+		"connection refused",
+		"401 Unauthorized",
+		"response truncated: hit max token limit (4096 output tokens)",
+	} {
+		if _, ok := classifyContextSizeError(errors.New(msg)); ok {
+			t.Errorf("classifyContextSizeError matched unrelated error: %q", msg)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Implementation of the observation strategies described in designs/013.

- Windowed owner-only (woo): slides 8-turn window, strips assistant text, observes per-window
- Adaptive: tries woo first, falls back to default if NONE
- Per-mode observation storage (strategies don't clobber each other)
- Context-size error classification for graceful skip on pathological windows
- Parallel window processing via nested errgroups
- New `--observe-mode` flag (default: "" for existing behavior)

## Stacking

Depends on #168 (design docs). No conflicts — either can merge first.