### PR TITLE
Send MCP keepalives as progress notifications to prevent client timeouts

### DIFF
--- a/e2e/mcp_test.go
+++ b/e2e/mcp_test.go
@@ -393,3 +393,82 @@ func TestMCP_NoThinkingOmitsTag(t *testing.T) {
 		t.Errorf("response = %q, want %q", text, "Plain answer.")
 	}
 }
+
+// captureSession is a minimal ClientSession whose NotificationChannel is a
+// buffered channel the test owns. Registering it on the server and injecting
+// it into the request context lets the test observe what the server actually
+// pushes through its real notification routing — one layer below the client,
+// which the in-process client transport cannot observe (it never drains the
+// session channel).
+type captureSession struct {
+	id   string
+	ch   chan mcp.JSONRPCNotification
+	init bool
+}
+
+func (s *captureSession) SessionID() string                                   { return s.id }
+func (s *captureSession) NotificationChannel() chan<- mcp.JSONRPCNotification { return s.ch }
+func (s *captureSession) Initialize()                                         { s.init = true }
+func (s *captureSession) Initialized() bool                                   { return s.init }
+
+// TestMCP_KeepaliveDelivered_Regression verifies the timeout fix end to end at
+// the server boundary: invoking the ask tool with a progress token causes the
+// server to actually deliver a notifications/progress (NOT a log notification)
+// carrying that token. This guards the regression where the keepalive was sent
+// as notifications/message, which opencode ignores for timeout resets, so long
+// inference calls were aborted. It exercises the server's real notification
+// routing, which the in-process client transport cannot (it drops server→client
+// notifications by never draining the session channel).
+func TestMCP_KeepaliveDelivered_Regression(t *testing.T) {
+	llm := &thinkingLLM{thinking: "Let me think...", response: "Answer."}
+	m := museinternal.New(llm, "test document")
+	srv := musemcp.NewServer(m)
+
+	sess := &captureSession{id: "test-session", ch: make(chan mcp.JSONRPCNotification, 16)}
+	sess.Initialize()
+	if err := srv.RegisterSession(context.Background(), sess); err != nil {
+		t.Fatalf("RegisterSession: %v", err)
+	}
+	ctx := srv.WithContext(context.Background(), sess)
+
+	req, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "ask",
+			"arguments": map[string]any{"question": "think please"},
+			"_meta":     map[string]any{"progressToken": "tok-xyz"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	srv.HandleMessage(ctx, req)
+
+	// Drain everything the server pushed and find the progress notifications.
+	var progress []mcp.JSONRPCNotification
+	for {
+		select {
+		case n := <-sess.ch:
+			if n.Method == "notifications/message" {
+				t.Errorf("server sent a log notification as keepalive; clients do not reset timeouts on these")
+			}
+			if n.Method == "notifications/progress" {
+				progress = append(progress, n)
+			}
+		default:
+			goto done
+		}
+	}
+done:
+	if len(progress) == 0 {
+		t.Fatal("expected the server to deliver at least one notifications/progress, got none")
+	}
+	for _, n := range progress {
+		if n.Params.AdditionalFields["progressToken"] != "tok-xyz" {
+			t.Errorf("progressToken = %v, want tok-xyz", n.Params.AdditionalFields["progressToken"])
+		}
+	}
+}

--- a/internal/mcp/keepalive_test.go
+++ b/internal/mcp/keepalive_test.go
@@ -1,0 +1,142 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// These unit tests cover the keepalive decision logic (which notification to
+// emit and with what payload). End-to-end delivery through the server's real
+// notification routing is guarded by TestMCP_KeepaliveDelivered_Regression in
+// the e2e package.
+
+// capturedNotification records one SendNotificationToClient call.
+type capturedNotification struct {
+	method string
+	params map[string]any
+}
+
+// fakeNotifier captures notifications instead of sending them, and can be
+// configured to fail after a given number of sends.
+type fakeNotifier struct {
+	sent     []capturedNotification
+	failFrom int // if > 0, the Nth send (1-indexed) and onward return an error
+}
+
+func (f *fakeNotifier) SendNotificationToClient(_ context.Context, method string, params map[string]any) error {
+	f.sent = append(f.sent, capturedNotification{method: method, params: params})
+	if f.failFrom > 0 && len(f.sent) >= f.failFrom {
+		return errors.New("send failed")
+	}
+	return nil
+}
+
+// TestKeepalive_EmitsProgressWithToken locks in the load-bearing behavior of
+// the timeout fix: with a progress token, the keepalive emits
+// "notifications/progress" (NOT a log notification) carrying that token.
+// If a future change reverts to "notifications/message", this fails.
+func TestKeepalive_EmitsProgressWithToken(t *testing.T) {
+	f := &fakeNotifier{}
+	k := newKeepalive(context.Background(), f, "tok-1")
+
+	k.send("hello")
+
+	if len(f.sent) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(f.sent))
+	}
+	n := f.sent[0]
+	if n.method != "notifications/progress" {
+		t.Errorf("method = %q, want notifications/progress (log notifications do not reset client timeouts)", n.method)
+	}
+	if n.params["progressToken"] != "tok-1" {
+		t.Errorf("progressToken = %v, want tok-1", n.params["progressToken"])
+	}
+	if n.params["message"] != "hello" {
+		t.Errorf("message = %v, want hello", n.params["message"])
+	}
+}
+
+// TestKeepalive_ProgressIncreases verifies the progress value strictly
+// increases across sends, as the MCP spec requires.
+func TestKeepalive_ProgressIncreases(t *testing.T) {
+	f := &fakeNotifier{}
+	k := newKeepalive(context.Background(), f, "tok-1")
+
+	k.send("a")
+	k.send("b")
+	k.send("c")
+
+	if len(f.sent) != 3 {
+		t.Fatalf("expected 3 notifications, got %d", len(f.sent))
+	}
+	var prev float64
+	for i, n := range f.sent {
+		p, ok := n.params["progress"].(float64)
+		if !ok {
+			t.Fatalf("send %d: progress not a float64: %T", i, n.params["progress"])
+		}
+		if i > 0 && p <= prev {
+			t.Errorf("send %d: progress %v did not increase from %v", i, p, prev)
+		}
+		prev = p
+	}
+}
+
+// TestKeepalive_NoTokenEmitsNothing verifies that without a progress token
+// the keepalive sends nothing — there is no token to associate a timeout
+// reset with, so a progress notification would be meaningless.
+func TestKeepalive_NoTokenEmitsNothing(t *testing.T) {
+	f := &fakeNotifier{}
+	k := newKeepalive(context.Background(), f, nil)
+
+	k.send("hello")
+	k.send("again")
+
+	if len(f.sent) != 0 {
+		t.Fatalf("expected no notifications without a token, got %d", len(f.sent))
+	}
+}
+
+// TestKeepalive_StopsAfterFailure verifies that once a send fails the
+// keepalive stops sending (so a broken connection doesn't get hammered), but
+// the failure never panics — inference must continue regardless.
+func TestKeepalive_StopsAfterFailure(t *testing.T) {
+	f := &fakeNotifier{failFrom: 1} // first send fails
+	k := newKeepalive(context.Background(), f, "tok-1")
+
+	k.send("first") // fails
+	k.send("second")
+	k.send("third")
+
+	if len(f.sent) != 1 {
+		t.Errorf("expected sending to stop after first failure, got %d sends", len(f.sent))
+	}
+}
+
+// TestKeepalive_DueRespectsInterval verifies due() gates sends to the flush
+// interval and reports false after a failure.
+func TestKeepalive_DueRespectsInterval(t *testing.T) {
+	f := &fakeNotifier{}
+	k := newKeepalive(context.Background(), f, "tok-1")
+
+	// Fresh keepalive: lastFlush is the zero time, so a flush is due.
+	if !k.due() {
+		t.Error("expected due() true before any send")
+	}
+	k.send("x")
+	if k.due() {
+		t.Error("expected due() false immediately after a send")
+	}
+	// Simulate the interval elapsing.
+	k.lastFlush = time.Now().Add(-flushInterval - time.Second)
+	if !k.due() {
+		t.Error("expected due() true after the interval elapsed")
+	}
+	// After a failure, never due.
+	k.failed = true
+	if k.due() {
+		t.Error("expected due() false after failure")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -15,9 +15,70 @@ import (
 	"github.com/ellistarn/muse/prompts"
 )
 
-// flushInterval controls how often thinking tokens are flushed as log
+// flushInterval controls how often thinking tokens are flushed as progress
 // notifications to keep the MCP connection alive during long inference calls.
 const flushInterval = 3 * time.Second
+
+// leadingMessage is the first progress message sent before any inference
+// output, signaling to clients that this is a long extended-thinking call.
+const leadingMessage = "Consulting the muse (extended thinking — this may take a minute)…"
+
+// notifier delivers a single MCP notification to the connected client. It
+// exists to invert the dependency on the mcp-go server so the keepalive
+// decision logic (which notification to send, and with what payload) can be
+// tested without a live client connection. The production implementation is
+// the mcp-go server itself.
+type notifier interface {
+	SendNotificationToClient(ctx context.Context, method string, params map[string]any) error
+}
+
+// keepalive emits progress notifications during a long inference call so the
+// client's per-request timeout keeps resetting. Clients reset that timeout on
+// notifications/progress — not on log notifications — so the notification TYPE
+// is load-bearing: this MUST send "notifications/progress" carrying the
+// request's progress token, never a log notification.
+//
+// When the client did not supply a progress token there is nothing to
+// associate a reset with, so keepalive emits nothing.
+type keepalive struct {
+	ctx       context.Context
+	notifier  notifier
+	token     mcp.ProgressToken
+	progress  float64
+	lastFlush time.Time
+	failed    bool
+}
+
+func newKeepalive(ctx context.Context, n notifier, token mcp.ProgressToken) *keepalive {
+	return &keepalive{ctx: ctx, notifier: n, token: token}
+}
+
+// send emits one progress notification carrying message. The progress value
+// must strictly increase per the MCP spec. No fixed total is sent since
+// inference length is unknown; the rising progress plus the message signals
+// to clients that the call is expected to take a while. It is a no-op once a
+// send has failed (stop trying, but never abort inference) or when no progress
+// token was supplied.
+func (k *keepalive) send(message string) {
+	if k.failed || k.token == nil {
+		return
+	}
+	k.lastFlush = time.Now()
+	k.progress++
+	if err := k.notifier.SendNotificationToClient(k.ctx, "notifications/progress", map[string]any{
+		"progressToken": k.token,
+		"progress":      k.progress,
+		"message":       message,
+	}); err != nil {
+		k.failed = true
+	}
+}
+
+// due reports whether enough time has elapsed since the last flush to send
+// another keepalive.
+func (k *keepalive) due() bool {
+	return !k.failed && time.Since(k.lastFlush) >= flushInterval
+}
 
 // NewServer creates an MCP server with an ask tool.
 // Each MCP client connection gets its own Bedrock session so concurrent
@@ -50,34 +111,33 @@ func NewServer(m *muse.Muse) *server.MCPServer {
 			museSessionID := museSessionByClient[clientID]
 			mu.Unlock()
 
-			// Stream thinking tokens as log notifications to keep the
-			// connection alive during long inference calls. The calling
-			// agent also benefits from seeing the muse's reasoning chain.
-			mcpServer := server.ServerFromContext(ctx)
-			var thinking strings.Builder
-			var notifyBuf strings.Builder
-			var lastFlush time.Time
-			notifyFailed := false
+			var token mcp.ProgressToken
+			if req.Params.Meta != nil {
+				token = req.Params.Meta.ProgressToken
+			}
+			ka := newKeepalive(ctx, server.ServerFromContext(ctx), token)
 
+			// Leading tick: announce up front that this is a long,
+			// max-thinking inference call, and cover the gap before Bedrock
+			// emits its first delta (otherwise unprotected by the cadence).
+			ka.send(leadingMessage)
+
+			// Accumulate the full reasoning chain for inclusion in the
+			// response; stream chunks of it through the keepalive so the
+			// calling agent can observe the muse's reasoning as it goes.
+			var thinking strings.Builder
+			var pending strings.Builder
 			streamFunc := func(delta inference.StreamDelta) {
 				if !delta.Thinking {
 					return
 				}
 				thinking.WriteString(delta.Text)
-				notifyBuf.WriteString(delta.Text)
-
-				if notifyFailed || time.Since(lastFlush) < flushInterval {
+				pending.WriteString(delta.Text)
+				if !ka.due() {
 					return
 				}
-				lastFlush = time.Now()
-				if err := mcpServer.SendNotificationToClient(ctx, "notifications/message", map[string]any{
-					"level":  "info",
-					"logger": "muse",
-					"data":   notifyBuf.String(),
-				}); err != nil {
-					notifyFailed = true // stop sending; don't abort inference
-				}
-				notifyBuf.Reset()
+				ka.send(pending.String())
+				pending.Reset()
 			}
 
 			result, err := m.Ask(ctx, muse.AskInput{
@@ -86,14 +146,9 @@ func NewServer(m *muse.Muse) *server.MCPServer {
 				New:        museSessionID == "", // First call for this client; don't resume latest from "muse ask".
 				StreamFunc: streamFunc,
 			})
-			// Flush any remaining thinking tokens that didn't hit the
-			// time threshold.
-			if !notifyFailed && notifyBuf.Len() > 0 {
-				_ = mcpServer.SendNotificationToClient(ctx, "notifications/message", map[string]any{
-					"level":  "info",
-					"logger": "muse",
-					"data":   notifyBuf.String(),
-				})
+			// Flush any remaining thinking tokens that didn't hit the cadence.
+			if pending.Len() > 0 {
+				ka.send(pending.String())
 			}
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("failed to ask: %v", err)), nil


### PR DESCRIPTION
## Problem

Long extended-thinking `ask` calls were timing out in the opencode MCP client.

Root cause (verified against opencode's MCP source): opencode resets its per-tool-call timeout **only** on `notifications/progress` — it sets `resetTimeoutOnProgress: true` and registers an `onprogress` hook. It routes `notifications/message` (log) to its logger and does **not** reset the timeout on them. The server was sending keepalives as log notifications, so the timer never reset and long calls were aborted.

## Fix

Switch the keepalive to emit `notifications/progress` carrying the request's progress token, with:
- a leading "extended thinking — this may take a minute" message sent before the first inference delta (covers the cold-start gap), and
- a strictly increasing `progress` value (per the MCP spec).

The notification **type** is the load-bearing part of the fix.

## Structure & tests

- Extract the keepalive decision logic behind a narrow `notifier` interface so it is unit-testable without a live client connection.
- `internal/mcp/keepalive_test.go`: unit tests for the decision logic — progress-with-token (asserts the **type**, the regression guard), strictly increasing progress, no-token-emits-nothing, stop-after-failure.
- `e2e/mcp_test.go` `TestMCP_KeepaliveDelivered_Regression`: drives the server's real notification routing via a registered `ClientSession` and asserts a `notifications/progress` (and never a log notification) is delivered with the token. This exercises one layer below the client, which the in-process client transport cannot observe.

## Verification notes

The in-process tests prove the server emits and routes the correct notification type with the correct token. End-to-end confirmation that opencode honors it (a real call running past opencode's base timeout and still returning) was verified manually.