### PR TITLE
fix: update e2e mock for ValidateThesis

### DIFF
--- a/e2e/compose_test.go
+++ b/e2e/compose_test.go
@@ -460,6 +460,9 @@ func (m *clusterMockLLM) ConverseMessages(_ context.Context, system string, mess
 	if strings.Contains(system, "Summarize these") {
 		return &inference.Response{Text: "I prefer explicit, clear patterns in code.", Usage: usage}, nil
 	}
+	if strings.Contains(system, "structural skeleton") {
+		return &inference.Response{Text: "## Identity\n\nA developer focused on explicitness.\n\n## Thesis\n\nExplicitness over cleverness.\n\n## Tensions\n\nNone identified.\n\n## Structure\n\n- Cluster 1: **core** — explicit patterns", Usage: usage}, nil
+	}
 	if strings.Contains(system, "producing muse.md") {
 		return &inference.Response{Text: "# How I Think\n\nI value explicitness over cleverness.", Usage: usage}, nil
 	}


### PR DESCRIPTION
## Summary

- Add thesis mock response to `clusterMockLLM` in `e2e/compose_test.go`
- `TestClustered_Limit` (and other clustered tests) have been failing since #147 introduced `ValidateThesis`, which expects thesis output to contain "Cluster N" for each cluster
- The mock had no case for the thesis prompt, so it fell through to the default response which lacks cluster references

## Test plan

- [x] `go test ./e2e/ -run TestClustered -count=1` passes all 5 clustered tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)